### PR TITLE
feat(run): zero-setup governance bridge for launched agents (Epic A)

### DIFF
--- a/python/tests/test_kernel_correlation.py
+++ b/python/tests/test_kernel_correlation.py
@@ -1,0 +1,202 @@
+"""Unit tests for the kernelcapture daemon client + cgroup helpers.
+
+These run on any platform: the cgroup helpers are parameterized by a root
+directory (env ``ARDUR_RUN_CGROUP_ROOT``) so a temp dir stands in for
+``/sys/fs/cgroup``, and the daemon client speaks AF_UNIX which works on macOS
+and Linux alike.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from vibap import kernel_correlation as kc
+
+
+@pytest.fixture
+def sockdir():
+    """A short-pathed temp dir for AF_UNIX sockets.
+
+    AF_UNIX paths are capped (104 bytes on macOS, 108 on Linux); the deep
+    pytest ``tmp_path`` blows past that on macOS, so bind sockets under /tmp.
+    """
+    path = Path(tempfile.mkdtemp(dir="/tmp"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+# ── cgroup helpers ─────────────────────────────────────────────────────────────
+
+
+def _fake_cgroup_root(base: Path, *, unified: bool) -> Path:
+    root = base / "cgroup"
+    root.mkdir(parents=True, exist_ok=True)
+    if unified:
+        (root / "cgroup.controllers").write_text("cpu memory\n", encoding="utf-8")
+    return root
+
+
+def test_cgroup_v2_available_requires_controllers_file(tmp_path: Path) -> None:
+    unified = _fake_cgroup_root(tmp_path / "a", unified=True)
+    legacy = _fake_cgroup_root(tmp_path / "b", unified=False)
+    assert kc.cgroup_v2_available(unified) is True
+    assert kc.cgroup_v2_available(legacy) is False
+
+
+def test_create_run_cgroup_returns_handle_with_inode_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _fake_cgroup_root(tmp_path, unified=True)
+    monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(root))
+
+    handle = kc.create_run_cgroup("sess-abc/123")
+    assert handle is not None
+    assert handle.path.is_dir()
+    # cgroup id == inode of the cgroup directory (what bpf_get_current_cgroup_id returns)
+    assert handle.cgroup_id == os.stat(handle.path).st_ino
+
+    handle.adopt_pid(4242)
+    assert (handle.path / "cgroup.procs").read_text().strip() == "4242"
+
+
+def test_cleanup_removes_empty_cgroup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _fake_cgroup_root(tmp_path, unified=True)
+    monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(root))
+    handle = kc.create_run_cgroup("empty")
+    assert handle is not None
+    # On real cgroupfs the only entries are virtual files that rmdir ignores; an
+    # empty cgroup dir on a normal FS is removed cleanly. cleanup never raises.
+    handle.cleanup()
+    assert not handle.path.exists()
+
+
+def test_create_run_cgroup_none_when_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy = _fake_cgroup_root(tmp_path, unified=False)
+    monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(legacy))
+    assert kc.create_run_cgroup("sess") is None
+
+
+# ── daemon client ──────────────────────────────────────────────────────────────
+
+
+class _FakeDaemon:
+    """A one-shot AF_UNIX server that replays canned JSON-line responses."""
+
+    def __init__(self, socket_path: Path, response: dict) -> None:
+        self.socket_path = socket_path
+        self.response = response
+        self.received: dict | None = None
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(socket_path))
+        self._server.listen(1)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._server.accept()
+        except OSError:
+            return
+        with conn:
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            line = buf.split(b"\n", 1)[0]
+            try:
+                self.received = json.loads(line.decode("utf-8"))
+            except ValueError:
+                self.received = None
+            conn.sendall(json.dumps(self.response).encode("utf-8") + b"\n")
+
+    def close(self) -> None:
+        self._server.close()
+
+
+def test_register_session_roundtrip(sockdir: Path) -> None:
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": True,
+            "method": "register_session",
+            "session_id": "sess-1",
+            "status": "registered",
+        },
+    )
+    daemon.start()
+    try:
+        client = kc.KernelCaptureClient(sock)
+        resp = client.register_session(
+            session_id="sess-1",
+            root_pid=1234,
+            cgroup_id=99887766,
+            ttl_seconds=3600,
+            mission_id="mission-1",
+            trace_id="trace-1",
+        )
+    finally:
+        daemon.close()
+
+    assert resp["status"] == "registered"
+    assert daemon.received is not None
+    assert daemon.received["method"] == "register_session"
+    payload = daemon.received["register_session"]
+    assert payload["session_id"] == "sess-1"
+    assert payload["root_pid"] == 1234
+    assert payload["cgroup_id"] == 99887766
+    assert payload["event_classes"] == [kc.EVENT_CLASS_PROCESS_LIFECYCLE]
+    assert payload["ttl_seconds"] == 3600
+
+
+def test_client_raises_on_daemon_error(sockdir: Path) -> None:
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": False,
+            "method": "register_session",
+            "error": "cgroup_id is required",
+        },
+    )
+    daemon.start()
+    try:
+        client = kc.KernelCaptureClient(sock)
+        with pytest.raises(kc.DaemonProtocolError, match="cgroup_id is required"):
+            client.register_session(session_id="s", root_pid=1, cgroup_id=1, ttl_seconds=60)
+    finally:
+        daemon.close()
+
+
+def test_client_raises_unavailable_when_socket_missing(sockdir: Path) -> None:
+    client = kc.KernelCaptureClient(sockdir / "absent.sock")
+    with pytest.raises(kc.DaemonUnavailable):
+        client.health()
+
+
+def test_daemon_available_false_for_missing_socket(tmp_path: Path) -> None:
+    assert kc.daemon_available(tmp_path / "nope.sock") is False
+
+
+def test_register_session_validates_inputs(tmp_path: Path) -> None:
+    client = kc.KernelCaptureClient(tmp_path / "x.sock")
+    with pytest.raises(ValueError):
+        client.register_session(session_id="", root_pid=1, cgroup_id=1, ttl_seconds=60)
+    with pytest.raises(ValueError):
+        client.register_session(session_id="s", root_pid=0, cgroup_id=1, ttl_seconds=60)
+    with pytest.raises(ValueError):
+        client.register_session(session_id="s", root_pid=1, cgroup_id=0, ttl_seconds=60)

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -241,6 +241,41 @@ def test_transparent_intercept_is_scaffold_only(tmp_path: Path) -> None:
 # ── CLI dispatch ───────────────────────────────────────────────────────────────
 
 
+def test_claude_adapter_proxy_receives_zero_events_when_hook_governs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Document the hook↔proxy receipt gap on the claude-code path.
+
+    ClaudeCodeAdapter inherits ARDUR_PROXY_URL from EnvProxyAdapter but the
+    Claude Code hook evaluates tool calls locally via the plugin — it never
+    POSTs to /evaluate.  Even when real tool calls are made through the hook,
+    the embedded proxy's event counter stays at 0.  This test verifies the
+    current (known-incomplete) behaviour with a noop subprocess so that any
+    future change that wires the hook to also POST to /evaluate will cause an
+    assertion failure here, prompting an update to expect total_events > 0.
+    See: run_bridge.ClaudeCodeAdapter docstring and Epic A (#63).
+    """
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    home = tmp_path / "cc-home"
+    noop = tmp_path / "noop.py"
+    noop.write_text("import sys; sys.exit(0)", encoding="utf-8")
+
+    result = run_governed(
+        command=[sys.executable, str(noop)],
+        mission="ClaudeCode hook path: proxy gets 0 events.",
+        allowed_tools=["Read"],
+        home=home,
+        via="claude-code",
+    )
+    assert result.adapter == "claude-code"
+    # The subprocess made no calls to ARDUR_PROXY_URL/evaluate.
+    # Even for a real `claude` subprocess governed via the hook, calls are
+    # evaluated locally by the hook — the proxy never sees them.
+    assert result.total_events == 0
+    # An attestation is still issued (it covers the session, not only proxy hits).
+    assert result.attestation_token
+
+
 def test_run_dispatch_legacy_vs_governance() -> None:
     """`ardur run` stays on the legacy hub path until a governance flag appears."""
     from vibap.cli import _run_has_governance_intent, build_parser

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -1,0 +1,259 @@
+"""Integration + unit tests for the ``ardur run`` governance bridge.
+
+The headline test (:func:`test_ardur_run_governs_launched_agent_zero_setup`)
+proves the bridge's contract end to end: ``ardur run`` of a stand-in agent that
+makes a PERMIT-able and a DENY-able tool call results in a started session,
+evaluated calls, a verifiable signed receipt chain, and a verifiable behavioral
+attestation — with **zero** manual ``ardur protect`` setup and no edit to the
+user's ``~/.claude/settings.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from vibap import kernel_correlation as kc
+from vibap.attestation import verify_attestation
+from vibap.passport import load_public_key
+from vibap.receipt import verify_chain
+from vibap.run_bridge import (
+    ClaudeCodeAdapter,
+    EnvProxyAdapter,
+    RunContext,
+    TransparentInterceptAdapter,
+    run_governed,
+    select_adapter,
+)
+
+# A self-contained stand-in agent. It speaks the documented env contract
+# (ARDUR_PROXY_URL / ARDUR_API_TOKEN / ARDUR_SESSION_ID) and routes three tool
+# calls through the governance proxy: one PERMIT-able (Read), one DENY-able
+# (Bash, which the mission forbids), one PERMIT-able (Glob).
+STANDIN_AGENT = '''\
+import json, os, sys, urllib.request
+
+proxy = os.environ["ARDUR_PROXY_URL"]
+token = os.environ["ARDUR_API_TOKEN"]
+session = os.environ["ARDUR_SESSION_ID"]
+
+
+def evaluate(tool, args):
+    body = json.dumps({"session_id": session, "tool_name": tool, "arguments": args}).encode()
+    req = urllib.request.Request(
+        proxy + "/evaluate", data=body, method="POST",
+        headers={"Authorization": "Bearer " + token, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as r:
+        return json.loads(r.read())
+
+
+decisions = {}
+for tool, args in [
+    ("Read", {"file_path": "README.md"}),
+    ("Bash", {"command": "rm -rf /"}),
+    ("Glob", {"pattern": "*.py"}),
+]:
+    decisions[tool] = evaluate(tool, args)["decision"]
+
+sys.stdout.write(json.dumps(decisions))
+'''
+
+
+@pytest.fixture
+def standin_agent(tmp_path: Path) -> Path:
+    path = tmp_path / "standin_agent.py"
+    path.write_text(STANDIN_AGENT, encoding="utf-8")
+    return path
+
+
+def _hermetic_kernel_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Force kernel correlation to degrade deterministically on any platform.
+
+    Points the cgroup root at a directory with no ``cgroup.controllers`` (so
+    cgroup v2 looks unavailable) and the daemon socket at a path that does not
+    exist — so the bridge takes its graceful-degradation path without touching
+    the host's real ``/sys/fs/cgroup`` or any live daemon.
+    """
+    fake_cgroup_root = tmp_path / "fake-cgroup"
+    fake_cgroup_root.mkdir()
+    monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(fake_cgroup_root))
+    monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(tmp_path / "no-such-daemon.sock"))
+
+
+def test_ardur_run_governs_launched_agent_zero_setup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path
+) -> None:
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    home = tmp_path / "ardur-home"
+
+    result = run_governed(
+        command=[sys.executable, str(standin_agent)],
+        mission="Integration: govern a launched stand-in agent.",
+        allowed_tools=["Read", "Glob", "Grep"],
+        forbidden_tools=["Bash"],
+        max_tool_calls=10,
+        home=home,
+        via="env",
+    )
+
+    # — a session started —
+    assert result.session_id
+    assert result.mission_id
+    assert result.exit_code == 0
+    assert result.adapter == "env-proxy"
+
+    # — calls were evaluated (PERMIT + DENY) —
+    assert result.total_events == 3
+    assert result.permits == 2
+    assert result.denials == 1
+
+    # — a signed receipt chain was produced and verifies cryptographically —
+    public_key = load_public_key(keys_dir=home / "keys")
+    receipts_path = Path(result.receipts_path)
+    assert receipts_path.is_file()
+    entries = [json.loads(line) for line in receipts_path.read_text().splitlines() if line.strip()]
+    assert len(entries) == 3
+    verified = verify_chain(entries, public_key)
+    assert len(verified) == 3
+    verdicts = [c.get("verdict") for c in verified]
+    # Signed receipts record a compliant (PERMIT) and a violation (DENY) verdict.
+    assert "compliant" in verdicts
+    assert "violation" in verdicts
+
+    # — a behavioral attestation was issued and verifies —
+    assert result.attestation_token
+    assert result.attestation_digest.startswith("sha-256:")
+    att = verify_attestation(result.attestation_token, public_key)
+    assert att["passport_jti"] == result.session_id
+    assert int(att["permits"]) == 2
+    assert int(att["denials"]) == 1
+
+    # — ZERO manual ardur protect: governance ran from an isolated ephemeral
+    #   home with its own passport; nothing was written to ~/.claude/settings.json —
+    assert (home / "active_mission.jwt").is_file()
+    assert not (home / "settings.json").exists()
+
+    # — kernel correlation degraded gracefully (no daemon on the test host) —
+    assert result.correlation["available"] is False
+    assert "governing via env/hook" in result.correlation["reason"]
+
+
+def test_ardur_run_denies_when_no_tools_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path
+) -> None:
+    """A mission with an empty allowlist denies every call but still attests."""
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    home = tmp_path / "deny-home"
+
+    result = run_governed(
+        command=[sys.executable, str(standin_agent)],
+        mission="Deny everything.",
+        allowed_tools=[],
+        forbidden_tools=["Bash"],
+        max_tool_calls=10,
+        home=home,
+        via="env",
+    )
+    assert result.total_events == 3
+    assert result.denials >= 1
+    assert result.receipt_count == 3
+    assert result.attestation_token
+
+
+def test_run_governed_rejects_empty_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="requires a command"):
+        run_governed(command=[], mission="x", home=tmp_path / "h")
+
+
+def test_run_governed_rejects_unknown_via(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="unknown --via"):
+        run_governed(command=["true"], via="bogus", home=tmp_path / "h")
+
+
+# ── adapter unit tests ─────────────────────────────────────────────────────────
+
+
+def _ctx(tmp_path: Path, plugin_dir: Path | None = None) -> RunContext:
+    return RunContext(
+        home=tmp_path,
+        passport_token="tok",
+        passport_path=tmp_path / "active_mission.jwt",
+        session_id="sess-1",
+        mission_id="mission-1",
+        trace_id="sess-1",
+        proxy_url="http://127.0.0.1:9",
+        api_token="api-tok",
+        plugin_dir=plugin_dir,
+    )
+
+
+def test_select_adapter_routes_by_mode_and_autodetect() -> None:
+    assert isinstance(select_adapter(["python", "agent.py"], "env"), EnvProxyAdapter)
+    assert isinstance(select_adapter(["claude"], "auto"), ClaudeCodeAdapter)
+    assert isinstance(select_adapter(["/usr/bin/claude"], "auto"), ClaudeCodeAdapter)
+    assert isinstance(select_adapter(["grok"], "auto"), EnvProxyAdapter)
+    assert isinstance(select_adapter(["x"], "intercept"), TransparentInterceptAdapter)
+
+
+def test_env_adapter_exports_governance_contract(tmp_path: Path) -> None:
+    env, command, notes = EnvProxyAdapter().prepare(_ctx(tmp_path), ["python", "a.py"], {})
+    assert env["ARDUR_PROXY_URL"] == "http://127.0.0.1:9"
+    assert env["ARDUR_API_TOKEN"] == "api-tok"
+    assert env["ARDUR_SESSION_ID"] == "sess-1"
+    assert env["VIBAP_HOME"] == str(tmp_path)
+    assert env["ARDUR_MISSION_PASSPORT"] == str(tmp_path / "active_mission.jwt")
+    assert command == ["python", "a.py"]
+    assert notes
+
+
+def test_claude_adapter_injects_plugin_dir_scoped(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins" / "claude-code"
+    plugin_dir.mkdir(parents=True)
+    env, command, notes = ClaudeCodeAdapter().prepare(
+        _ctx(tmp_path, plugin_dir=plugin_dir), ["claude", "-p", "do work"], {}
+    )
+    assert command == ["claude", "--plugin-dir", str(plugin_dir), "-p", "do work"]
+    # The hook is pointed at this run via env, not a settings.json edit.
+    assert env["VIBAP_HOME"] == str(tmp_path)
+    assert any("no settings.json edit" in note for note in notes)
+
+
+def test_claude_adapter_does_not_double_inject_plugin_dir(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "p"
+    plugin_dir.mkdir()
+    _env, command, _notes = ClaudeCodeAdapter().prepare(
+        _ctx(tmp_path, plugin_dir=plugin_dir), ["claude", "--plugin-dir", "/other"], {}
+    )
+    assert command == ["claude", "--plugin-dir", "/other"]
+
+
+def test_transparent_intercept_is_scaffold_only(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="scaffolded only"):
+        TransparentInterceptAdapter().prepare(_ctx(tmp_path), ["grok"], {})
+
+
+# ── CLI dispatch ───────────────────────────────────────────────────────────────
+
+
+def test_run_dispatch_legacy_vs_governance() -> None:
+    """`ardur run` stays on the legacy hub path until a governance flag appears."""
+    from vibap.cli import _run_has_governance_intent, build_parser
+
+    parser = build_parser()
+    legacy = parser.parse_args(["run", "--", "echo", "hi"])
+    assert _run_has_governance_intent(legacy) is False
+
+    for argv in (
+        ["run", "--mission", "x", "--", "echo"],
+        ["run", "--allowed-tools", "Read", "--", "echo"],
+        ["run", "--max-tool-calls", "5", "--", "echo"],
+        ["run", "--via", "env", "--", "echo"],
+    ):
+        args = parser.parse_args(argv)
+        assert _run_has_governance_intent(args) is True, argv

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -72,6 +72,7 @@ from .codex_app_server_fixture import (
 from .posture_index import build_posture_index, format_posture_report
 from .claude_code_daemon import install_native_pre_tool_use_command, resolve_native_pre_tool_use_command_path
 from .proxy import DEFAULT_STATE_DIR, GovernanceProxy, GovernanceSession, serve_proxy
+from .run_bridge import VALID_VIA_MODES, run_governed_cli
 from .shareable_redaction import path_aliases, redact_local_path_text
 
 
@@ -1818,7 +1819,23 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_has_governance_intent(args: argparse.Namespace) -> bool:
+    """True when ``ardur run`` was invoked as a governance bridge.
+
+    The legacy ``ardur run`` streams a command through the Ardur Personal Hub.
+    The governance bridge (issue passport → start session → launch governed) is
+    selected whenever any governance flag is present, keeping the legacy path
+    untouched for existing callers.
+    """
+    return any(
+        getattr(args, name, None) not in (None, False)
+        for name in ("mission", "allowed_tools", "forbidden_tools", "via", "govern")
+    ) or getattr(args, "max_tool_calls", None) is not None
+
+
 def cmd_run(args: argparse.Namespace) -> int:
+    if _run_has_governance_intent(args):
+        return run_governed_cli(args)
     return run_under_hub(args)
 
 
@@ -3093,10 +3110,50 @@ def build_parser() -> argparse.ArgumentParser:
     )
     uninstall.set_defaults(func=cmd_uninstall)
 
-    run = subparsers.add_parser("run", help="run a CLI command through Ardur Personal Hub")
-    run.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL")
+    run = subparsers.add_parser(
+        "run",
+        help="run a command through Ardur — governed launcher (with --mission/--allowed-tools) "
+        "or Ardur Personal Hub streaming (legacy)",
+    )
+    run.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL (legacy hub path)")
     run.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
-    run.add_argument("--home", type=Path, help="Ardur Personal home directory")
+    run.add_argument("--home", type=Path, help="Ardur home directory (ephemeral by default for governance)")
+    # Governance-bridge flags. Supplying any of these switches `ardur run` from
+    # the legacy hub-streaming path to the zero-setup governance launcher.
+    run.add_argument("--mission", help="mission text for the governed agent run")
+    run.add_argument(
+        "--allowed-tools",
+        action="append",
+        help="comma-separated allowlist of tools the agent may call (repeatable)",
+    )
+    run.add_argument(
+        "--forbidden-tools",
+        action="append",
+        help="comma-separated denylist of tools the agent may not call (repeatable)",
+    )
+    run.add_argument(
+        "--max-tool-calls",
+        type=int,
+        default=None,
+        help="maximum governed tool calls for the run (default 250 when governing)",
+    )
+    run.add_argument(
+        "--max-duration-s",
+        type=int,
+        default=86400,
+        help="wall-clock budget for the governed run in seconds",
+    )
+    run.add_argument(
+        "--via",
+        choices=sorted(VALID_VIA_MODES),
+        default=None,
+        help="how to route the agent's tool-call governance (default auto-detects Claude Code)",
+    )
+    run.add_argument(
+        "--no-kernel-correlation",
+        action="store_true",
+        help="skip eBPF daemon/cgroup correlation even when available",
+    )
     run.add_argument("command", nargs=argparse.REMAINDER, help="command to run after --")
     run.set_defaults(func=cmd_run)
 

--- a/python/vibap/kernel_correlation.py
+++ b/python/vibap/kernel_correlation.py
@@ -1,0 +1,306 @@
+"""Bridge from a launched agent's cgroup to the eBPF kernelcapture daemon.
+
+This module is the Python client side of the Go kernelcapture daemon's Unix
+socket control plane (``go/pkg/kernelcapture/daemon_socket_server.go`` +
+``daemon_session_registry.go``). It lets ``ardur run`` close the
+detect→session link: when the kernel detector sees the launched agent process,
+the daemon already knows which governance session owns that cgroup.
+
+Everything here degrades gracefully. On non-Linux hosts (no cgroup v2), or when
+the daemon socket is absent, or when the unprivileged launcher cannot create a
+cgroup, the helpers return ``None``/``unavailable`` results instead of raising.
+The caller (``run_bridge``) still governs the agent through the hook/env path —
+kernel correlation is an enhancement, never a hard dependency.
+
+Wire protocol (one JSON object + ``\\n`` per message, JSON-line framed):
+
+    request:  {"protocol_version": "kernelcapture.daemon.v1",
+               "method": "register_session",
+               "register_session": {"session_id": ..., "root_pid": ...,
+                                    "cgroup_id": ..., "ttl_seconds": ...,
+                                    "event_classes": ["process_lifecycle"]}}
+    response: {"protocol_version": "kernelcapture.daemon.v1", "ok": true,
+               "method": "register_session", "session_id": ..., "status": ...}
+
+The daemon authenticates the peer at the socket layer (SO_PEERCRED on Linux),
+so the client carries no token. Daemon-owned path fields and peer-identity
+fields are rejected by the daemon if a client tries to smuggle them in; this
+client never sends them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Must track go/pkg/kernelcapture/daemon_protocol.go.
+DAEMON_PROTOCOL_VERSION = "kernelcapture.daemon.v1"
+EVENT_CLASS_PROCESS_LIFECYCLE = "process_lifecycle"
+MAX_TTL_SECONDS = 24 * 60 * 60
+
+# Defaults mirror DaemonCustodyPlan.SocketPath in the Go daemon. Override with
+# ARDUR_KERNELCAPTURE_SOCKET for tests or a non-default deployment.
+DEFAULT_DAEMON_SOCKET = "/run/ardur/kernelcapture/control.sock"
+DAEMON_SOCKET_ENV = "ARDUR_KERNELCAPTURE_SOCKET"
+
+# cgroup v2 unified hierarchy root. Override with ARDUR_RUN_CGROUP_ROOT (used by
+# tests to point at a writable temp dir without root, and by deployments that
+# mount cgroupfs elsewhere).
+DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
+CGROUP_ROOT_ENV = "ARDUR_RUN_CGROUP_ROOT"
+
+# Subdirectory under the cgroup root that holds Ardur's per-run cgroups.
+RUN_CGROUP_NAMESPACE = "ardur.run"
+
+
+class DaemonProtocolError(RuntimeError):
+    """Raised when the daemon rejects a request or replies malformed data."""
+
+
+class DaemonUnavailable(RuntimeError):
+    """Raised when the daemon socket cannot be reached at all."""
+
+
+def daemon_socket_path() -> Path:
+    """Resolve the kernelcapture daemon control socket path."""
+    return Path(os.environ.get(DAEMON_SOCKET_ENV, DEFAULT_DAEMON_SOCKET)).expanduser()
+
+
+def daemon_available(socket_path: Path | None = None) -> bool:
+    """Return True only when a Unix-socket file exists at the daemon path.
+
+    This is a cheap pre-check; an actual connect may still fail (and that is
+    handled where it matters). We deliberately do not connect here so a missing
+    daemon costs a single ``stat`` rather than a connection timeout.
+    """
+    path = socket_path or daemon_socket_path()
+    try:
+        return path.is_socket()
+    except OSError:
+        return False
+
+
+class KernelCaptureClient:
+    """Minimal JSON-line client for the kernelcapture daemon control socket."""
+
+    def __init__(self, socket_path: Path | None = None, *, timeout_s: float = 2.0) -> None:
+        self.socket_path = socket_path or daemon_socket_path()
+        self.timeout_s = timeout_s
+
+    def _roundtrip(self, request: dict[str, Any]) -> dict[str, Any]:
+        payload = json.dumps(request, separators=(",", ":"), sort_keys=True).encode("utf-8") + b"\n"
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(self.timeout_s)
+                sock.connect(str(self.socket_path))
+                sock.sendall(payload)
+                chunks: list[bytes] = []
+                while b"\n" not in b"".join(chunks):
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+        except (FileNotFoundError, ConnectionRefusedError) as exc:
+            raise DaemonUnavailable(f"kernelcapture daemon not reachable at {self.socket_path}: {exc}") from exc
+        except OSError as exc:
+            raise DaemonUnavailable(f"kernelcapture daemon I/O error at {self.socket_path}: {exc}") from exc
+
+        raw = b"".join(chunks).split(b"\n", 1)[0]
+        if not raw:
+            raise DaemonProtocolError("empty response from kernelcapture daemon")
+        try:
+            response = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise DaemonProtocolError(f"malformed daemon response: {exc}") from exc
+        if not isinstance(response, dict):
+            raise DaemonProtocolError("daemon response was not a JSON object")
+        if response.get("protocol_version") != DAEMON_PROTOCOL_VERSION:
+            raise DaemonProtocolError(
+                f"unexpected daemon protocol version: {response.get('protocol_version')!r}"
+            )
+        if not response.get("ok", False):
+            raise DaemonProtocolError(str(response.get("error") or "daemon returned ok=false"))
+        return response
+
+    def health(self) -> dict[str, Any]:
+        return self._roundtrip(
+            {
+                "protocol_version": DAEMON_PROTOCOL_VERSION,
+                "method": "health",
+                "health": {},
+            }
+        )
+
+    def register_session(
+        self,
+        *,
+        session_id: str,
+        root_pid: int,
+        cgroup_id: int,
+        ttl_seconds: int,
+        mission_id: str | None = None,
+        trace_id: str | None = None,
+        event_classes: tuple[str, ...] = (EVENT_CLASS_PROCESS_LIFECYCLE,),
+    ) -> dict[str, Any]:
+        if not session_id:
+            raise ValueError("session_id is required")
+        if root_pid <= 0:
+            raise ValueError("root_pid must be positive")
+        if cgroup_id <= 0:
+            raise ValueError("cgroup_id must be positive")
+        ttl = max(1, min(int(ttl_seconds), MAX_TTL_SECONDS))
+        register: dict[str, Any] = {
+            "session_id": session_id,
+            "root_pid": int(root_pid),
+            "cgroup_id": int(cgroup_id),
+            "ttl_seconds": ttl,
+            "event_classes": list(event_classes),
+        }
+        if mission_id:
+            register["mission_id"] = mission_id
+        if trace_id:
+            register["trace_id"] = trace_id
+        return self._roundtrip(
+            {
+                "protocol_version": DAEMON_PROTOCOL_VERSION,
+                "method": "register_session",
+                "register_session": register,
+            }
+        )
+
+    def end_session(self, *, session_id: str, trace_id: str | None = None) -> dict[str, Any]:
+        if not session_id:
+            raise ValueError("session_id is required")
+        end: dict[str, Any] = {"session_id": session_id}
+        if trace_id:
+            end["trace_id"] = trace_id
+        return self._roundtrip(
+            {
+                "protocol_version": DAEMON_PROTOCOL_VERSION,
+                "method": "end_session",
+                "end_session": end,
+            }
+        )
+
+
+# ── cgroup v2 helpers ──────────────────────────────────────────────────────────
+
+
+def cgroup_root() -> Path:
+    return Path(os.environ.get(CGROUP_ROOT_ENV, DEFAULT_CGROUP_ROOT)).expanduser()
+
+
+def cgroup_v2_available(root: Path | None = None) -> bool:
+    """True when the unified (v2) cgroup hierarchy is mounted at ``root``.
+
+    The unified hierarchy exposes ``cgroup.controllers`` at its root; the legacy
+    v1 layout does not. This file is absent on macOS/Windows, so the check is
+    naturally False off Linux without a platform special-case.
+    """
+    base = root or cgroup_root()
+    try:
+        return (base / "cgroup.controllers").exists()
+    except OSError:
+        return False
+
+
+@dataclass
+class CgroupHandle:
+    """A per-run cgroup the launcher created and is responsible for cleaning up."""
+
+    path: Path
+    cgroup_id: int
+
+    def adopt_self(self) -> None:
+        """Move the *current* process into this cgroup.
+
+        Intended for use as a ``subprocess.Popen(preexec_fn=...)`` callback so
+        the agent starts life inside the cgroup, before ``exec``. Writing the
+        literal pid ``0`` to ``cgroup.procs`` is the kernel idiom for "the
+        writing process". Best-effort: a failure here must not abort the launch,
+        so the caller wraps it.
+        """
+        procs = self.path / "cgroup.procs"
+        with procs.open("w", encoding="ascii") as handle:
+            handle.write(f"{os.getpid()}\n")
+
+    def adopt_pid(self, pid: int) -> None:
+        procs = self.path / "cgroup.procs"
+        with procs.open("w", encoding="ascii") as handle:
+            handle.write(f"{int(pid)}\n")
+
+    def cleanup(self) -> None:
+        """Remove the cgroup directory (best effort).
+
+        cgroup v2 only allows ``rmdir`` once the cgroup has no member
+        processes; by the time the launcher calls this the agent has exited, so
+        the directory is empty. Any failure is swallowed: a leaked empty cgroup
+        is harmless and self-clearing on reboot.
+        """
+        try:
+            self.path.rmdir()
+        except OSError:
+            pass
+
+
+def create_run_cgroup(session_id: str, *, root: Path | None = None) -> CgroupHandle | None:
+    """Create a dedicated cgroup for a run and return a handle, or None.
+
+    Returns ``None`` (never raises) when cgroup v2 is unavailable or the
+    unprivileged launcher cannot create the directory — the graceful-degradation
+    contract the rest of the bridge relies on.
+
+    The cgroup id reported to the daemon is the directory's inode number. In
+    cgroup v2 the kernel's cgroup id *is* the inode of the cgroup directory in
+    cgroupfs, which is exactly what eBPF ``bpf_get_current_cgroup_id()`` returns,
+    so this value correlates 1:1 with kernel-side events.
+    """
+    base = root or cgroup_root()
+    if not cgroup_v2_available(base):
+        return None
+    # Sanitize the session id into a single safe path segment.
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in session_id)[:128]
+    namespace = base / RUN_CGROUP_NAMESPACE
+    target = namespace / f"sess-{safe}"
+    try:
+        namespace.mkdir(parents=True, exist_ok=True)
+        target.mkdir(parents=False, exist_ok=True)
+        cgroup_id = os.stat(target).st_ino
+    except OSError:
+        return None
+    if cgroup_id <= 0:
+        return None
+    return CgroupHandle(path=target, cgroup_id=cgroup_id)
+
+
+# ── orchestration result ───────────────────────────────────────────────────────
+
+
+@dataclass
+class CorrelationResult:
+    """Outcome of attempting to wire a run's cgroup to the kernel daemon."""
+
+    available: bool
+    reason: str
+    method: str = "none"
+    cgroup_id: int | None = None
+    cgroup_path: str | None = None
+    daemon_socket: str | None = None
+    daemon_status: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "available": self.available,
+            "reason": self.reason,
+            "method": self.method,
+            "cgroup_id": self.cgroup_id,
+            "cgroup_path": self.cgroup_path,
+            "daemon_socket": self.daemon_socket,
+            "daemon_status": self.daemon_status,
+            "details": dict(self.details),
+        }

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -1,0 +1,712 @@
+"""``ardur run`` governance bridge — zero-setup auto-governance for a launched agent.
+
+This is the bridge layer that turns Ardur's detection into governance. Running
+
+    ardur run --mission "..." --allowed-tools Read,Glob --max-tool-calls 50 -- <agent-cmd...>
+
+does all of this with no prior ``ardur protect`` and no permanent edits to the
+user's ``~/.claude/settings.json``:
+
+1. Issues a Mission Passport and starts a governance session for the agent, in a
+   private ephemeral Ardur home (keys + state + active passport).
+2. Launches ``<agent-cmd>`` with the environment that routes the agent's
+   tool-call governance to this session. For a hook-supporting agent (Claude
+   Code) it points the hook at this run via ``VIBAP_HOME`` + a scoped
+   ``--plugin-dir`` — temporary, run-scoped, no settings.json mutation.
+3. If the eBPF kernelcapture daemon is available, creates a dedicated cgroup for
+   the agent and registers it with the daemon, closing the detect→session link.
+   Otherwise it degrades gracefully and still governs via the hook/env path.
+4. On agent exit, finalizes the session into a behavioral attestation + a signed
+   receipt chain and prints a short governance summary.
+
+The transparent-intercept path for non-hook agents (Grok/Kimi/arbitrary CLIs)
+is scaffolded only — see :class:`TransparentInterceptAdapter`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from . import kernel_correlation as kc
+
+# Environment-variable contract the bridge exports to the launched agent. The
+# proxy-routed path (EnvProxyAdapter) and any cooperating agent read these.
+ENV_PROXY_URL = "ARDUR_PROXY_URL"
+ENV_API_TOKEN = "ARDUR_API_TOKEN"
+ENV_SESSION_ID = "ARDUR_SESSION_ID"
+ENV_HOME = "VIBAP_HOME"
+ENV_MISSION_PASSPORT = "ARDUR_MISSION_PASSPORT"
+ENV_TRACE_ID = "ARDUR_TRACE_ID"
+
+DEFAULT_AGENT_ID = "local-user:ardur-run"
+DEFAULT_MAX_TOOL_CALLS = 250
+DEFAULT_MAX_DURATION_S = 86400
+
+VALID_VIA_MODES = ("auto", "env", "claude-code", "intercept")
+
+
+# ── agent adapters ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunContext:
+    """Everything an adapter needs to wire an agent into the live session."""
+
+    home: Path
+    passport_token: str
+    passport_path: Path
+    session_id: str
+    mission_id: str
+    trace_id: str
+    proxy_url: str
+    api_token: str
+    plugin_dir: Path | None
+
+
+class AgentAdapter:
+    """Strategy for routing a launched agent's tool calls to the session."""
+
+    name = "base"
+
+    def prepare(
+        self,
+        ctx: RunContext,
+        command: list[str],
+        base_env: dict[str, str],
+    ) -> tuple[dict[str, str], list[str], list[str]]:
+        """Return ``(env, command, notes)`` for launching the agent."""
+        raise NotImplementedError
+
+
+class EnvProxyAdapter(AgentAdapter):
+    """Route governance via environment variables to the embedded proxy.
+
+    This is the generic path: a cooperating agent (or the integration test's
+    stand-in) reads :data:`ENV_PROXY_URL`/:data:`ENV_API_TOKEN`/
+    :data:`ENV_SESSION_ID` and POSTs each tool call to ``/evaluate`` before
+    acting on it.
+    """
+
+    name = "env-proxy"
+
+    def prepare(
+        self,
+        ctx: RunContext,
+        command: list[str],
+        base_env: dict[str, str],
+    ) -> tuple[dict[str, str], list[str], list[str]]:
+        env = dict(base_env)
+        env[ENV_PROXY_URL] = ctx.proxy_url
+        env[ENV_API_TOKEN] = ctx.api_token
+        env[ENV_SESSION_ID] = ctx.session_id
+        env[ENV_HOME] = str(ctx.home)
+        env[ENV_MISSION_PASSPORT] = str(ctx.passport_path)
+        env[ENV_TRACE_ID] = ctx.trace_id
+        return env, list(command), [f"governance routed via env → {ctx.proxy_url}/evaluate"]
+
+
+class ClaudeCodeAdapter(EnvProxyAdapter):
+    """Point Claude Code's hook at this run without touching settings.json.
+
+    Builds on :class:`EnvProxyAdapter` (so the proxy env is also present) and
+    additionally activates the Claude Code plugin for *this run only* by
+    injecting ``--plugin-dir`` into the ``claude`` invocation. Combined with the
+    ``VIBAP_HOME`` the base adapter sets — which makes the hook load this run's
+    ``active_mission.jwt`` — the agent is governed by the hook with zero
+    permanent configuration. Nothing is written to ``~/.claude/settings.json``.
+    """
+
+    name = "claude-code"
+
+    _CLAUDE_BASENAMES = {"claude", "claude-code"}
+
+    def prepare(
+        self,
+        ctx: RunContext,
+        command: list[str],
+        base_env: dict[str, str],
+    ) -> tuple[dict[str, str], list[str], list[str]]:
+        env, command, notes = super().prepare(ctx, command, base_env)
+        new_command = list(command)
+        basename = Path(command[0]).name if command else ""
+        if (
+            basename in self._CLAUDE_BASENAMES
+            and ctx.plugin_dir is not None
+            and "--plugin-dir" not in command
+        ):
+            new_command = [command[0], "--plugin-dir", str(ctx.plugin_dir), *command[1:]]
+            notes.append(
+                f"Claude Code hook scoped to this run via --plugin-dir {ctx.plugin_dir} "
+                "and VIBAP_HOME (no settings.json edit)"
+            )
+        else:
+            notes.append(
+                "Claude Code hook scoped via VIBAP_HOME (no settings.json edit); "
+                "--plugin-dir left as supplied"
+            )
+        return env, new_command, notes
+
+
+class TransparentInterceptAdapter(AgentAdapter):
+    """SCAFFOLD: transparent interception for non-hook agents.
+
+    Grok, Kimi, and arbitrary CLIs do not expose a tool-call hook, so governance
+    cannot be wired through env or a plugin. The intended mechanism is to
+    transparently intercept the agent's *egress* (model/tool API traffic) and
+    route it through the governance proxy, via one of:
+
+    * an ``iptables`` REDIRECT (Linux) sending the agent's outbound connections
+      to a local transparent proxy that evaluates each tool call, or
+    * an ``LD_PRELOAD`` / proxy-env shim that injects ``HTTP(S)_PROXY`` and a
+      CA-trust bundle so the agent's HTTPS client talks to the governance proxy.
+
+    This is intentionally NOT implemented in this slice. It is the follow-up for
+    issue #69 (wire governance to auto-detected agents). The interface is fixed
+    here so the launcher can dispatch to it once the path is built.
+    """
+
+    name = "transparent-intercept"
+
+    def prepare(
+        self,
+        ctx: RunContext,
+        command: list[str],
+        base_env: dict[str, str],
+    ) -> tuple[dict[str, str], list[str], list[str]]:
+        raise NotImplementedError(
+            "transparent-intercept governance is scaffolded only (issue #69). "
+            "Use --via env for cooperating agents or --via claude-code for Claude Code. "
+            "TODO: iptables REDIRECT / LD_PRELOAD egress shim to the governance proxy."
+        )
+
+
+def select_adapter(command: list[str], via: str) -> AgentAdapter:
+    if via == "env":
+        return EnvProxyAdapter()
+    if via == "claude-code":
+        return ClaudeCodeAdapter()
+    if via == "intercept":
+        return TransparentInterceptAdapter()
+    # auto
+    basename = Path(command[0]).name if command else ""
+    if basename in ClaudeCodeAdapter._CLAUDE_BASENAMES:
+        return ClaudeCodeAdapter()
+    return EnvProxyAdapter()
+
+
+def _claude_plugin_dir() -> Path | None:
+    candidate = Path(__file__).resolve().parents[2] / "plugins" / "claude-code"
+    return candidate if candidate.exists() else None
+
+
+# ── embedded governance server ─────────────────────────────────────────────────
+
+
+def _build_embedded_server(
+    proxy: Any,
+    session_id: str,
+    api_token: str,
+    private_key: Any,
+    host: str = "127.0.0.1",
+) -> ThreadingHTTPServer:
+    """A minimal loopback HTTP server delegating to the real GovernanceProxy.
+
+    Exposes just the endpoints the launched agent needs (``/health``,
+    ``/evaluate``, ``/result``, ``/session/end``, ``/attest``). It reuses the
+    proxy's real evaluation, receipt-signing, and attestation logic — it is only
+    the transport. Unlike :func:`proxy.serve_proxy` it is cleanly stoppable
+    (``shutdown()``), which the launcher needs so the server does not outlive the
+    run (important when the bridge runs in-process under a test).
+    """
+    from .proxy import Decision
+
+    token_material = api_token.encode("utf-8")
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "ArdurRunBridge/0.1"
+
+        def log_message(self, *_args: object) -> None:  # silence default logging
+            return
+
+        def _send(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _authorized(self) -> bool:
+            header = self.headers.get("Authorization", "")
+            prefix = "Bearer "
+            if not header.startswith(prefix):
+                return False
+            supplied = header[len(prefix):].strip().encode("utf-8")
+            return hmac.compare_digest(supplied, token_material)
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            data = json.loads(raw.decode("utf-8") or "{}")
+            if not isinstance(data, dict):
+                raise ValueError("request body must be a JSON object")
+            return data
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.split("?", 1)[0] in {"/health", "/healthz"}:
+                self._send(200, {"status": "ok", "session_id": session_id})
+                return
+            self._send(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            if not self._authorized():
+                self._send(401, {"error": "unauthorized"})
+                return
+            try:
+                payload = self._read_json()
+            except (ValueError, UnicodeDecodeError) as exc:
+                self._send(400, {"error": f"bad request: {exc}"})
+                return
+            sid = str(payload.get("session_id") or session_id)
+            try:
+                if path == "/evaluate":
+                    arguments = payload.get("arguments") or {}
+                    if not isinstance(arguments, dict):
+                        raise ValueError("arguments must be a JSON object")
+                    tool_name = payload.get("tool_name")
+                    if not tool_name:
+                        raise ValueError("missing field: tool_name")
+                    decision, reason = proxy.evaluate_tool_call(sid, str(tool_name), dict(arguments))
+                    response: dict[str, Any] = {"decision": decision.value, "session_id": sid}
+                    if decision != Decision.PERMIT:
+                        response["reason"] = reason
+                    self._send(200, response)
+                    return
+                if path == "/result":
+                    proxy.record_tool_result(
+                        sid,
+                        str(payload.get("response", "")),
+                        float(payload.get("duration_ms", 0.0)),
+                    )
+                    self._send(200, {"status": "recorded"})
+                    return
+                if path in {"/session/end", "/end"}:
+                    summary = proxy.end_session(sid)
+                    token, _ = proxy.issue_attestation_for_session(sid, private_key)
+                    self._send(200, {"attestation_token": token, "summary": summary})
+                    return
+                if path == "/attest":
+                    token, claims = proxy.issue_attestation_for_session(sid, private_key)
+                    self._send(200, {"token": token, "claims": claims})
+                    return
+            except (ValueError, KeyError, PermissionError) as exc:
+                self._send(400, {"error": str(exc)})
+                return
+            except Exception as exc:  # noqa: BLE001 — embedded server must not crash the run
+                self._send(500, {"error": f"internal error: {exc}"})
+                return
+            self._send(404, {"error": "not found"})
+
+    server = ThreadingHTTPServer((host, 0), Handler)
+    return server
+
+
+# ── result type ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GovernanceRunResult:
+    exit_code: int
+    session_id: str
+    mission_id: str
+    agent_id: str
+    adapter: str
+    via: str
+    proxy_url: str
+    home: str
+    passport_path: str
+    summary: dict[str, Any]
+    permits: int
+    denials: int
+    total_events: int
+    attestation_token: str
+    attestation_digest: str
+    receipts_path: str
+    receipt_count: int
+    correlation: dict[str, Any]
+    notes: list[str] = field(default_factory=list)
+
+
+def _count_lines(path: Path) -> int:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+    except OSError:
+        return 0
+
+
+def _attestation_digest(token: str) -> str:
+    return "sha-256:" + hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+# ── kernel correlation orchestration ───────────────────────────────────────────
+
+
+def _correlate_launch(
+    *,
+    session_id: str,
+    mission_id: str,
+    trace_id: str,
+    pid: int,
+    cgroup_handle: kc.CgroupHandle | None,
+    ttl_seconds: int,
+    enabled: bool,
+) -> kc.CorrelationResult:
+    """Register the launched process's cgroup with the eBPF daemon, if possible.
+
+    Never raises — returns an ``available=False`` result describing why
+    correlation was skipped or failed, so the caller can keep governing.
+    """
+    socket_path = kc.daemon_socket_path()
+    if not enabled:
+        return kc.CorrelationResult(available=False, reason="kernel correlation disabled by caller")
+    if cgroup_handle is None:
+        return kc.CorrelationResult(
+            available=False,
+            reason="cgroup v2 unavailable or not writable (governing via env/hook only)",
+            method="degraded",
+            daemon_socket=str(socket_path),
+        )
+    if not kc.daemon_available(socket_path):
+        return kc.CorrelationResult(
+            available=False,
+            reason="eBPF kernelcapture daemon socket not present (cgroup created, governing via env/hook)",
+            method="degraded",
+            cgroup_id=cgroup_handle.cgroup_id,
+            cgroup_path=str(cgroup_handle.path),
+            daemon_socket=str(socket_path),
+        )
+    try:
+        client = kc.KernelCaptureClient(socket_path)
+        response = client.register_session(
+            session_id=session_id,
+            root_pid=pid,
+            cgroup_id=cgroup_handle.cgroup_id,
+            ttl_seconds=ttl_seconds,
+            mission_id=mission_id,
+            trace_id=trace_id,
+        )
+    except (kc.DaemonUnavailable, kc.DaemonProtocolError, ValueError) as exc:
+        return kc.CorrelationResult(
+            available=False,
+            reason=f"daemon registration failed: {exc}",
+            method="degraded",
+            cgroup_id=cgroup_handle.cgroup_id,
+            cgroup_path=str(cgroup_handle.path),
+            daemon_socket=str(socket_path),
+        )
+    return kc.CorrelationResult(
+        available=True,
+        reason="cgroup registered with eBPF daemon; detect→session link active",
+        method="cgroup_daemon_register",
+        cgroup_id=cgroup_handle.cgroup_id,
+        cgroup_path=str(cgroup_handle.path),
+        daemon_socket=str(socket_path),
+        daemon_status=str(response.get("status") or "registered"),
+    )
+
+
+# ── main entry ─────────────────────────────────────────────────────────────────
+
+
+def run_governed(
+    *,
+    command: list[str],
+    mission: str | None = None,
+    allowed_tools: list[str] | None = None,
+    forbidden_tools: list[str] | None = None,
+    max_tool_calls: int = DEFAULT_MAX_TOOL_CALLS,
+    max_duration_s: int = DEFAULT_MAX_DURATION_S,
+    home: Path | None = None,
+    via: str = "auto",
+    agent_id: str = DEFAULT_AGENT_ID,
+    env: dict[str, str] | None = None,
+    enable_kernel_correlation: bool = True,
+    cwd: Path | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+) -> GovernanceRunResult:
+    """Launch ``command`` under a fresh, fully-governed Ardur session.
+
+    Returns a :class:`GovernanceRunResult` once the agent exits. Raises
+    ``ValueError`` for invalid input (empty command, bad ``via``) and
+    ``NotImplementedError`` for the scaffolded intercept path.
+    """
+    from .passport import MissionPassport, generate_keypair, issue_passport
+
+    if not command:
+        raise ValueError("ardur run requires a command to govern")
+    if via not in VALID_VIA_MODES:
+        raise ValueError(f"unknown --via mode: {via!r} (choose from {', '.join(VALID_VIA_MODES)})")
+
+    work_dir = Path(cwd).expanduser().resolve() if cwd else Path.cwd()
+
+    ephemeral = home is None
+    if ephemeral:
+        home = Path(tempfile.mkdtemp(prefix="ardur-run-"))
+    else:
+        home = Path(home).expanduser().resolve()
+        home.mkdir(parents=True, exist_ok=True)
+    keys_dir = home / "keys"
+    state_dir = home / "state"
+
+    # 1. Key material + Mission Passport (zero manual `ardur protect`).
+    private_key, _public_key = generate_keypair(keys_dir=keys_dir)
+    mission_text = mission or "Ardur-governed agent run."
+    passport = MissionPassport(
+        agent_id=agent_id,
+        mission=mission_text,
+        allowed_tools=list(allowed_tools or []),
+        forbidden_tools=list(forbidden_tools or []),
+        resource_scope=[str(work_dir), f"{work_dir}/*"],
+        cwd=str(work_dir),
+        max_tool_calls=max_tool_calls,
+        max_duration_s=max_duration_s,
+    )
+    token = issue_passport(passport, private_key, ttl_s=max_duration_s)
+    passport_path = home / "active_mission.jwt"
+    passport_path.write_text(token + "\n", encoding="utf-8")
+    try:
+        passport_path.chmod(0o600)
+    except OSError:
+        pass
+
+    # 2. Embedded governance proxy + session.
+    from .proxy import GovernanceProxy
+
+    proxy = GovernanceProxy(
+        log_path=home / "governance_log.jsonl",
+        state_dir=state_dir,
+        keys_dir=keys_dir,
+    )
+    session = proxy.start_session(token)
+    session_id = session.jti
+    mission_id = str(session.passport_claims.get("mission_id") or "")
+    trace_id = session_id
+
+    api_token = _generate_api_token()
+    server = _build_embedded_server(proxy, session_id, api_token, proxy.receipt_private_key)
+    port = server.server_address[1]
+    proxy_url = f"http://127.0.0.1:{port}"
+    server_thread = threading.Thread(target=server.serve_forever, name="ardur-run-proxy", daemon=True)
+    server_thread.start()
+
+    correlation = kc.CorrelationResult(available=False, reason="not attempted")
+    cgroup_handle: kc.CgroupHandle | None = None
+    daemon_registered = False
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        _wait_for_health(proxy_url, api_token)
+
+        # 3. Build the run environment via the selected adapter.
+        adapter = select_adapter(command, via)
+        ctx = RunContext(
+            home=home,
+            passport_token=token,
+            passport_path=passport_path,
+            session_id=session_id,
+            mission_id=mission_id,
+            trace_id=trace_id,
+            proxy_url=proxy_url,
+            api_token=api_token,
+            plugin_dir=_claude_plugin_dir(),
+        )
+        run_env, run_command, notes = adapter.prepare(ctx, command, env if env is not None else dict(os.environ))
+
+        # 4. Dedicated cgroup (Linux + cgroup v2 + writable), best effort.
+        if enable_kernel_correlation:
+            cgroup_handle = kc.create_run_cgroup(session_id)
+
+        # 5. Launch the agent.
+        proc = subprocess.Popen(
+            run_command,
+            env=run_env,
+            cwd=str(work_dir),
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        if cgroup_handle is not None:
+            try:
+                cgroup_handle.adopt_pid(proc.pid)
+            except OSError:
+                cgroup_handle.cleanup()
+                cgroup_handle = None
+
+        correlation = _correlate_launch(
+            session_id=session_id,
+            mission_id=mission_id,
+            trace_id=trace_id,
+            pid=proc.pid,
+            cgroup_handle=cgroup_handle,
+            ttl_seconds=min(max_duration_s, kc.MAX_TTL_SECONDS),
+            enabled=enable_kernel_correlation,
+        )
+        daemon_registered = correlation.available
+
+        # 6. Wait for the agent to exit (bounded by the mission duration budget).
+        try:
+            exit_code = proc.wait(timeout=max_duration_s)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            try:
+                exit_code = proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                exit_code = proc.wait()
+            notes.append(f"agent exceeded max-duration {max_duration_s}s and was terminated")
+    finally:
+        # 7. Finalize the governance session: attestation + receipt chain.
+        summary = proxy.end_session(session_id)
+        attestation_token, _claims = proxy.issue_attestation_for_session(
+            session_id, proxy.receipt_private_key
+        )
+        if daemon_registered and cgroup_handle is not None:
+            try:
+                kc.KernelCaptureClient(kc.daemon_socket_path()).end_session(
+                    session_id=session_id, trace_id=trace_id
+                )
+            except (kc.DaemonUnavailable, kc.DaemonProtocolError):
+                pass
+        if cgroup_handle is not None:
+            cgroup_handle.cleanup()
+        server.shutdown()
+        server.server_close()
+
+    receipts_path = proxy.receipts_log_path
+    result = GovernanceRunResult(
+        exit_code=exit_code if proc is not None else 127,
+        session_id=session_id,
+        mission_id=mission_id,
+        agent_id=agent_id,
+        adapter=adapter.name,
+        via=via,
+        proxy_url=proxy_url,
+        home=str(home),
+        passport_path=str(passport_path),
+        summary=dict(summary),
+        permits=int(summary.get("permits", 0)),
+        denials=int(summary.get("denials", 0)),
+        total_events=int(summary.get("total_events", 0)),
+        attestation_token=attestation_token,
+        attestation_digest=_attestation_digest(attestation_token),
+        receipts_path=str(receipts_path),
+        receipt_count=_count_lines(receipts_path),
+        correlation=correlation.to_dict(),
+        notes=notes,
+    )
+    return result
+
+
+def _generate_api_token() -> str:
+    import secrets
+
+    return secrets.token_urlsafe(32)
+
+
+def _wait_for_health(proxy_url: str, api_token: str, timeout_s: float = 5.0) -> None:
+    deadline = time.time() + timeout_s
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            request = urllib.request.Request(f"{proxy_url}/health", method="GET")
+            with urllib.request.urlopen(request, timeout=1.0) as response:  # noqa: S310 — loopback only
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, OSError) as exc:
+            last_error = exc
+            time.sleep(0.02)
+    raise RuntimeError(f"embedded governance proxy did not become healthy: {last_error}")
+
+
+# ── human-readable summary + CLI glue ──────────────────────────────────────────
+
+
+def format_summary(result: GovernanceRunResult) -> str:
+    lines = [
+        "── Ardur governance summary ─────────────────────────────",
+        f"  session       {result.session_id}",
+        f"  mission_id    {result.mission_id}",
+        f"  adapter       {result.adapter} (--via {result.via})",
+        f"  tool calls    {result.total_events} evaluated "
+        f"({result.permits} permit / {result.denials} deny)",
+        f"  receipts      {result.receipt_count} signed → {result.receipts_path}",
+        f"  attestation   {result.attestation_digest}",
+        f"  kernel link   {result.correlation.get('reason')}",
+        f"  agent exit    {result.exit_code}",
+    ]
+    for note in result.notes:
+        lines.append(f"  note          {note}")
+    lines.append("─────────────────────────────────────────────────────────")
+    return "\n".join(lines)
+
+
+def run_governed_cli(args: Any) -> int:
+    """Argparse entry point used by ``cmd_run`` when governance flags are present."""
+    command = list(getattr(args, "command", None) or [])
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("ardur run requires a command to govern after --", file=sys.stderr)
+        print("usage: ardur run --mission \"...\" --allowed-tools Read,Glob -- <agent-cmd...>", file=sys.stderr)
+        return 2
+
+    allowed = _split_csv(getattr(args, "allowed_tools", None))
+    forbidden = _split_csv(getattr(args, "forbidden_tools", None))
+    try:
+        result = run_governed(
+            command=command,
+            mission=getattr(args, "mission", None),
+            allowed_tools=allowed,
+            forbidden_tools=forbidden,
+            max_tool_calls=int(getattr(args, "max_tool_calls", DEFAULT_MAX_TOOL_CALLS)),
+            max_duration_s=int(getattr(args, "max_duration_s", DEFAULT_MAX_DURATION_S)),
+            home=getattr(args, "home", None),
+            via=getattr(args, "via", None) or "auto",
+            enable_kernel_correlation=not getattr(args, "no_kernel_correlation", False),
+        )
+    except NotImplementedError as exc:
+        print(f"ardur run: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"ardur run: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_summary(result), file=sys.stderr)
+    return result.exit_code
+
+
+def _split_csv(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        items: list[str] = []
+        for entry in value:
+            items.extend(_split_csv(entry))
+        return items
+    return [part.strip() for part in str(value).split(",") if part.strip()]

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -128,6 +128,16 @@ class ClaudeCodeAdapter(EnvProxyAdapter):
     ``VIBAP_HOME`` the base adapter sets — which makes the hook load this run's
     ``active_mission.jwt`` — the agent is governed by the hook with zero
     permanent configuration. Nothing is written to ``~/.claude/settings.json``.
+
+    .. note::
+        **Receipt gap**: the Claude Code hook evaluates tool calls locally via
+        the plugin mechanism; it does **not** POST to ``ARDUR_PROXY_URL``
+        (``/evaluate``).  As a result, ``RunResult.total_events`` is 0 on this
+        path — governance is enforced by the hook but the embedded proxy-side
+        receipt chain is empty.  The hook's own JSONL output in ``VIBAP_HOME``
+        is the authoritative governance record for ClaudeCode invocations.
+        Wiring the hook to also report to the embedded proxy is tracked as a
+        follow-up under Epic A (#63).
     """
 
     name = "claude-code"


### PR DESCRIPTION
## The bridge layer: eBPF detection → real auto-governance

This wires Ardur's proven detection and governance halves together so a single
command governs an agent with **zero manual per-project setup**. Today the eBPF
detector (`go/pkg/kernelcapture/`) sees an agent launch but nothing routes that
process's tool calls through the governance proxy (`python/vibap/proxy.py`), and
governance is opt-in via `ardur protect` writing per-project hooks. This PR
turns `ardur run` into the launcher that closes that gap.

Refs **Epic A (#63)**, **#66** (daemon/launcher), **#69** (wire governance to
auto-detected agents).

### What works now (Slice 1)

`ardur run --mission "..." --allowed-tools Read,Glob --max-tool-calls N -- <agent-cmd...>`:

1. **Issues a Mission Passport + starts a governance session** in a private,
   ephemeral Ardur home (keys + state + `active_mission.jwt`). No prior
   `ardur protect`.
2. **Launches the agent** with the environment that routes its tool-call
   governance to this session, via an `AgentAdapter`:
   - `EnvProxyAdapter` (generic / default): exports
     `ARDUR_PROXY_URL` / `ARDUR_API_TOKEN` / `ARDUR_SESSION_ID` so a cooperating
     agent POSTs each tool call to the session's `/evaluate`.
   - `ClaudeCodeAdapter`: points Claude Code's hook at this run via `VIBAP_HOME`
     + a **scoped `--plugin-dir`** — run-scoped, temporary, **no permanent edit
     to `~/.claude/settings.json`**.
3. **Correlates detect→session**: on Linux it creates a dedicated cgroup v2 for
   the agent and registers `(session_id, root_pid, cgroup_id)` with the eBPF
   daemon over its Unix-socket control plane (`kernelcapture.daemon.v1`). The
   cgroup id is the cgroup directory inode — exactly what
   `bpf_get_current_cgroup_id()` returns — so it correlates 1:1 with kernel
   events. When cgroup v2 or the daemon is unavailable (e.g. macOS, unprivileged
   host), it **degrades gracefully** and still governs via the env/hook path.
4. **On agent exit, finalizes the session** into a behavioral attestation +
   signed receipt chain and prints a short governance summary
   (permits/denials, attestation digest, receipt count, kernel-link status).

```
── Ardur governance summary ─────────────────────────────
  session       9062175d-b062-468c-a691-99ef3872f8d9
  mission_id    mission:local-user:ardur-run:6d7028efd49d
  adapter       env-proxy (--via env)
  tool calls    3 evaluated (2 permit / 1 deny)
  receipts      3 signed → .../receipts_log.jsonl
  attestation   sha-256:d11953b3e862cd…
  kernel link   cgroup v2 unavailable or not writable (governing via env/hook only)
  agent exit    0
```

### Tests

`python/tests/test_run_bridge.py` — integration test: `ardur run`s a stand-in
agent that makes a PERMIT-able (`Read`) and a DENY-able (`Bash`) tool call and
asserts, with **zero `ardur protect` setup**:
- a session started;
- 3 calls were evaluated (2 PERMIT / 1 DENY);
- a **signed receipt chain** was produced and **verifies cryptographically**
  (`verify_chain`);
- a **behavioral attestation** was issued and **verifies** (`verify_attestation`),
  with `permits`/`denials` matching;
- nothing was written to `~/.claude/settings.json`;
- kernel correlation degraded gracefully.

Plus adapter unit tests and `python/tests/test_kernel_correlation.py` (cgroup
helpers against a temp-dir fake root; the daemon client against a fake AF_UNIX
server; input validation; graceful-degradation paths).

Results: **full Python suite 1036 passed / 32 skipped**; Go `kernelcapture` and
`go build ./...` green. New files are ruff-clean.

### Design notes (decisive, pragmatic)

- The bridge runs a small **embedded loopback HTTP server** that delegates to the
  real `GovernanceProxy` (evaluate / result / end / attest). It reuses the real
  evaluation, receipt-signing, and attestation logic; it is cleanly stoppable so
  it does not outlive a run (important under tests). It does **not** fork the
  big `serve_proxy`.
- `ardur run`'s **legacy** Ardur-Personal-Hub streaming path is preserved and
  selected when no governance flag is present; governance flags switch it to the
  bridge. Existing `run_under_hub` tests stay green.
- The kernelcapture daemon has no Go client helper; the launcher (Python) speaks
  its documented JSON-line protocol directly. A native Go launcher remains a
  possible future.

### Scaffold only / remaining gap (the honest part)

- **Transparent intercept for non-hook agents** (Grok / Kimi / arbitrary CLIs)
  is `TransparentInterceptAdapter` — a fixed interface + clear `TODO`, **not
  implemented**. The intended mechanism is an iptables REDIRECT (Linux) or an
  `LD_PRELOAD` / proxy-env egress shim routing the agent's API traffic through
  the governance proxy. **Follow-up: #69.**
- Kernel correlation is exercised on Linux with a live daemon; the verified
  paths here are the protocol client, the cgroup helpers (temp-root), and the
  graceful-degradation branches (the bridge ran end-to-end on macOS).
- For Claude Code, governance evidence today is the hook's in-process receipt
  chain (under the run's `VIBAP_HOME`); unifying the hook to also drive the
  embedded proxy session's `/evaluate` is a natural follow-up.

Opening as **draft** — not for merge.
