### PR TITLE
feat(trust): wire per-tier egress NetworkPolicy + live telemetry ingestion

### DIFF
--- a/go/cmd/operator/main.go
+++ b/go/cmd/operator/main.go
@@ -31,6 +31,7 @@ func main() {
 		metricsAddr          string
 		healthProbeAddr      string
 		telemetryAddr        string
+		telemetryToken       string
 		enableLeaderElection bool
 		signingKeyPath       string
 		issuerURI            string
@@ -40,6 +41,9 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Metrics endpoint bind address.")
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "Health probe bind address.")
 	flag.StringVar(&telemetryAddr, "telemetry-bind-address", ":8082", "Telemetry signal ingestion address. POST /telemetry/signal")
+	flag.StringVar(&telemetryToken, "telemetry-token", os.Getenv("VIBAP_TELEMETRY_TOKEN"),
+		"Bearer token required on POST /telemetry/signal. Also read from VIBAP_TELEMETRY_TOKEN. "+
+			"Without a token every request is rejected (fail-closed).")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for HA.")
 	flag.StringVar(&signingKeyPath, "signing-key", "", "Path to Ed25519 signing key (JWK). Required in production.")
 	flag.StringVar(&issuerURI, "issuer-uri", "https://vibap.ardur.dev", "Credential issuer URI.")
@@ -103,7 +107,10 @@ func main() {
 	ingestor := NewTelemetryIngestor(reconciler.trustAgg, func(ctx context.Context, namespace, tier string) error {
 		return reconciler.applyNetworkPolicyForTier(ctx, namespace, tier)
 	})
-	telemetryMux.Handle("/telemetry/signal", ingestor)
+	if telemetryToken == "" {
+		setupLog.Info("WARNING: no telemetry token configured; POST /telemetry/signal will reject all requests")
+	}
+	telemetryMux.Handle("/telemetry/signal", BearerAuthMiddleware(telemetryToken, ingestor))
 
 	go func() {
 		setupLog.Info("starting telemetry ingestor", "addr", telemetryAddr)

--- a/go/cmd/operator/main.go
+++ b/go/cmd/operator/main.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"net/http"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,6 +30,7 @@ func main() {
 	var (
 		metricsAddr          string
 		healthProbeAddr      string
+		telemetryAddr        string
 		enableLeaderElection bool
 		signingKeyPath       string
 		issuerURI            string
@@ -36,6 +39,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Metrics endpoint bind address.")
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "Health probe bind address.")
+	flag.StringVar(&telemetryAddr, "telemetry-bind-address", ":8082", "Telemetry signal ingestion address. POST /telemetry/signal")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for HA.")
 	flag.StringVar(&signingKeyPath, "signing-key", "", "Path to Ed25519 signing key (JWK). Required in production.")
 	flag.StringVar(&issuerURI, "issuer-uri", "https://vibap.ardur.dev", "Credential issuer URI.")
@@ -89,6 +93,25 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+
+	// Telemetry ingestor: Tetragon/Kubescape/verifiers POST signals to
+	// /telemetry/signal; on tier change the NetworkPolicy is re-applied.
+	//
+	// REQUIRES_CLUSTER: applyPolicy calls the K8s API; fails gracefully
+	// without a cluster (score update still persists).
+	telemetryMux := http.NewServeMux()
+	ingestor := NewTelemetryIngestor(reconciler.trustAgg, func(ctx context.Context, namespace, tier string) error {
+		return reconciler.applyNetworkPolicyForTier(ctx, namespace, tier)
+	})
+	telemetryMux.Handle("/telemetry/signal", ingestor)
+
+	go func() {
+		setupLog.Info("starting telemetry ingestor", "addr", telemetryAddr)
+		srv := &http.Server{Addr: telemetryAddr, Handler: telemetryMux}
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			setupLog.Error(err, "telemetry server exited")
+		}
+	}()
 
 	setupLog.Info("starting VIBAP operator")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/go/cmd/operator/reconciler.go
+++ b/go/cmd/operator/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -254,6 +255,15 @@ func (r *AgentPassportReconciler) issueCredential(ctx context.Context, ap *vibap
 		ap.Status.CompositeScore = result.Credential.Claims.Trust.CompositeScore
 	}
 
+	// REQUIRES_CLUSTER: apply the per-tier NetworkPolicy so egress enforcement
+	// reflects the current trust tier immediately after every credential issuance.
+	if npErr := r.applyNetworkPolicyForTier(ctx, ap.Namespace, ap.Status.TrustTier); npErr != nil {
+		logger.Error(npErr, "failed to apply tier NetworkPolicy",
+			"namespace", ap.Namespace, "tier", ap.Status.TrustTier)
+		r.recordEvent(ap, corev1.EventTypeWarning, "NetworkPolicyFailed",
+			"Failed to apply egress NetworkPolicy for tier %s: %v", ap.Status.TrustTier, npErr)
+	}
+
 	governanceErr := r.reconcileGovernance(ctx, ap)
 
 	setCondition(ap, vibapv1alpha1.ConditionCredentialIssued, metav1.ConditionTrue,
@@ -294,6 +304,44 @@ func (r *AgentPassportReconciler) ensureAgentRegistered(ctx context.Context, age
 		trustSpec.StaticCapabilityScore,
 		trustSpec.HistoricalReputation,
 	)
+}
+
+// applyNetworkPolicyForTier creates or updates the NetworkPolicy for the given
+// trust tier in the given namespace.
+//
+// REQUIRES_CLUSTER: calls the K8s networking API (Get + Create/Update).
+// No-op when tier is empty (pre-issue state).
+func (r *AgentPassportReconciler) applyNetworkPolicyForTier(ctx context.Context, namespace, tier string) error {
+	if tier == "" {
+		return nil
+	}
+	desired := trust.NetworkPolicyForTier(tier, namespace)
+	return applyNetworkPolicy(ctx, r.Client, desired)
+}
+
+// applyNetworkPolicy creates or updates np via the K8s API.
+// REQUIRES_CLUSTER: calls the K8s networking API.
+func applyNetworkPolicy(ctx context.Context, c client.Client, desired *networkingv1.NetworkPolicy) error {
+	existing := &networkingv1.NetworkPolicy{}
+	key := client.ObjectKey{Namespace: desired.Namespace, Name: desired.Name}
+
+	err := c.Get(ctx, key, existing)
+	if apierrors.IsNotFound(err) {
+		if createErr := c.Create(ctx, desired); createErr != nil {
+			return fmt.Errorf("creating NetworkPolicy %s: %w", desired.Name, createErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting NetworkPolicy %s: %w", desired.Name, err)
+	}
+
+	existing.Spec = desired.Spec
+	existing.Labels = desired.Labels
+	if updateErr := c.Update(ctx, existing); updateErr != nil {
+		return fmt.Errorf("updating NetworkPolicy %s: %w", desired.Name, updateErr)
+	}
+	return nil
 }
 
 func (r *AgentPassportReconciler) loadPolicyFromConfigMap(ctx context.Context, ns string, ref *vibapv1alpha1.PolicyReference) (string, error) {

--- a/go/cmd/operator/telemetry_handler.go
+++ b/go/cmd/operator/telemetry_handler.go
@@ -117,6 +117,20 @@ func isNotFound(err error) bool {
 		containsError(err, trust.ErrAgentNotFound))
 }
 
+// BearerAuthMiddleware rejects requests whose Authorization header does not
+// match "Bearer <token>". An empty token is treated as misconfigured — every
+// request is rejected (fail-closed). This prevents privilege escalation via
+// forged signals when no token has been provisioned.
+func BearerAuthMiddleware(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token == "" || r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func containsError(err, target error) bool {
 	for err != nil {
 		if err == target {

--- a/go/cmd/operator/telemetry_handler.go
+++ b/go/cmd/operator/telemetry_handler.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/trust"
+)
+
+// TelemetryIngestor exposes an HTTP endpoint that accepts TelemetrySignal
+// objects from monitoring sources (Tetragon, Kubescape, verifiers) and feeds
+// them into the trust ScoreAggregator.
+//
+// POST /telemetry/signal
+//
+//	Body: JSON-encoded TelemetrySignal
+//	Response 200: updated TrustScore JSON
+//	Response 400: malformed request
+//	Response 404: agent not registered
+//	Response 500: internal error
+//
+// REQUIRES_CLUSTER: after ingestion, if the tier changes the reconciler applies
+// a NetworkPolicy. The NetworkPolicy application step is skipped when
+// applyPolicy is nil (e.g. unit tests without a K8s client).
+type TelemetryIngestor struct {
+	agg         trust.ScoreAggregator
+	applyPolicy func(ctx context.Context, namespace, tier string) error
+}
+
+// NewTelemetryIngestor creates a handler wired to the given aggregator.
+// applyPolicy may be nil; if supplied it is called when a signal causes a
+// tier change, so the reconciler can enforce the new NetworkPolicy.
+func NewTelemetryIngestor(agg trust.ScoreAggregator, applyPolicy func(ctx context.Context, namespace, tier string) error) *TelemetryIngestor {
+	return &TelemetryIngestor{agg: agg, applyPolicy: applyPolicy}
+}
+
+// telemetryRequest is the wire format for inbound signals.
+// Timestamp is optional; defaults to now if omitted.
+type telemetryRequest struct {
+	AgentID   string     `json:"agent_id"`
+	Type      string     `json:"type"`
+	Severity  string     `json:"severity"`
+	Source    string     `json:"source"`
+	Details   string     `json:"details"`
+	Namespace string     `json:"namespace"` // needed for NetworkPolicy application
+	Timestamp *time.Time `json:"timestamp,omitempty"`
+}
+
+// ServeHTTP handles POST /telemetry/signal.
+func (h *TelemetryIngestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req telemetryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if req.AgentID == "" {
+		http.Error(w, "agent_id is required", http.StatusBadRequest)
+		return
+	}
+
+	ts := time.Now()
+	if req.Timestamp != nil {
+		ts = *req.Timestamp
+	}
+
+	signal := trust.TelemetrySignal{
+		AgentID:   req.AgentID,
+		Type:      trust.SignalType(req.Type),
+		Severity:  trust.SignalSeverity(req.Severity),
+		Timestamp: ts,
+		Source:    req.Source,
+		Details:   req.Details,
+	}
+
+	ctx := r.Context()
+
+	// Capture old tier before ingestion to detect tier changes.
+	oldScore, _ := h.agg.GetScore(ctx, req.AgentID)
+	oldTier := ""
+	if oldScore != nil {
+		oldTier = oldScore.AuthorizationTier
+	}
+
+	score, err := h.agg.IngestSignal(ctx, signal)
+	if err != nil {
+		if isNotFound(err) {
+			http.Error(w, fmt.Sprintf("agent %q not registered", req.AgentID), http.StatusNotFound)
+			return
+		}
+		http.Error(w, fmt.Sprintf("ingestion error: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Apply NetworkPolicy if tier changed and a namespace was provided.
+	// Failure is non-fatal: the score update already succeeded; the next
+	// reconcile loop will retry the NetworkPolicy application.
+	if h.applyPolicy != nil && req.Namespace != "" && score.AuthorizationTier != oldTier {
+		_ = h.applyPolicy(ctx, req.Namespace, score.AuthorizationTier)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(score)
+}
+
+func isNotFound(err error) bool {
+	return err != nil && (err == trust.ErrAgentNotFound ||
+		containsError(err, trust.ErrAgentNotFound))
+}
+
+func containsError(err, target error) bool {
+	for err != nil {
+		if err == target {
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		if u, ok := err.(unwrapper); ok {
+			err = u.Unwrap()
+		} else {
+			return false
+		}
+	}
+	return false
+}

--- a/go/cmd/operator/telemetry_handler_test.go
+++ b/go/cmd/operator/telemetry_handler_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/trust"
+)
+
+// newTestIngestor builds an ingestor backed by a fresh in-memory aggregator
+// with "test-agent" pre-registered at scores that place it in the full tier.
+func newTestIngestor(t *testing.T) (*TelemetryIngestor, trust.ScoreAggregator) {
+	t.Helper()
+	agg, err := trust.NewInMemoryAggregator()
+	if err != nil {
+		t.Fatalf("creating aggregator: %v", err)
+	}
+	if err := agg.RegisterAgent(context.Background(), "test-agent", 0.8, 0.8); err != nil {
+		t.Fatalf("registering agent: %v", err)
+	}
+	return NewTelemetryIngestor(agg, nil), agg
+}
+
+func postSignal(t *testing.T, h http.Handler, body telemetryRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshaling request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestTelemetryIngestor_CleanInterval(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	w := postSignal(t, h, telemetryRequest{
+		AgentID:  "test-agent",
+		Type:     string(trust.SignalCleanInterval),
+		Severity: string(trust.SeverityInfo),
+		Source:   "verifier",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var score trust.TrustScore
+	if err := json.NewDecoder(w.Body).Decode(&score); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if score.AgentID != "test-agent" {
+		t.Errorf("expected agent_id test-agent, got %q", score.AgentID)
+	}
+	if score.CompositeScore <= 0 {
+		t.Error("expected positive composite score after clean interval")
+	}
+}
+
+func TestTelemetryIngestor_PolicyViolationDegrades(t *testing.T) {
+	h, agg := newTestIngestor(t)
+
+	baseScore, err := agg.GetScore(context.Background(), "test-agent")
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	w := postSignal(t, h, telemetryRequest{
+		AgentID:  "test-agent",
+		Type:     string(trust.SignalPolicyViolation),
+		Severity: string(trust.SeverityHigh),
+		Source:   "kubescape",
+		Details:  "privileged container detected",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var score trust.TrustScore
+	if err := json.NewDecoder(w.Body).Decode(&score); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if score.CompositeScore >= baseScore.CompositeScore {
+		t.Errorf("score should degrade after high violation: before=%.2f after=%.2f",
+			baseScore.CompositeScore, score.CompositeScore)
+	}
+}
+
+func TestTelemetryIngestor_UnknownAgent404(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	w := postSignal(t, h, telemetryRequest{
+		AgentID:  "ghost-agent",
+		Type:     string(trust.SignalCleanInterval),
+		Severity: string(trust.SeverityInfo),
+		Source:   "verifier",
+	})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown agent, got %d", w.Code)
+	}
+}
+
+func TestTelemetryIngestor_MissingAgentID400(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	w := postSignal(t, h, telemetryRequest{
+		Type:     string(trust.SignalCleanInterval),
+		Severity: string(trust.SeverityInfo),
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing agent_id, got %d", w.Code)
+	}
+}
+
+func TestTelemetryIngestor_InvalidJSON400(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+func TestTelemetryIngestor_WrongMethod405(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	req := httptest.NewRequest(http.MethodGet, "/telemetry/signal", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", w.Code)
+	}
+}
+
+func TestTelemetryIngestor_TimestampOverride(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	ts := time.Now().Add(-5 * time.Minute)
+	w := postSignal(t, h, telemetryRequest{
+		AgentID:   "test-agent",
+		Type:      string(trust.SignalCleanInterval),
+		Severity:  string(trust.SeverityInfo),
+		Source:    "verifier",
+		Timestamp: &ts,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with explicit timestamp, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestTelemetryIngestor_ApplyPolicyCalledOnTierChange verifies the applyPolicy
+// callback fires when a signal causes a tier transition.
+func TestTelemetryIngestor_ApplyPolicyCalledOnTierChange(t *testing.T) {
+	agg, err := trust.NewInMemoryAggregator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Register near the quarantine boundary
+	if err := agg.RegisterAgent(context.Background(), "fringe-agent", 0.4, 0.4); err != nil {
+		t.Fatal(err)
+	}
+
+	var capturedTier string
+	applyFn := func(_ context.Context, _ string, tier string) error {
+		capturedTier = tier
+		return nil
+	}
+
+	h := NewTelemetryIngestor(agg, applyFn)
+
+	// Apply critical signals to push into quarantine
+	for range 5 {
+		w := postSignal(t, h, telemetryRequest{
+			AgentID:   "fringe-agent",
+			Type:      string(trust.SignalPolicyViolation),
+			Severity:  string(trust.SeverityCritical),
+			Source:    "tetragon",
+			Namespace: "agents",
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	}
+
+	score, err := agg.GetScore(context.Background(), "fringe-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// After heavy degradation agent should be in quarantine and callback should have fired
+	if score.AuthorizationTier == trust.TierQuarantine && capturedTier == "" {
+		t.Error("applyPolicy callback was not called despite tier change to quarantine")
+	}
+}
+
+// TestTelemetryIngestor_ResponseContainsAuthorizationTier checks the JSON
+// response includes the authorization_tier field.
+func TestTelemetryIngestor_ResponseContainsAuthorizationTier(t *testing.T) {
+	h, _ := newTestIngestor(t)
+	w := postSignal(t, h, telemetryRequest{
+		AgentID:  "test-agent",
+		Type:     string(trust.SignalCleanInterval),
+		Severity: string(trust.SeverityInfo),
+		Source:   "verifier",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var m map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["authorization_tier"]; !ok {
+		t.Error("response must contain authorization_tier field")
+	}
+}

--- a/go/cmd/operator/telemetry_handler_test.go
+++ b/go/cmd/operator/telemetry_handler_test.go
@@ -195,6 +195,62 @@ func TestTelemetryIngestor_ApplyPolicyCalledOnTierChange(t *testing.T) {
 	}
 }
 
+// TestBearerAuthMiddleware_NoAuth_Returns401 verifies unauthenticated requests
+// are rejected with 401, preventing any pod from forging telemetry signals.
+func TestBearerAuthMiddleware_NoAuth_Returns401(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := BearerAuthMiddleware("secret-token", inner)
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for missing auth header, got %d", w.Code)
+	}
+}
+
+func TestBearerAuthMiddleware_WrongToken_Returns401(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := BearerAuthMiddleware("secret-token", inner)
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for wrong token, got %d", w.Code)
+	}
+}
+
+func TestBearerAuthMiddleware_CorrectToken_PassesThrough(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := BearerAuthMiddleware("secret-token", inner)
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestBearerAuthMiddleware_EmptyToken_RejectsAll(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := BearerAuthMiddleware("", inner)
+	req := httptest.NewRequest(http.MethodPost, "/telemetry/signal", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for empty token (fail-closed), got %d", w.Code)
+	}
+}
+
 // TestTelemetryIngestor_ResponseContainsAuthorizationTier checks the JSON
 // response includes the authorization_tier field.
 func TestTelemetryIngestor_ResponseContainsAuthorizationTier(t *testing.T) {

--- a/go/pkg/trust/network_policy.go
+++ b/go/pkg/trust/network_policy.go
@@ -1,0 +1,214 @@
+// Package trust — NetworkPolicy generation for per-tier egress enforcement.
+//
+// Each trust tier maps to a distinct egress posture (documented in scorer.go):
+//
+//   - Full  (≥70): all egress allowed (no EgressRule restrictions)
+//   - Limited (≥40): cluster-internal egress only (port 53 for DNS, no
+//     external destinations)
+//   - Quarantine (<40): egress denied to everything except the Prometheus
+//     scrape port (9090/TCP) within the same namespace
+//
+// NetworkPolicy objects are generated as in-memory Kubernetes API objects.
+// Applying them to a cluster requires the K8s client (see reconciler.go).
+// The generation logic itself is locally testable without a cluster.
+package trust
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	// NetworkPolicyNameFull is the NetworkPolicy name for full-tier agents.
+	NetworkPolicyNameFull = "vibap-egress-full"
+	// NetworkPolicyNameLimited is the NetworkPolicy name for limited-tier agents.
+	NetworkPolicyNameLimited = "vibap-egress-limited"
+	// NetworkPolicyNameQuarantine is the NetworkPolicy name for quarantine-tier agents.
+	NetworkPolicyNameQuarantine = "vibap-egress-quarantine"
+
+	// labelKeyTier is the pod label the NetworkPolicy selects on.
+	labelKeyTier = "vibap.ardur.dev/trust-tier"
+
+	// prometheusPort is the only port quarantined agents may reach.
+	prometheusPort = 9090
+)
+
+// NetworkPolicyForTier returns the canonical Kubernetes NetworkPolicy that
+// enforces egress for the given trust tier in namespace ns.
+//
+// The returned object has no ResourceVersion — callers must create or update
+// it via the K8s API. The object's name is deterministic so callers can use
+// server-side apply or a simple Get + Create/Update cycle.
+//
+// Callers targeting a real cluster:
+//
+//	REQUIRES_CLUSTER: applying or listing NetworkPolicy objects
+func NetworkPolicyForTier(tier, namespace string) *networkingv1.NetworkPolicy {
+	switch tier {
+	case TierFull:
+		return fullEgressPolicy(namespace)
+	case TierLimited:
+		return limitedEgressPolicy(namespace)
+	default:
+		return quarantineEgressPolicy(namespace)
+	}
+}
+
+// PolicyNameForTier returns the deterministic NetworkPolicy name for a tier.
+func PolicyNameForTier(tier string) string {
+	switch tier {
+	case TierFull:
+		return NetworkPolicyNameFull
+	case TierLimited:
+		return NetworkPolicyNameLimited
+	default:
+		return NetworkPolicyNameQuarantine
+	}
+}
+
+// AllTierPolicyNames returns all tier NetworkPolicy names. Useful for cleanup.
+func AllTierPolicyNames() []string {
+	return []string{
+		NetworkPolicyNameFull,
+		NetworkPolicyNameLimited,
+		NetworkPolicyNameQuarantine,
+	}
+}
+
+// fullEgressPolicy allows all egress — no EgressRule restrictions.
+// Equivalent to "any destination, any port".
+func fullEgressPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NetworkPolicyNameFull,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vibap-operator",
+				"vibap.ardur.dev/policy-tier":  TierFull,
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelKeyTier: TierFull,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+			},
+			// Single rule with no To or Ports restrictions means allow all egress.
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{},
+			},
+		},
+	}
+}
+
+// limitedEgressPolicy allows only cluster-internal egress:
+//   - UDP 53 for in-cluster DNS resolution
+//   - TCP to any cluster-internal destination (no CIDR block for external IPs)
+//
+// This prevents reaching external endpoints while permitting in-cluster service calls.
+func limitedEgressPolicy(namespace string) *networkingv1.NetworkPolicy {
+	dnsPort := intstr.FromInt32(53)
+	tcpProto := corev1.ProtocolTCP
+	udpProto := corev1.ProtocolUDP
+
+	return &networkingv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NetworkPolicyNameLimited,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vibap-operator",
+				"vibap.ardur.dev/policy-tier":  TierLimited,
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelKeyTier: TierLimited,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					// DNS egress: UDP 53 to kube-dns
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &udpProto, Port: &dnsPort},
+					},
+				},
+				{
+					// Cluster-internal TCP — PodSelector with no IPBlock
+					// allows any cluster pod but blocks external IP addresses.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcpProto},
+					},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// quarantineEgressPolicy denies all egress except Prometheus scraping (TCP 9090)
+// from within the same namespace. No external access permitted.
+func quarantineEgressPolicy(namespace string) *networkingv1.NetworkPolicy {
+	prometheusPortVal := intstr.FromInt32(prometheusPort)
+	tcpProto := corev1.ProtocolTCP
+
+	return &networkingv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NetworkPolicyNameQuarantine,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vibap-operator",
+				"vibap.ardur.dev/policy-tier":  TierQuarantine,
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelKeyTier: TierQuarantine,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					// Only allow Prometheus scrape port within the same namespace.
+					// Empty PodSelector matches all pods; absent NamespaceSelector
+					// restricts to the current namespace.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcpProto, Port: &prometheusPortVal},
+					},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/go/pkg/trust/network_policy.go
+++ b/go/pkg/trust/network_policy.go
@@ -144,9 +144,25 @@ func limitedEgressPolicy(namespace string) *networkingv1.NetworkPolicy {
 			},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
 				{
-					// DNS egress: UDP 53 to kube-dns
+					// DNS egress: UDP 53 scoped to kube-dns pods in kube-system.
+					// The To restriction prevents using port 53 as an exfiltration
+					// channel to arbitrary external resolvers.
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &udpProto, Port: &dnsPort},
+					},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": "kube-system",
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"k8s-app": "kube-dns",
+								},
+							},
+						},
 					},
 				},
 				{

--- a/go/pkg/trust/network_policy_test.go
+++ b/go/pkg/trust/network_policy_test.go
@@ -1,0 +1,211 @@
+package trust
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestNetworkPolicyForTier_Full(t *testing.T) {
+	np := NetworkPolicyForTier(TierFull, "default")
+
+	if np.Name != NetworkPolicyNameFull {
+		t.Errorf("expected name %q, got %q", NetworkPolicyNameFull, np.Name)
+	}
+	if np.Namespace != "default" {
+		t.Errorf("expected namespace %q, got %q", "default", np.Namespace)
+	}
+	if np.Labels["vibap.ardur.dev/policy-tier"] != TierFull {
+		t.Errorf("expected tier label %q", TierFull)
+	}
+
+	sel := np.Spec.PodSelector.MatchLabels
+	if sel[labelKeyTier] != TierFull {
+		t.Errorf("pod selector must match tier=%s", TierFull)
+	}
+
+	assertPolicyType(t, np, networkingv1.PolicyTypeEgress)
+
+	// Full tier: one egress rule with no port/To restrictions (allow-all)
+	if len(np.Spec.Egress) == 0 {
+		t.Fatal("full tier must have at least one egress rule")
+	}
+	rule := np.Spec.Egress[0]
+	if len(rule.Ports) != 0 || len(rule.To) != 0 {
+		t.Error("full tier egress rule must have no port or To restrictions")
+	}
+}
+
+func TestNetworkPolicyForTier_Limited(t *testing.T) {
+	np := NetworkPolicyForTier(TierLimited, "agents")
+
+	if np.Name != NetworkPolicyNameLimited {
+		t.Errorf("expected name %q, got %q", NetworkPolicyNameLimited, np.Name)
+	}
+	if np.Namespace != "agents" {
+		t.Errorf("expected namespace %q, got %q", "agents", np.Namespace)
+	}
+
+	sel := np.Spec.PodSelector.MatchLabels
+	if sel[labelKeyTier] != TierLimited {
+		t.Errorf("pod selector must match tier=%s", TierLimited)
+	}
+
+	assertPolicyType(t, np, networkingv1.PolicyTypeEgress)
+
+	if len(np.Spec.Egress) < 2 {
+		t.Fatalf("limited tier must have at least 2 egress rules, got %d", len(np.Spec.Egress))
+	}
+
+	// Find DNS rule (UDP 53)
+	dnsFound := false
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			if p.Protocol != nil && *p.Protocol == corev1.ProtocolUDP &&
+				p.Port != nil && p.Port.IntVal == 53 {
+				dnsFound = true
+			}
+		}
+	}
+	if !dnsFound {
+		t.Error("limited tier must include UDP 53 egress rule for DNS")
+	}
+
+	// Must not permit external IPs: at least one rule must have a To with PodSelector
+	hasPodSelectorRule := false
+	for _, rule := range np.Spec.Egress {
+		for _, peer := range rule.To {
+			if peer.PodSelector != nil && peer.IPBlock == nil {
+				hasPodSelectorRule = true
+			}
+		}
+	}
+	if !hasPodSelectorRule {
+		t.Error("limited tier must have a To rule with PodSelector (no IPBlock) to block external IPs")
+	}
+}
+
+func TestNetworkPolicyForTier_Quarantine(t *testing.T) {
+	np := NetworkPolicyForTier(TierQuarantine, "secure")
+
+	if np.Name != NetworkPolicyNameQuarantine {
+		t.Errorf("expected name %q, got %q", NetworkPolicyNameQuarantine, np.Name)
+	}
+
+	sel := np.Spec.PodSelector.MatchLabels
+	if sel[labelKeyTier] != TierQuarantine {
+		t.Errorf("pod selector must match tier=%s", TierQuarantine)
+	}
+
+	assertPolicyType(t, np, networkingv1.PolicyTypeEgress)
+
+	if len(np.Spec.Egress) == 0 {
+		t.Fatal("quarantine tier must have at least one egress rule for Prometheus")
+	}
+
+	// Only Prometheus port (9090/TCP) allowed
+	prometheusFound := false
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			if p.Protocol != nil && *p.Protocol == corev1.ProtocolTCP &&
+				p.Port != nil && p.Port.IntVal == prometheusPort {
+				prometheusFound = true
+			}
+		}
+	}
+	if !prometheusFound {
+		t.Errorf("quarantine tier must permit TCP %d (Prometheus)", prometheusPort)
+	}
+
+	// No IPBlock peers allowed (no external IPs)
+	for _, rule := range np.Spec.Egress {
+		for _, peer := range rule.To {
+			if peer.IPBlock != nil {
+				t.Error("quarantine tier must not include IPBlock peers (no external IPs)")
+			}
+		}
+	}
+}
+
+// TestNetworkPolicyForTier_UnknownTierFallsToQuarantine ensures unrecognized
+// tier names are treated as quarantine (fail-safe).
+func TestNetworkPolicyForTier_UnknownTierFallsToQuarantine(t *testing.T) {
+	np := NetworkPolicyForTier("unknown-tier", "default")
+	if np.Name != NetworkPolicyNameQuarantine {
+		t.Errorf("unknown tier must fall to quarantine policy, got %q", np.Name)
+	}
+}
+
+// TestPolicyNameForTier checks deterministic name mapping.
+func TestPolicyNameForTier(t *testing.T) {
+	cases := []struct {
+		tier string
+		want string
+	}{
+		{TierFull, NetworkPolicyNameFull},
+		{TierLimited, NetworkPolicyNameLimited},
+		{TierQuarantine, NetworkPolicyNameQuarantine},
+		{"bogus", NetworkPolicyNameQuarantine},
+	}
+	for _, tc := range cases {
+		got := PolicyNameForTier(tc.tier)
+		if got != tc.want {
+			t.Errorf("PolicyNameForTier(%q) = %q, want %q", tc.tier, got, tc.want)
+		}
+	}
+}
+
+// TestAllTierPolicyNames ensures all three tier names are returned.
+func TestAllTierPolicyNames(t *testing.T) {
+	names := AllTierPolicyNames()
+	if len(names) != 3 {
+		t.Fatalf("expected 3 tier policy names, got %d", len(names))
+	}
+	want := map[string]bool{
+		NetworkPolicyNameFull:       true,
+		NetworkPolicyNameLimited:    true,
+		NetworkPolicyNameQuarantine: true,
+	}
+	for _, n := range names {
+		if !want[n] {
+			t.Errorf("unexpected policy name %q", n)
+		}
+	}
+}
+
+// TestNetworkPolicyForTier_Metadata checks managed-by label and type metadata.
+func TestNetworkPolicyForTier_Metadata(t *testing.T) {
+	for _, tier := range []string{TierFull, TierLimited, TierQuarantine} {
+		np := NetworkPolicyForTier(tier, "ns")
+		if np.Labels["app.kubernetes.io/managed-by"] != "vibap-operator" {
+			t.Errorf("tier %s: missing managed-by label", tier)
+		}
+		if np.APIVersion != "networking.k8s.io/v1" {
+			t.Errorf("tier %s: wrong APIVersion %q", tier, np.APIVersion)
+		}
+		if np.Kind != "NetworkPolicy" {
+			t.Errorf("tier %s: wrong Kind %q", tier, np.Kind)
+		}
+	}
+}
+
+// TestNetworkPolicyForTier_NamespaceIsolation verifies namespace is propagated.
+func TestNetworkPolicyForTier_NamespaceIsolation(t *testing.T) {
+	for _, tier := range []string{TierFull, TierLimited, TierQuarantine} {
+		np := NetworkPolicyForTier(tier, "production")
+		if np.Namespace != "production" {
+			t.Errorf("tier %s: expected namespace %q, got %q", tier, "production", np.Namespace)
+		}
+	}
+}
+
+func assertPolicyType(t *testing.T, np *networkingv1.NetworkPolicy, want networkingv1.PolicyType) {
+	t.Helper()
+	for _, pt := range np.Spec.PolicyTypes {
+		if pt == want {
+			return
+		}
+	}
+	t.Errorf("policy %q missing PolicyType %q", np.Name, want)
+}

--- a/go/pkg/trust/network_policy_test.go
+++ b/go/pkg/trust/network_policy_test.go
@@ -200,6 +200,44 @@ func TestNetworkPolicyForTier_NamespaceIsolation(t *testing.T) {
 	}
 }
 
+// TestLimitedDNSEgressScopedToKubeDNS verifies the UDP/53 egress rule in the
+// limited tier is scoped to kube-dns pods in kube-system, not open to any
+// destination (which would be an exfiltration channel).
+func TestLimitedDNSEgressScopedToKubeDNS(t *testing.T) {
+	np := NetworkPolicyForTier(TierLimited, "agents")
+
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			if p.Protocol == nil || *p.Protocol != corev1.ProtocolUDP {
+				continue
+			}
+			if p.Port == nil || p.Port.IntVal != 53 {
+				continue
+			}
+			// Found DNS rule — must have a To restriction.
+			if len(rule.To) == 0 {
+				t.Fatal("UDP/53 egress rule has no To restriction: allows DNS to any destination (exfil risk)")
+			}
+			for _, peer := range rule.To {
+				ns := peer.NamespaceSelector
+				pod := peer.PodSelector
+				if ns == nil || pod == nil {
+					t.Error("DNS peer must specify both NamespaceSelector and PodSelector")
+					continue
+				}
+				if ns.MatchLabels["kubernetes.io/metadata.name"] != "kube-system" {
+					t.Errorf("DNS peer NamespaceSelector must target kube-system, got %v", ns.MatchLabels)
+				}
+				if pod.MatchLabels["k8s-app"] != "kube-dns" {
+					t.Errorf("DNS peer PodSelector must target k8s-app=kube-dns, got %v", pod.MatchLabels)
+				}
+			}
+			return
+		}
+	}
+	t.Error("no UDP/53 egress rule found in limited tier policy")
+}
+
 func assertPolicyType(t *testing.T, np *networkingv1.NetworkPolicy, want networkingv1.PolicyType) {
 	t.Helper()
 	for _, pt := range np.Spec.PolicyTypes {


### PR DESCRIPTION
Closes #41

## What

### (a) Per-tier NetworkPolicy egress enforcement

**`go/pkg/trust/network_policy.go`** — pure Go generator, no cluster needed:

| Tier | Policy | Egress rule |
|---|---|---|
| `full` (≥70) | `vibap-egress-full` | Allow all |
| `limited` (≥40) | `vibap-egress-limited` | Cluster-internal only (UDP 53 to kube-dns + TCP to pods, no IPBlock) |
| `quarantine` (<40) | `vibap-egress-quarantine` | TCP 9090 (Prometheus) same-namespace only |

The **reconciler** (`issueCredential`) calls `applyNetworkPolicyForTier` after every credential issuance, so a tier change takes effect on the next reconcile without waiting.

### (b) Live telemetry ingestion

**`go/cmd/operator/telemetry_handler.go`** — HTTP handler:
- Endpoint: `POST /telemetry/signal` (default `:8082`, flag `--telemetry-bind-address`)
- Accepts Tetragon / Kubescape / verifier signals as JSON (`TelemetrySignal` wire format)
- Returns updated `TrustScore` JSON (including `authorization_tier`)
- On tier change + namespace provided: fires `applyPolicy` callback to immediately re-enforce egress

## Security fixes (07f7f4c)

Two hard blockers identified in review are now resolved:

**1. Unauthenticated telemetry endpoint (privilege escalation)**

`POST /telemetry/signal` previously had no authentication — any pod could forge a signal to change any agent's trust tier. Fixed by `BearerAuthMiddleware` in `telemetry_handler.go`:
- Token configured via `--telemetry-token` flag or `VIBAP_TELEMETRY_TOKEN` env var
- Requests without a matching `Authorization: Bearer <token>` header receive **401**
- Empty token → fail-closed (every request rejected)

**2. DNS egress exfiltration channel (NetworkPolicy)**

The `limitedEgressPolicy` UDP/53 egress rule had no `To:` restriction, allowing DNS queries to any external resolver. Fixed by scoping the rule to kube-dns pods in kube-system:
```
To:
  - namespaceSelector:
      matchLabels:
        kubernetes.io/metadata.name: kube-system
    podSelector:
      matchLabels:
        k8s-app: kube-dns
```

## Tests

| Package | New tests | All pass |
|---|---|---|
| `go/pkg/trust` | 10 (incl. `TestLimitedDNSEgressScopedToKubeDNS`) | ✅ |
| `go/cmd/operator` | 13 (incl. 4 `BearerAuthMiddleware` tests) | ✅ |
| All Go packages | — | ✅ 15/15 |
| Python suite | — | ✅ 900/900 |

## Needs a cluster

The following require a K8s cluster with a CNI that supports NetworkPolicy:
- `applyNetworkPolicy` (Get + Create/Update K8s API calls in reconciler)
- Acceptance criterion: _"a tier change measurably changes egress on a test cluster"_

Without a cluster, `applyNetworkPolicyForTier` logs a warning and continues — the trust score update still persists and the NetworkPolicy object is generated correctly (verified by unit tests).