### PR TITLE
fix: correct hook p95 latency claim to per-platform reality

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -95,10 +95,17 @@ Operational toggles:
   client when benchmarking or diagnosing the fast path; do not use it if you
   want Python fallback behavior.
 
-Claim boundary: the gated release test targets the native daemon-client path.
-Shell wrapper latency is recorded as telemetry because `/bin/bash` startup and
-workstation scheduler tails can dominate p95 even when the native hot path is
-fast.
+Claim boundary — per-platform numbers:
+
+- **In-process compute** (passport validation + scope check + receipt emit,
+  no IPC): p95 **<10ms**. Gated by `test_claude_code_daemon_hot_path_latency_target`.
+- **Full native daemon-client path** (native binary exec + Unix-socket
+  send/recv + response parse): p95 **<20ms**, measured ~15-17ms on Apple
+  Silicon macOS. Gated by `test_claude_code_native_daemon_client_latency_target`.
+- **Shell wrapper path**: latency recorded as telemetry only. `/bin/bash`
+  startup and workstation scheduler tails can dominate p95 even when the
+  native hot path is fast; enforcing a gate here would measure shell overhead,
+  not Ardur overhead.
 
 ## Built-In Options
 

--- a/python/tests/test_claude_code_hook_latency.py
+++ b/python/tests/test_claude_code_hook_latency.py
@@ -136,9 +136,19 @@ def test_claude_code_native_daemon_client_latency_target(
     """Gate the latency-critical native daemon-client command path.
 
     This is the low-overhead path installed by ``ardur protect claude-code``:
-    native Unix-socket client -> daemon. It is the defensible p95<10ms release
-    claim; the shell plugin wrapper below is telemetry only because shell
-    startup and desktop scheduler tails are outside Ardur's native hot path.
+    native Unix-socket client -> daemon.  Measured reality on Apple Silicon
+    macOS: p95 ~15-17ms end-to-end for the full client-to-daemon round-trip
+    (subprocess exec + Unix-socket send/recv + response parse).  The gate
+    below is set at p95<20ms to accommodate that measured baseline while
+    still catching regressions.
+
+    The in-process hot-path target (``test_claude_code_daemon_hot_path_latency_target``)
+    is the <10ms claim; it measures only compute inside the daemon with no
+    subprocess or IPC overhead and applies to the pure in-process code path.
+
+    The shell plugin wrapper test below is telemetry only because /bin/bash
+    startup and workstation scheduler tails are outside Ardur's native hot
+    path.
     """
     from vibap import claude_code_daemon as daemon_module
 
@@ -247,7 +257,12 @@ def test_claude_code_native_daemon_client_latency_target(
             f"n={iterations} median={median_ms:.2f}ms "
             f"p95={p95_ms:.2f}ms p99={p99_ms:.2f}ms"
         )
-        assert p95_ms < 10
+        # Measured on Apple Silicon macOS: p95 ~15-17ms for the full
+        # native client -> daemon round-trip.  Gate at <20ms to catch
+        # regressions while reflecting the real per-platform baseline.
+        # The <10ms claim applies only to in-process compute (see
+        # test_claude_code_daemon_hot_path_latency_target).
+        assert p95_ms < 20
     finally:
         if socket_path.exists():
             socket_path.unlink()
@@ -262,9 +277,11 @@ def test_claude_code_hook_wrapper_daemon_client_latency_telemetry(
     """Measure shell-wrapper latency without using it as a p95 release gate.
 
     The wrapper still has to exercise the native daemon client and return valid
-    hook output. Its latency is useful telemetry, but enforcing p95<10ms here
-    would rig the release claim against shell startup and workstation scheduler
-    tails rather than the Ardur native hot path.
+    hook output. Its latency is useful telemetry, but enforcing a strict p95
+    gate here would rig the release claim against /bin/bash startup and
+    workstation scheduler tails rather than the Ardur native hot path.  The
+    native daemon-client gate (p95<20ms, measured ~15-17ms on Apple Silicon
+    macOS) is the release signal; the shell path is reporting only.
     """
     repo_root = Path(__file__).resolve().parents[2]
     wrapper = repo_root / "plugins" / "claude-code" / "hooks" / "pre_tool_use"
@@ -392,6 +409,14 @@ def test_claude_code_daemon_hot_path_latency_target(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Gate the in-process compute path inside the daemon (p95<10ms).
+
+    This measures pure in-process compute: passport validation, scope check,
+    and receipt emission with no subprocess exec or Unix-socket IPC overhead.
+    The <10ms claim is defensible for this path.  The full client-to-daemon
+    round-trip (native binary + socket) targets p95<20ms and is gated by
+    ``test_claude_code_native_daemon_client_latency_target``.
+    """
     daemon_path = Path(__file__).resolve().parents[1] / "vibap" / "claude_code_daemon.py"
     if not daemon_path.exists():
         pytest.xfail("python/vibap/claude_code_daemon.py is not implemented yet")

--- a/site/content/source/plugins/claude-code/README.md
+++ b/site/content/source/plugins/claude-code/README.md
@@ -2,7 +2,7 @@
 title: "Ardur Claude Code Plugin"
 description: "This plugin protects Claude Code at the local tool boundary. `PreToolUse` runs"
 source_path: "plugins/claude-code/README.md"
-source_sha256: "ed8084415397e0e0e577667278ef59e5be6a2926a507dc7b5406d0dee255453f"
+source_sha256: "f9a5a0b9233581ac18aa00208cd7cf09417ad87128e1756a89a05391785a18ae"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]

--- a/site/content/source/plugins/claude-code/README.md
+++ b/site/content/source/plugins/claude-code/README.md
@@ -112,10 +112,17 @@ Operational toggles:
   client when benchmarking or diagnosing the fast path; do not use it if you
   want Python fallback behavior.
 
-Claim boundary: the gated release test targets the native daemon-client path.
-Shell wrapper latency is recorded as telemetry because `/bin/bash` startup and
-workstation scheduler tails can dominate p95 even when the native hot path is
-fast.
+Claim boundary — per-platform numbers:
+
+- **In-process compute** (passport validation + scope check + receipt emit,
+  no IPC): p95 **<10ms**. Gated by `test_claude_code_daemon_hot_path_latency_target`.
+- **Full native daemon-client path** (native binary exec + Unix-socket
+  send/recv + response parse): p95 **<20ms**, measured ~15-17ms on Apple
+  Silicon macOS. Gated by `test_claude_code_native_daemon_client_latency_target`.
+- **Shell wrapper path**: latency recorded as telemetry only. `/bin/bash`
+  startup and workstation scheduler tails can dominate p95 even when the
+  native hot path is fast; enforcing a gate here would measure shell overhead,
+  not Ardur overhead.
 
 ## Built-In Options
 


### PR DESCRIPTION
Relates to #37 (left open — broader platform re-measurement still warranted).

## What changed

The `p95<10ms` claim for the Claude Code hook was only accurate for
**in-process compute** (pure passport validation + scope check + receipt
emission, no IPC). The full **native daemon-client path** — where the
hook binary forks, connects to the daemon over a Unix socket, and parses
the response — measures **~15–17ms p95 on Apple Silicon macOS**, not
<10ms.

### Files changed

| File | Change |
|------|--------|
| `python/tests/test_claude_code_hook_latency.py` | Raise the `test_claude_code_native_daemon_client_latency_target` gate from `p95<10ms` to `p95<20ms` (brackets measured baseline, still catches regressions). Add explicit docstrings to both gated tests clarifying which path each one measures and why the numbers differ. |
| `plugins/claude-code/README.md` | Replace vague "gated release test targets the native daemon-client path" with a split table: in-process <10ms vs. full client path <20ms, with test names. |
| `site/content/source/plugins/claude-code/README.md` | Mirror of the README change. |

### Why not just fix the number everywhere?

The `p95<10ms` claim remains correct for the **in-process hot-path test**
(`test_claude_code_daemon_hot_path_latency_target`); that gate is
unchanged. The issue is that one gated test was labelled "defensible
p95<10ms release claim" while measuring the full round-trip path, which
is meaningfully slower.

## Test results

```
762 passed, 28 skipped
```

(Latency benchmarks are skipped unless `ARDUR_RUN_LATENCY_BENCH=1`; the
4 pre-existing collection errors are unrelated to this change.)