### PR TITLE
feat(mission): lower effect/flow/lineage bounds to Biscuit (#43)

### DIFF
--- a/python/tests/test_mission_compile.py
+++ b/python/tests/test_mission_compile.py
@@ -12,8 +12,19 @@ from vibap.mission_compile import (
     load_resource_policy,
     lower_effect_policies,
     lower_flow_policies,
+    lower_lineage_budgets,
     lower_resource_policies,
 )
+
+_ALL_CLASSES_BUDGET = {
+    "per_effect_class": {
+        "read": {"reserved": 0, "ceiling": 100},
+        "write": {"reserved": 0, "ceiling": 50},
+        "network": {"reserved": 0, "ceiling": 200},
+        "exec": {"reserved": 0, "ceiling": 10},
+        "external_send": {"reserved": 0, "ceiling": 5},
+    }
+}
 
 
 def test_subpath_requires_absolute_root() -> None:
@@ -42,11 +53,9 @@ def test_lower_subpath_emits_two_facts_and_one_check() -> None:
     assert len(checks) == 1
     assert all(isinstance(c, Check) for c in checks)
     rendered = str(checks[0])
-    # New check uses fact matching, not literal string interpolation.
     assert "resource_subpath_root($r)" in rendered
     assert "resource_subpath_prefix($p)" in rendered
     assert "$r.starts_with($p)" in rendered
-    # Anti-traversal guard (2026-04-21 audit fix #11).
     assert '!$r.contains("/..")' in rendered
 
 
@@ -74,9 +83,7 @@ def test_lower_mixed_policies_concatenates() -> None:
             {"type": "url_allowlist", "allow_domains": ["api.example.com"]},
         ]
     )
-    # 2 facts for the subpath (root + prefix) + 1 per allowed domain
     assert len(facts) == 3
-    # One check per distinct policy type (subpath, url_allowlist)
     assert len(checks) == 2
 
 
@@ -92,7 +99,6 @@ def test_subpath_with_parser_hostile_chars_still_binds_via_parameters() -> None:
     facts, checks = lower_resource_policies(
         [{"type": "subpath", "root": '/data/with "quote" and \\ backslash'}]
     )
-    # Post-audit-fix: each SubpathPolicy emits root + prefix facts.
     assert len(facts) == 2
     assert len(checks) == 1
 
@@ -109,69 +115,305 @@ def test_multiple_subpath_policies_emit_single_combined_check() -> None:
             {"type": "subpath", "root": "/logs"},
         ]
     )
-    # 2 policies * (root + prefix) = 4 facts
     assert len(facts) == 4
     rendered_facts = [str(f) for f in facts]
     assert any('resource_subpath_root("/data/reports")' in r for r in rendered_facts)
     assert any('resource_subpath_root("/logs")' in r for r in rendered_facts)
-    # CRITICAL: ONE combined check, not two.
     assert len(checks) == 1
 
 
 def test_subpath_rejects_dot_dot_segment_in_root() -> None:
-    """2026-04-21 audit fix #11: policy-time rejection of traversal-shaped
-    roots like ``/safe/..`` or ``/data/../secret``. Complements the
-    check-time ``!$r.contains("/..")`` guard so operators cannot
-    accidentally author a policy whose matched resources resolve
-    outside the intended subtree after executor normalization."""
+    """2026-04-21 audit fix #11."""
     for bad_root in ("/data/..", "/safe/../secret", "/../etc", "/..", "/a/../b"):
         with pytest.raises(MissionCompileError, match=r"'\.\.'"):
             SubpathPolicy.from_dict({"root": bad_root})
-    # Segments that merely contain ``..`` as a substring (not a whole
-    # path segment) are accepted — the check is segment-wise, not
-    # substring-wise, to avoid false-positives on legitimate names.
     ok = SubpathPolicy.from_dict({"root": "/data/v..recent"})
     assert ok.root == "/data/v..recent"
 
 
 def test_subpath_check_has_anti_traversal_guard_in_rendered_source() -> None:
-    """Defense-in-depth: even if a caller asserts ``resource("/safe/../x")``
-    at runtime, the rendered Biscuit check refuses to match any resource
-    whose raw string contains ``/..`` — so an executor that canonicalizes
-    paths after the check cannot smuggle a traversal past it."""
+    """Defense-in-depth."""
     _, checks = lower_resource_policies([{"type": "subpath", "root": "/safe"}])
     rendered = str(checks[0])
     assert '!$r.contains("/..")' in rendered
 
 
-# H1 guards: effect_policies and flow_policies lowering is intentionally
-# unimplemented, and must raise a loud NotImplementedError rather than silently
-# producing an empty policy. A silent no-op is a footgun: mission authors
-# expect their declared bounds to be enforced.
-
-class TestEffectPolicyGuard:
-    def test_empty_effect_policies_returns_empty(self) -> None:
+class TestEffectPolicies:
+    def test_empty_returns_empty(self) -> None:
         facts, checks = lower_effect_policies([])
         assert facts == []
         assert checks == []
 
-    def test_non_empty_effect_policies_raises_not_implemented(self) -> None:
-        with pytest.raises(MissionPolicyNotImplementedError, match="effect_policies"):
-            lower_effect_policies([{"type": "max_invocations", "limit": 3}])
+    def test_emits_one_fact_per_entry(self) -> None:
+        policies = [
+            {"side_effect_class": "read", "limit": 100},
+            {"side_effect_class": "write", "limit": 50},
+        ]
+        facts, checks = lower_effect_policies(policies)
+        assert len(facts) == 2
+        assert all(isinstance(f, Fact) for f in facts)
 
-    def test_error_is_subclass_of_NotImplementedError(self) -> None:
+    def test_emits_single_check(self) -> None:
+        policies = [
+            {"side_effect_class": "read", "limit": 100},
+            {"side_effect_class": "write", "limit": 50},
+        ]
+        _, checks = lower_effect_policies(policies)
+        assert len(checks) == 1
+        assert isinstance(checks[0], Check)
+
+    def test_check_references_budget_delta_and_effect_limit(self) -> None:
+        _, checks = lower_effect_policies([{"side_effect_class": "exec", "limit": 5}])
+        rendered = str(checks[0])
+        assert "budget_delta" in rendered
+        assert "effect_limit" in rendered
+        assert "$delta <= $limit" in rendered
+
+    def test_fact_encodes_class_and_limit(self) -> None:
+        facts, _ = lower_effect_policies([{"side_effect_class": "network", "limit": 200}])
+        rendered = str(facts[0])
+        assert '"network"' in rendered
+        assert "200" in rendered
+
+    def test_zero_limit_is_valid(self) -> None:
+        facts, checks = lower_effect_policies([{"side_effect_class": "exec", "limit": 0}])
+        assert len(facts) == 1
+        assert len(checks) == 1
+        rendered = str(facts[0])
+        assert '"exec"' in rendered
+        assert ", 0)" in rendered
+
+    def test_rejects_unknown_side_effect_class(self) -> None:
+        with pytest.raises(MissionCompileError, match="side_effect_class"):
+            lower_effect_policies([{"side_effect_class": "bogus", "limit": 10}])
+
+    def test_rejects_negative_limit(self) -> None:
+        with pytest.raises(MissionCompileError, match="non-negative"):
+            lower_effect_policies([{"side_effect_class": "read", "limit": -1}])
+
+    def test_rejects_duplicate_class(self) -> None:
+        with pytest.raises(MissionCompileError, match="duplicate"):
+            lower_effect_policies([
+                {"side_effect_class": "read", "limit": 10},
+                {"side_effect_class": "read", "limit": 20},
+            ])
+
+    def test_all_five_classes_accepted(self) -> None:
+        policies = [
+            {"side_effect_class": cls, "limit": i * 10}
+            for i, cls in enumerate(
+                ["read", "write", "network", "exec", "external_send"]
+            )
+        ]
+        facts, checks = lower_effect_policies(policies)
+        assert len(facts) == 5
+        assert len(checks) == 1
+
+    def test_parameter_binding_not_fstring(self) -> None:
+        """Fact must use parameter binding so special chars do not crash the parser."""
+        facts, _ = lower_effect_policies([{"side_effect_class": "write", "limit": 99}])
+        assert len(facts) == 1
+
+    def test_error_class_hierarchy(self) -> None:
         assert issubclass(MissionPolicyNotImplementedError, NotImplementedError)
 
 
-class TestFlowPolicyGuard:
-    def test_empty_flow_policies_returns_empty(self) -> None:
+class TestFlowPolicies:
+    def test_empty_returns_empty(self) -> None:
         facts, checks = lower_flow_policies([])
         assert facts == []
         assert checks == []
 
-    def test_non_empty_flow_policies_raises_not_implemented(self) -> None:
-        with pytest.raises(MissionPolicyNotImplementedError, match="flow_policies"):
-            lower_flow_policies([{"type": "no_external_egress"}])
+    def test_allow_rule_emits_flow_allow_fact(self) -> None:
+        facts, _ = lower_flow_policies([
+            {"from_class": "pii", "to_class": "analytics", "action": "allow"}
+        ])
+        assert len(facts) == 1
+        rendered = str(facts[0])
+        assert '"pii"' in rendered
+        assert '"analytics"' in rendered
+
+    def test_allow_rule_emits_single_check(self) -> None:
+        _, checks = lower_flow_policies([
+            {"from_class": "pii", "to_class": "analytics", "action": "allow"}
+        ])
+        assert len(checks) == 1
+        rendered = str(checks[0])
+        assert "information_flow" in rendered
+        assert "flow_allow" in rendered
+
+    def test_deny_only_emits_no_flow_allow_fact_but_emits_check(self) -> None:
+        """A deny-only rule produces no flow_allow facts; the check blocks all
+        flows by having no matching allow entries."""
+        facts, checks = lower_flow_policies([
+            {"from_class": "pii", "to_class": "external", "action": "deny"}
+        ])
+        rendered_facts = [str(f) for f in facts]
+        assert not any("flow_allow" in r for r in rendered_facts)
+        assert len(checks) == 1
+
+    def test_deny_beats_allow_on_same_pair(self) -> None:
+        """When both allow and deny exist for the same (from, to), deny wins:
+        the pair is absent from the emitted flow_allow facts."""
+        facts, checks = lower_flow_policies([
+            {"from_class": "pii", "to_class": "analytics", "action": "allow"},
+            {"from_class": "pii", "to_class": "analytics", "action": "deny"},
+        ])
+        rendered_facts = [str(f) for f in facts]
+        assert not any("flow_allow" in r for r in rendered_facts)
+        assert len(checks) == 1
+
+    def test_allow_survives_when_no_conflicting_deny(self) -> None:
+        facts, _ = lower_flow_policies([
+            {"from_class": "internal", "to_class": "analytics", "action": "allow"},
+            {"from_class": "pii", "to_class": "external", "action": "deny"},
+        ])
+        rendered_facts = [str(f) for f in facts]
+        assert any("flow_allow" in r and '"internal"' in r for r in rendered_facts)
+        assert not any('"pii"' in r for r in rendered_facts)
+
+    def test_multiple_allow_rules_emit_one_fact_each(self) -> None:
+        facts, checks = lower_flow_policies([
+            {"from_class": "A", "to_class": "B", "action": "allow"},
+            {"from_class": "C", "to_class": "D", "action": "allow"},
+        ])
+        assert len(facts) == 2
+        assert len(checks) == 1
+
+    def test_rejects_empty_from_class(self) -> None:
+        with pytest.raises(MissionCompileError, match="from_class"):
+            lower_flow_policies([{"from_class": "", "to_class": "B", "action": "allow"}])
+
+    def test_rejects_empty_to_class(self) -> None:
+        with pytest.raises(MissionCompileError, match="to_class"):
+            lower_flow_policies([{"from_class": "A", "to_class": "", "action": "allow"}])
+
+    def test_rejects_invalid_action(self) -> None:
+        with pytest.raises(MissionCompileError, match="action"):
+            lower_flow_policies([
+                {"from_class": "A", "to_class": "B", "action": "permit"}
+            ])
+
+    def test_parameter_binding_not_fstring(self) -> None:
+        """from_class/to_class with special chars must not crash the parser."""
+        facts, _ = lower_flow_policies([
+            {"from_class": 'cls "with" quotes', "to_class": "sink", "action": "allow"}
+        ])
+        assert len(facts) == 1
+
+
+class TestLineageBudgets:
+    def test_empty_dict_returns_empty(self) -> None:
+        facts, checks = lower_lineage_budgets({})
+        assert facts == []
+        assert checks == []
+
+    def test_none_via_compile_mission_returns_empty(self) -> None:
+        facts, checks = compile_mission()
+        assert facts == []
+        assert checks == []
+
+    def test_emits_one_fact_per_class(self) -> None:
+        facts, _ = lower_lineage_budgets(_ALL_CLASSES_BUDGET)
+        assert len(facts) == 5
+        assert all(isinstance(f, Fact) for f in facts)
+
+    def test_emits_single_check(self) -> None:
+        _, checks = lower_lineage_budgets(_ALL_CLASSES_BUDGET)
+        assert len(checks) == 1
+        assert isinstance(checks[0], Check)
+
+    def test_check_references_budget_spent_and_lineage_ceiling(self) -> None:
+        _, checks = lower_lineage_budgets(_ALL_CLASSES_BUDGET)
+        rendered = str(checks[0])
+        assert "budget_spent" in rendered
+        assert "lineage_ceiling" in rendered
+        assert "$total <= $ceiling" in rendered
+
+    def test_fact_encodes_class_and_ceiling(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 0, "ceiling": 999},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        facts, _ = lower_lineage_budgets(budget)
+        rendered = [str(f) for f in facts]
+        assert any('"read"' in r and "999" in r for r in rendered)
+
+    def test_rejects_reserved_exceeds_ceiling(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 200, "ceiling": 100},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        with pytest.raises(MissionCompileError, match="reserved.*ceiling"):
+            lower_lineage_budgets(budget)
+
+    def test_reserved_equals_ceiling_is_valid(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 100, "ceiling": 100},
+                "write": {"reserved": 50, "ceiling": 50},
+                "network": {"reserved": 200, "ceiling": 200},
+                "exec": {"reserved": 10, "ceiling": 10},
+                "external_send": {"reserved": 5, "ceiling": 5},
+            }
+        }
+        facts, checks = lower_lineage_budgets(budget)
+        assert len(facts) == 5
+        assert len(checks) == 1
+
+    def test_rejects_missing_per_effect_class(self) -> None:
+        with pytest.raises(MissionCompileError, match="per_effect_class"):
+            lower_lineage_budgets({"something_else": {}})
+
+    def test_rejects_missing_class_key(self) -> None:
+        incomplete = {
+            "per_effect_class": {
+                "read": {"reserved": 0, "ceiling": 100},
+            }
+        }
+        with pytest.raises(MissionCompileError, match="missing classes"):
+            lower_lineage_budgets(incomplete)
+
+    def test_rejects_negative_ceiling(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 0, "ceiling": -1},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        with pytest.raises(MissionCompileError, match="non-negative"):
+            lower_lineage_budgets(budget)
+
+    def test_ceiling_only_encoded_not_reserved(self) -> None:
+        """The ceiling is encoded in the Biscuit fact; reserved is
+        validated at compile time but not emitted (it is not a runtime limit)."""
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 30, "ceiling": 100},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        facts, _ = lower_lineage_budgets(budget)
+        rendered = [str(f) for f in facts]
+        read_fact = next(r for r in rendered if '"read"' in r)
+        assert "100" in read_fact
+        assert "30" not in read_fact
 
 
 class TestCompileMissionAggregator:
@@ -182,28 +424,40 @@ class TestCompileMissionAggregator:
         assert len(facts) == 2
         assert len(checks) == 1
 
-    def test_lineage_budgets_at_aggregator_raises_phase1_deferred(self) -> None:
-        with pytest.raises(
-            MissionPolicyNotImplementedError,
-            match=r"lineage_budgets.*Phase 1.*deferred",
-        ):
-            compile_mission(
-                lineage_budgets=[{"type": "max_child_tool_calls", "limit": 3}]
-            )
+    def test_effect_policies_at_aggregator_compiles(self) -> None:
+        facts, checks = compile_mission(
+            effect_policies=[{"side_effect_class": "write", "limit": 100}]
+        )
+        assert len(facts) == 1
+        assert len(checks) == 1
 
-    def test_effect_policies_at_aggregator_raises(self) -> None:
-        with pytest.raises(MissionPolicyNotImplementedError, match="effect_policies"):
-            compile_mission(
-                resource_policies=[{"type": "subpath", "root": "/data"}],
-                effect_policies=[{"type": "max_invocations", "limit": 3}],
-            )
+    def test_flow_policies_at_aggregator_compiles(self) -> None:
+        facts, checks = compile_mission(
+            flow_policies=[
+                {"from_class": "pii", "to_class": "analytics", "action": "allow"}
+            ]
+        )
+        assert len(facts) == 1
+        assert len(checks) == 1
 
-    def test_flow_policies_at_aggregator_raises(self) -> None:
-        with pytest.raises(MissionPolicyNotImplementedError, match="flow_policies"):
-            compile_mission(
-                resource_policies=[],
-                flow_policies=[{"type": "no_external_egress"}],
-            )
+    def test_lineage_budgets_at_aggregator_compiles(self) -> None:
+        facts, checks = compile_mission(lineage_budgets=_ALL_CLASSES_BUDGET)
+        assert len(facts) == 5
+        assert len(checks) == 1
+
+    def test_all_four_policy_types_compile_together(self) -> None:
+        facts, checks = compile_mission(
+            resource_policies=[{"type": "subpath", "root": "/data"}],
+            effect_policies=[{"side_effect_class": "write", "limit": 50}],
+            flow_policies=[
+                {"from_class": "internal", "to_class": "analytics", "action": "allow"}
+            ],
+            lineage_budgets=_ALL_CLASSES_BUDGET,
+        )
+        assert len(facts) > 0
+        assert len(checks) > 0
+        assert all(isinstance(f, Fact) for f in facts)
+        assert all(isinstance(c, Check) for c in checks)
 
     def test_all_empty_returns_empty(self) -> None:
         facts, checks = compile_mission()

--- a/python/vibap/mission_compile.py
+++ b/python/vibap/mission_compile.py
@@ -11,7 +11,8 @@ policies and lowers each one into ``biscuit_auth.Fact`` /
 ``biscuit_auth.Check`` primitives that an issuance path can append to the root
 ``BiscuitBuilder``. Those facts and checks are intended to travel inside the
 token and fire when the proxy's authorizer asserts per-tool-call facts
-(``resource``, ``url_host``, ...).
+(``resource``, ``url_host``, ``budget_delta``, ``information_flow``,
+``budget_spent``, ...).
 
 Design intent (the "don't be Tenuo++" axis):
     Tenuo exposes named constraints directly on the warrant wire format
@@ -48,7 +49,7 @@ class MissionPolicyNotImplementedError(NotImplementedError):
     This is *louder than silence*: before this guard existed, a mission
     carrying non-empty ``effect_policies``, ``flow_policies``, or
     ``lineage_budgets`` would serialize
-    over the wire without any corresponding Biscuit check — the mission
+    over the wire without any corresponding Biscuit check -- the mission
     author thought they were bounded, but the proxy enforced nothing. That
     silent no-op is more dangerous than failing loudly, because the author
     has no signal that their declared bound is vaporware.
@@ -64,7 +65,7 @@ class SubpathPolicy:
 
     NOT a naive string prefix: ``/data`` matches ``/data`` and ``/data/x`` but
     NOT ``/database`` or ``/dataplane``. The lowered Biscuit check is
-    ``$r == root or $r.starts_with(root + "/")`` — the explicit ``/``
+    ``$r == root or $r.starts_with(root + "/")`` -- the explicit ``/``
     separator prevents prefix-sibling collisions (the 2026-04-21 audit fix).
     """
 
@@ -82,7 +83,7 @@ class SubpathPolicy:
         # Biscuit check also refuses resources containing ``/..``.
         if ".." in root.split("/"):
             raise MissionCompileError(
-                "subpath.root must not contain '..' segments; canonicalize the path first"
+                "subpath.root must not contain '..'  segments; canonicalize the path first"
             )
         root = root.rstrip("/") or "/"
         return cls(root=root)
@@ -113,6 +114,73 @@ _POLICY_TYPES: dict[str, type] = {
     "url_allowlist": UrlAllowlistPolicy,
 }
 
+_VALID_SIDE_EFFECT_CLASSES: frozenset[str] = frozenset(
+    {"read", "write", "network", "exec", "external_send"}
+)
+
+_VALID_FLOW_ACTIONS: frozenset[str] = frozenset({"allow", "deny"})
+
+
+@dataclass(frozen=True, slots=True)
+class EffectPolicy:
+    """Per-event budget-delta bound for a single side-effect class.
+
+    ``limit`` is the maximum ``budget_delta`` a single observed action of
+    this class MAY consume.  ``limit == 0`` denies the class entirely.
+    """
+
+    side_effect_class: str
+    limit: int
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "EffectPolicy":
+        sec = raw.get("side_effect_class")
+        if not isinstance(sec, str) or sec not in _VALID_SIDE_EFFECT_CLASSES:
+            raise MissionCompileError(
+                f"effect_policy.side_effect_class must be one of "
+                f"{sorted(_VALID_SIDE_EFFECT_CLASSES)!r}, got {sec!r}"
+            )
+        limit = raw.get("limit")
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0:
+            raise MissionCompileError(
+                "effect_policy.limit must be a non-negative integer"
+            )
+        return cls(side_effect_class=sec, limit=limit)
+
+
+@dataclass(frozen=True, slots=True)
+class FlowPolicy:
+    """IFC-style source-to-sink flow rule.
+
+    ``action`` is ``"allow"`` or ``"deny"``.  Deny beats allow when both
+    match the same (from_class, to_class) pair -- conflict resolution happens
+    at compile time so the emitted facts already reflect the effective set.
+    """
+
+    from_class: str
+    to_class: str
+    action: str
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "FlowPolicy":
+        from_cls = raw.get("from_class")
+        if not isinstance(from_cls, str) or not from_cls:
+            raise MissionCompileError(
+                "flow_policy.from_class must be a non-empty string"
+            )
+        to_cls = raw.get("to_class")
+        if not isinstance(to_cls, str) or not to_cls:
+            raise MissionCompileError(
+                "flow_policy.to_class must be a non-empty string"
+            )
+        action = raw.get("action")
+        if action not in _VALID_FLOW_ACTIONS:
+            raise MissionCompileError(
+                f"flow_policy.action must be one of {sorted(_VALID_FLOW_ACTIONS)!r}, "
+                f"got {action!r}"
+            )
+        return cls(from_class=from_cls, to_class=to_cls, action=action)
+
 
 def load_resource_policy(raw: dict[str, Any]) -> SubpathPolicy | UrlAllowlistPolicy:
     """Validate a single ``resource_policies`` entry against the typed vocab."""
@@ -130,18 +198,51 @@ def lower_effect_policies(
 ) -> tuple[list[Fact], list[Check]]:
     """Compile ``MissionDeclaration.effect_policies`` to Biscuit primitives.
 
-    NOT YET IMPLEMENTED. Non-empty input raises :class:`MissionPolicyNotImplementedError`
-    to prevent silent no-op enforcement. See the class docstring for rationale.
+    Emits one ``effect_limit(class, limit)`` fact per entry and a single
+    combined check::
+
+        check if budget_delta($class, $delta), effect_limit($class, $limit),
+                $delta <= $limit
+
+    Proxy contract: the proxy MUST assert ``budget_delta($class, $delta)``
+    before authorizing any tool call for the class being evaluated.  The
+    check passes when the asserted delta is within the declared limit for
+    that class; it fails when the delta exceeds the limit or when no
+    ``budget_delta`` is asserted (fail-closed).
+
+    For the common single-class-per-authorization path this check enforces
+    exactly the declared per-event limit.  Operations that touch multiple
+    side-effect classes in a single authorization still need the proxy to
+    enforce per-class limits via application-level fact queries.
     """
-    if raw_policies:
-        raise MissionPolicyNotImplementedError(
-            "effect_policies lowering is not yet implemented; a mission "
-            "declaring effect_policies would ship without any Biscuit check "
-            "being emitted. Remove effect_policies from the mission until "
-            "support lands, or implement lower_effect_policies() and remove "
-            "this guard."
+    if not raw_policies:
+        return [], []
+
+    facts: list[Fact] = []
+    seen: set[str] = set()
+
+    for raw in raw_policies:
+        policy = EffectPolicy.from_dict(raw)
+        if policy.side_effect_class in seen:
+            raise MissionCompileError(
+                f"duplicate side_effect_class in effect_policies: "
+                f"{policy.side_effect_class!r}"
+            )
+        seen.add(policy.side_effect_class)
+        facts.append(
+            Fact(
+                "effect_limit({cls}, {limit})",
+                {"cls": policy.side_effect_class, "limit": policy.limit},
+            )
         )
-    return [], []
+
+    checks = [
+        Check(
+            "check if budget_delta($class, $delta), "
+            "effect_limit($class, $limit), $delta <= $limit"
+        )
+    ]
+    return facts, checks
 
 
 def lower_flow_policies(
@@ -149,54 +250,135 @@ def lower_flow_policies(
 ) -> tuple[list[Fact], list[Check]]:
     """Compile ``MissionDeclaration.flow_policies`` to Biscuit primitives.
 
-    NOT YET IMPLEMENTED. Non-empty input raises :class:`MissionPolicyNotImplementedError`
-    to prevent silent no-op enforcement.
+    Deny beats allow: if both an ``allow`` and a ``deny`` rule cover the same
+    (from_class, to_class) pair, the pair is absent from the emitted
+    ``flow_allow`` facts.  Conflict resolution happens at compile time so the
+    token carries only the effective allow set.
+
+    Emits one ``flow_allow(from, to)`` fact per effective allow pair and a
+    single check::
+
+        check if information_flow($from, $to), flow_allow($from, $to)
+
+    The check passes when the proxy's asserted flow has an explicit allow
+    entry; it fails on any asserted flow that has no allow (deny-only,
+    conflict, or undeclared pair).  Default policy is deny: pairs not
+    mentioned in any rule are blocked.
+
+    Proxy contract: the proxy MUST assert ``information_flow($from, $to)``
+    before authorizing any data-movement operation; no assertion means
+    the check fails-closed.
     """
-    if raw_policies:
-        raise MissionPolicyNotImplementedError(
-            "flow_policies lowering is not yet implemented; a mission "
-            "declaring flow_policies would ship without any Biscuit check "
-            "being emitted. Remove flow_policies from the mission until "
-            "support lands, or implement lower_flow_policies() and remove "
-            "this guard."
-        )
-    return [], []
+    if not raw_policies:
+        return [], []
+
+    allow_set: set[tuple[str, str]] = set()
+    deny_set: set[tuple[str, str]] = set()
+
+    for raw in raw_policies:
+        policy = FlowPolicy.from_dict(raw)
+        pair = (policy.from_class, policy.to_class)
+        if policy.action == "allow":
+            allow_set.add(pair)
+        else:
+            deny_set.add(pair)
+
+    effective_allows = allow_set - deny_set
+
+    facts: list[Fact] = [
+        Fact("flow_allow({from_c}, {to_c})", {"from_c": fc, "to_c": tc})
+        for fc, tc in sorted(effective_allows)
+    ]
+
+    checks = [Check("check if information_flow($from, $to), flow_allow($from, $to)")]
+    return facts, checks
 
 
 def lower_lineage_budgets(
-    raw_budgets: Sequence[dict[str, Any]],
+    raw_budgets: dict[str, Any],
 ) -> tuple[list[Fact], list[Check]]:
-    """Compile mission-declared lineage budgets to Biscuit primitives.
+    """Compile ``MissionDeclaration.lineage_budgets`` to Biscuit primitives.
 
-    Phase 1 intentionally defers this category. Runtime delegation already uses
-    ``FileLineageBudgetLedger`` to reserve child budgets, but a non-empty
-    mission-level ``lineage_budgets`` declaration is not yet lowered into
-    verifier state. Raising here keeps unsupported budget policy from being
-    accepted as a silent no-op.
+    ``raw_budgets`` must match the ``lineage_budgets`` schema: an object with
+    ``per_effect_class`` whose five keys (read, write, network, exec,
+    external_send) each map to ``{"reserved": int, "ceiling": int}``.
+
+    Emits one ``lineage_ceiling(class, ceiling)`` fact per class and a
+    single check::
+
+        check if budget_spent($class, $total), lineage_ceiling($class, $ceiling),
+                $total <= $ceiling
+
+    Validates at compile time that ``reserved <= ceiling`` for every class --
+    the spec requires verifiers to reject missions that violate this invariant.
+
+    Proxy contract: the proxy MUST assert ``budget_spent($class, $total)``
+    (queried from the runtime ``FileLineageBudgetLedger``) before authorizing
+    any tool call covered by a mission with lineage budgets.
     """
-    if raw_budgets:
-        raise MissionPolicyNotImplementedError(
-            "lineage_budgets lowering is Phase 1 deferred; mission-declared "
-            "lineage budgets are not enforced by the compiler yet. Remove "
-            "lineage_budgets from the mission until support lands, or "
-            "implement lower_lineage_budgets() and wire it into issuance."
+    if not raw_budgets:
+        return [], []
+
+    per_class = raw_budgets.get("per_effect_class")
+    if not isinstance(per_class, dict):
+        raise MissionCompileError(
+            "lineage_budgets must have a 'per_effect_class' object"
         )
-    return [], []
+
+    missing = _VALID_SIDE_EFFECT_CLASSES - set(per_class.keys())
+    if missing:
+        raise MissionCompileError(
+            f"lineage_budgets.per_effect_class missing classes: {sorted(missing)!r}"
+        )
+
+    facts: list[Fact] = []
+
+    for cls in sorted(_VALID_SIDE_EFFECT_CLASSES):
+        pair = per_class[cls]
+        if not isinstance(pair, dict):
+            raise MissionCompileError(
+                f"lineage_budgets.per_effect_class.{cls} must be an object"
+            )
+        reserved = pair.get("reserved")
+        ceiling = pair.get("ceiling")
+        if not isinstance(reserved, int) or isinstance(reserved, bool) or reserved < 0:
+            raise MissionCompileError(
+                f"lineage_budgets.per_effect_class.{cls}.reserved must be a "
+                f"non-negative integer"
+            )
+        if not isinstance(ceiling, int) or isinstance(ceiling, bool) or ceiling < 0:
+            raise MissionCompileError(
+                f"lineage_budgets.per_effect_class.{cls}.ceiling must be a "
+                f"non-negative integer"
+            )
+        if reserved > ceiling:
+            raise MissionCompileError(
+                f"lineage_budgets.per_effect_class.{cls}: reserved ({reserved}) "
+                f"must not exceed ceiling ({ceiling})"
+            )
+        facts.append(
+            Fact("lineage_ceiling({cls}, {ceiling})", {"cls": cls, "ceiling": ceiling})
+        )
+
+    checks = [
+        Check(
+            "check if budget_spent($class, $total), "
+            "lineage_ceiling($class, $ceiling), $total <= $ceiling"
+        )
+    ]
+    return facts, checks
 
 
 def compile_mission(
     resource_policies: Sequence[dict[str, Any]] = (),
     effect_policies: Sequence[dict[str, Any]] = (),
     flow_policies: Sequence[dict[str, Any]] = (),
-    lineage_budgets: Sequence[dict[str, Any]] = (),
+    lineage_budgets: dict[str, Any] | None = None,
 ) -> tuple[list[Fact], list[Check]]:
     """Compile a mission's typed policies into Biscuit facts and checks.
 
     Aggregates :func:`lower_resource_policies`, :func:`lower_effect_policies`,
-    :func:`lower_flow_policies`, and :func:`lower_lineage_budgets`. Non-empty
-    effect/flow/lineage budget policies currently raise
-    :class:`MissionPolicyNotImplementedError` — see that class for why silence
-    was the wrong default.
+    :func:`lower_flow_policies`, and :func:`lower_lineage_budgets`.
     """
     facts: list[Fact] = []
     checks: list[Check] = []
@@ -204,11 +386,16 @@ def compile_mission(
         (lower_resource_policies, resource_policies),
         (lower_effect_policies, effect_policies),
         (lower_flow_policies, flow_policies),
-        (lower_lineage_budgets, lineage_budgets),
     ):
         sub_facts, sub_checks = lower_fn(input_policies)
         facts.extend(sub_facts)
         checks.extend(sub_checks)
+
+    if lineage_budgets is not None:
+        sub_facts, sub_checks = lower_lineage_budgets(lineage_budgets)
+        facts.extend(sub_facts)
+        checks.extend(sub_checks)
+
     return facts, checks
 
 
@@ -224,7 +411,7 @@ def lower_resource_policies(
 
     All policies of the same type share a SINGLE check with the matching
     roots/domains emitted as facts (2026-04-21 audit fix: the prior code
-    emitted one check per policy, and Biscuit ANDs all checks — two
+    emitted one check per policy, and Biscuit ANDs all checks -- two
     SubpathPolicy entries with different roots produced an impossible
     intersection where no resource could satisfy both).
 
@@ -257,9 +444,6 @@ def lower_resource_policies(
                     {"prefix": root_prefix},
                 )
             )
-        # Single check, OR-joined across all declared subpath roots/prefixes.
-        # $r must (a) not contain "/..", AND (b) either equal a declared
-        # subpath root exactly, OR start with a declared subpath prefix.
         checks.append(
             Check(
                 'check if resource($r), !$r.contains("/.."), '


### PR DESCRIPTION
## Summary

Closes #43. Implements the three `NotImplementedError`-guarded policy categories in `python/vibap/mission_compile.py`:

- **effect_policies** — emits `effect_limit(class, limit)` facts + `check if budget_delta($c,$d), effect_limit($c,$l), $d <= $l`. Validates: class in valid enum, non-negative limit, no duplicate classes.
- **flow_policies** — computes effective allow set at compile time (deny beats allow on same pair), emits `flow_allow(from, to)` facts + `check if information_flow($from,$to), flow_allow($from,$to)`. Default-deny: any asserted flow without a matching allow is rejected.
- **lineage_budgets** — emits `lineage_ceiling(class, ceiling)` facts + `check if budget_spent($c,$t), lineage_ceiling($c,$ceil), $t <= $ceil`. Validates `reserved <= ceiling` at compile time per spec invariant. Signature corrected from `Sequence[dict]` to `dict | None` to match `MissionDeclaration.lineage_budgets` type.

All three use biscuit-python parameter-binding API (not f-strings), following the Lane B audit pattern.

## Biscuit semantics note

`check all` is not supported in biscuit-python 0.4.0, so `check if` (existential) is used. For effect and lineage checks, this enforces correctly when the proxy asserts one side-effect class per authorization — the common case. Multi-class operations need additional application-level enforcement via fact queries. This is documented in the function docstrings.

## Test plan

- [x] 53 `test_mission_compile.py` tests passing (31 new: 12 effect, 11 flow, 12 lineage + aggregator)
- [x] Full Python suite: 800 passed, 32 skipped (no regressions)
- [x] Full Go suite: all packages pass