### PR TITLE
ci(go): add govulncheck CVE gate — fix #45 (SAFE)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,31 @@ jobs:
         working-directory: go
         run: go vet ./...
 
+  go-cve:
+    name: Go CVE scan
+    runs-on: ubuntu-latest
+    # Non-blocking until go/go.mod is bumped past go1.26.4 + golang.org/x/net@v0.55.0.
+    # Findings are real and tracked — the gate is no longer blind.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          # Must match the `go` directive in go/go.mod (currently 1.26.0).
+          go-version: '1.26.0'
+          cache: true
+          cache-dependency-path: go/go.sum
+
+      - name: Install govulncheck
+        # Pin to v1.1.4; @latest (v1.4.0) panics on generics via x/tools@v0.46.0.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck
+        working-directory: go
+        run: govulncheck ./...
+
   rwt-phase1:
     name: "RWT Phase 1 (fresh-user)"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `go-cve` job to `.github/workflows/tests.yml` that installs `govulncheck@v1.1.4` and runs `govulncheck ./...` against the Go module
- Pinned to `v1.1.4` (not `@latest` which is `v1.4.0`) — `v1.4.0` panics on generic types via `x/tools@v0.46.0` (#panic in `ForEachElement`)
- `continue-on-error: true` until the downstream Go version is bumped (see below); findings are real and tracked

**Root cause of blindness**: No `govulncheck` step existed in CI at all. The CI already used `go-version: '1.26.0'` matching `go/go.mod`, so no toolchain directive change was needed.

**govulncheck result (local, govulncheck@v1.1.4 + go1.26.0):**
18 vulnerabilities found — all in `go1.26` stdlib (fixed in `go1.26.1`–`go1.26.4`) plus `golang.org/x/net@v0.53.0` (`GO-2026-5026`, fixed in `v0.55.0`). The gate is **no longer blind**; it's reporting real findings.

**To make this gate blocking**: bump `go/go.mod` to `go 1.26.4` and `golang.org/x/net` to `v0.55.0`, then remove `continue-on-error: true`.

## Test plan

- [ ] `go-cve` job appears in CI run for this PR
- [ ] Job reports findings (exit 3 from govulncheck) but the overall job is marked allowed-failure so PR checks stay green
- [ ] All other existing jobs (`go`, `go-lint`, `python`, etc.) pass unaffected

Closes #45 (SAFE / govulncheck sub-task only — does not touch PR #17 or any dependabot PRs)