### PR TITLE
feat(daemon): ardur-kernelcaptured Slice 1 — always-on eBPF daemon

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_linux.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+func platformName() string { return "linux" }
+
+// runEBPFConsumer loads the embedded eBPF program, attaches exec/exit
+// tracepoints, and streams ProcessEvents to d.processKernelEvent until ctx is
+// cancelled.
+//
+// Claim boundary: loads the process-exec eBPF objects embedded in the binary,
+// attaches sched/sched_process_exec and sched/sched_process_exit, reads events
+// from the BPF ringbuf, and routes them to registered sessions. Does NOT pin
+// maps on bpffs, create or join cgroups, install/start a system service, or
+// enforce any action against the observed process.
+func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
+	btfPath := "/sys/kernel/btf/vmlinux"
+	if _, err := os.Stat(btfPath); err != nil {
+		return fmt.Errorf("BTF not available at %s (required for CO-RE eBPF): %w", btfPath, err)
+	}
+
+	kernelRelease, _ := os.ReadFile("/proc/sys/kernel/osrelease")
+	log.Info("loading eBPF objects",
+		"kernel", string(kernelRelease),
+		"btf", btfPath,
+	)
+
+	handles, err := kernelcapture.LoadAndAttachProcessExecEBPF()
+	if err != nil {
+		return fmt.Errorf("load and attach eBPF: %w", err)
+	}
+	defer handles.Close()
+
+	log.Info("eBPF tracepoints attached",
+		"exec", "sched/sched_process_exec",
+		"exit", "sched/sched_process_exit",
+	)
+
+	source := kernelcapture.NewRingbufProcessSourceFromRingbufReader(handles.Reader())
+	// No defer source.Close() here: handles.Close() owns the reader.
+
+	var loss kernelcapture.CaptureLoss
+	// Empty scope: all events reach the router (per-session filtering is done
+	// in daemon.routeEvent via the cgroup index and ProcessTreeScope).
+	scope := kernelcapture.SessionScope{}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		evt, ok, err := source.Next(ctx, scope)
+		if err != nil {
+			var ringErr *kernelcapture.RingbufNextError
+			if errors.As(err, &ringErr) {
+				switch ringErr.Kind {
+				case kernelcapture.RingbufErrorContextCanceled, kernelcapture.RingbufErrorDeadlineExceeded:
+					return ctx.Err()
+				case kernelcapture.RingbufErrorMalformedRecord:
+					loss.RingbufDropped++
+					log.Warn("malformed ringbuf record", "drop_count", loss.RingbufDropped)
+					continue
+				}
+			}
+			return fmt.Errorf("ringbuf read: %w", err)
+		}
+		if !ok {
+			continue
+		}
+
+		d.processKernelEvent(evt, loss)
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_linux.go
@@ -79,5 +79,6 @@ func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 		}
 
 		d.processKernelEvent(evt, loss)
+		loss = kernelcapture.CaptureLoss{} // reset: drops since last good event have been reported
 	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// Ensure the fs interface is satisfied by osEvidenceFS (compile-time check).
+var _ evidenceFS = osEvidenceFS{}
+
+// stubEvidenceFS captures AppendFile calls for inspection in tests.
+type stubEvidenceFS struct {
+	mu      sync.Mutex
+	dirs    []string
+	appends map[string][]byte
+	err     error
+}
+
+func newStubFS() *stubEvidenceFS { return &stubEvidenceFS{appends: map[string][]byte{}} }
+
+func (s *stubEvidenceFS) MkdirAll(path string, _ fs.FileMode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dirs = append(s.dirs, path)
+	return s.err
+}
+
+func (s *stubEvidenceFS) AppendFile(path string, data []byte, _ fs.FileMode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.appends[path] = append(s.appends[path], data...)
+	return nil
+}
+
+// newTestDaemon returns a daemon wired with an in-memory (stub) filesystem.
+// It bypasses BuildDaemonCustodyPlan path validation so tests can run without
+// privileged filesystem access.
+func newTestDaemon(t *testing.T) *daemon {
+	t.Helper()
+	tmpDir := t.TempDir()
+	return &daemon{
+		log:         testLogger(t),
+		registry:    kernelcapture.NewDaemonSessionRegistry(),
+		evidenceDir: filepath.Join(tmpDir, "evidence"),
+		cgroupIndex: make(map[uint64]string),
+		treeScopes:  make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators: make(map[string]*kernelcapture.Correlator),
+		fs:          osEvidenceFS{},
+	}
+}
+
+// testLogger returns a logger that writes to t.Log.
+func testLogger(t *testing.T) *slog.Logger {
+	return slog.New(slog.NewTextHandler(testLogWriter{t}, nil))
+}
+
+// testLogWriter bridges io.Writer to t.Log.
+type testLogWriter struct{ t *testing.T }
+
+func (w testLogWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+func TestSanitizeSessionID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"abc-123_XYZ", "abc-123_XYZ"},
+		{"ses/path/../etc", "ses_path____etc"},
+		{"uuid-0123456789abcdef", "uuid-0123456789abcdef"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := sanitizeSessionID(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeSessionID(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestOnSessionRegisteredAndEnded(t *testing.T) {
+	d := newTestDaemon(t)
+
+	reg := &kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "test-session-001",
+		RootPID:      12345,
+		CgroupID:     999,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   60,
+	}
+	d.onSessionRegistered(reg, "test-session-001")
+
+	d.mu.RLock()
+	cgroupSID, ok := d.cgroupIndex[999]
+	scope := d.treeScopes["test-session-001"]
+	corr := d.correlators["test-session-001"]
+	d.mu.RUnlock()
+
+	if !ok || cgroupSID != "test-session-001" {
+		t.Errorf("cgroup index: got %q, want %q", cgroupSID, "test-session-001")
+	}
+	if scope == nil {
+		t.Error("process tree scope not created")
+	}
+	if corr == nil {
+		t.Error("correlator not created")
+	}
+
+	d.onSessionEnded("test-session-001")
+
+	d.mu.RLock()
+	_, inCgroup := d.cgroupIndex[999]
+	_, inTree := d.treeScopes["test-session-001"]
+	_, inCorr := d.correlators["test-session-001"]
+	d.mu.RUnlock()
+
+	if inCgroup {
+		t.Error("cgroup index entry not removed after end_session")
+	}
+	if inTree {
+		t.Error("tree scope entry not removed after end_session")
+	}
+	if inCorr {
+		t.Error("correlator entry not removed after end_session")
+	}
+}
+
+func TestRouteEvent_CgroupMatch(t *testing.T) {
+	d := newTestDaemon(t)
+
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "route-test-001",
+		RootPID:      100,
+		CgroupID:     42,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   300,
+	}, "route-test-001")
+
+	evt := kernelcapture.ProcessEvent{
+		PID:      100,
+		CgroupID: 42,
+		Type:     kernelcapture.ProcessEventExec,
+	}
+	sid, corr := d.routeEvent(&evt)
+	if sid != "route-test-001" {
+		t.Errorf("routeEvent cgroup match: got %q, want %q", sid, "route-test-001")
+	}
+	if corr == nil {
+		t.Error("routeEvent: expected non-nil correlator")
+	}
+}
+
+func TestRouteEvent_NoMatch(t *testing.T) {
+	d := newTestDaemon(t)
+
+	evt := kernelcapture.ProcessEvent{PID: 9999, CgroupID: 77}
+	sid, corr := d.routeEvent(&evt)
+	if sid != "" {
+		t.Errorf("routeEvent no-match: got non-empty session %q", sid)
+	}
+	if corr != nil {
+		t.Error("routeEvent no-match: expected nil correlator")
+	}
+}
+
+func TestAppendKernelReceipt(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = evidenceFS(stub)
+
+	sessionID := "evidence-test-001"
+	evt := kernelcapture.ProcessEvent{PID: 200, CgroupID: 55, Type: kernelcapture.ProcessEventExec}
+	receipt := kernelcapture.SyntheticKernelReceipt{
+		EventID:               "evt-001",
+		EventClass:            "process_exec",
+		CoverageStatus:        "not_claimed",
+		CorrelationMethod:     "cgroup_time_window",
+		CorrelationConfidence: "medium",
+		Verdict:               "not_claimed",
+	}
+
+	d.appendKernelReceipt(sessionID, evt, receipt)
+
+	stub.mu.Lock()
+	data := stub.appends[filepath.Join(d.evidenceDir, sanitizeSessionID(sessionID), "kernel_receipts.jsonl")]
+	stub.mu.Unlock()
+
+	if len(data) == 0 {
+		t.Fatal("appendKernelReceipt: no data written")
+	}
+
+	var entry KernelReceiptEntry
+	if err := json.Unmarshal(data[:len(data)-1], &entry); err != nil {
+		t.Fatalf("unmarshal receipt entry: %v\n%s", err, data)
+	}
+	if entry.SessionID != sessionID {
+		t.Errorf("receipt entry session_id: got %q, want %q", entry.SessionID, sessionID)
+	}
+	if entry.SchemaVersion != KernelReceiptSchema {
+		t.Errorf("receipt entry schema_version: got %q, want %q", entry.SchemaVersion, KernelReceiptSchema)
+	}
+}
+
+func TestHandleAuthorizedRequest_RegisterUpdatesIndex(t *testing.T) {
+	d := newTestDaemon(t)
+
+	const fakeStartTicks uint64 = 12345678
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+		ProcessStartTimeTicks: fakeStartTicks,
+		Authorization: kernelcapture.DaemonPeerAuthorization{
+			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+			UID:                   uint32(os.Getuid()),
+			PID:                   uint32(os.Getpid()),
+			ProcessStartTimeTicks: fakeStartTicks,
+		},
+	}
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "dispatch-test-001",
+			RootPID:      50,
+			CgroupID:     17,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   120,
+		},
+	}
+
+	resp := d.handleAuthorizedRequest(context.Background(), req, handshake)
+	if !resp.OK {
+		t.Fatalf("handleAuthorizedRequest: not OK: %s", resp.Error)
+	}
+
+	d.mu.RLock()
+	_, hasIndex := d.cgroupIndex[17]
+	d.mu.RUnlock()
+
+	if !hasIndex {
+		t.Error("cgroup index not populated after handleAuthorizedRequest register_session")
+	}
+}
+
+func TestPruneExpiredSessions(t *testing.T) {
+	d := newTestDaemon(t)
+
+	// Insert a session directly into the routing index without going through
+	// the registry, so we can test pruning of an unknown session.
+	d.mu.Lock()
+	scope := kernelcapture.NewProcessTreeScope(1, 88)
+	scope.SessionID = "phantom-session"
+	d.treeScopes["phantom-session"] = &scope
+	d.cgroupIndex[88] = "phantom-session"
+	d.correlators["phantom-session"] = kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{})
+	d.mu.Unlock()
+
+	// pruneExpiredSessions should remove the phantom session because the
+	// registry has no record of it (ActiveSession returns an error).
+	d.pruneExpiredSessions()
+
+	d.mu.RLock()
+	_, stillInCgroup := d.cgroupIndex[88]
+	_, stillInTree := d.treeScopes["phantom-session"]
+	d.mu.RUnlock()
+
+	if stillInCgroup {
+		t.Error("phantom session cgroup entry not pruned")
+	}
+	if stillInTree {
+		t.Error("phantom session tree scope not pruned")
+	}
+}
+
+func TestOsEvidenceFS_AppendFile(t *testing.T) {
+	dir := t.TempDir()
+	fsys := osEvidenceFS{}
+	path := filepath.Join(dir, "receipts.jsonl")
+
+	if err := fsys.AppendFile(path, []byte("line1\n"), 0o600); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := fsys.AppendFile(path, []byte("line2\n"), 0o600); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != "line1\nline2\n" {
+		t.Errorf("file contents: got %q, want %q", data, "line1\nline2\n")
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -173,6 +173,39 @@ func TestRouteEvent_NoMatch(t *testing.T) {
 	}
 }
 
+// TestRouteEvent_SlowPathPIDTreeMatch exercises the slow-path PID-tree scan.
+// The session is registered with CgroupID=0 (no cgroup guard) so it does not
+// appear in cgroupIndex. The event carries CgroupID=99 which misses the fast
+// path (cgroupIndex[99] is empty), falling through to the PID-tree scan where
+// PID=100 matches the root PID.
+func TestRouteEvent_SlowPathPIDTreeMatch(t *testing.T) {
+	d := newTestDaemon(t)
+
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "slow-path-test",
+		RootPID:      100,
+		CgroupID:     0,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   300,
+	}, "slow-path-test")
+
+	// CgroupID=99: fast path checks cgroupIndex[99], finds nothing, falls through.
+	// scope.CgroupID=0 disables the cgroup guard inside MatchesAndTrack.
+	// PID=100 matches the registered root PID.
+	evt := kernelcapture.ProcessEvent{
+		PID:      100,
+		CgroupID: 99,
+		Type:     kernelcapture.ProcessEventExec,
+	}
+	sid, corr := d.routeEvent(&evt)
+	if sid != "slow-path-test" {
+		t.Errorf("routeEvent slow-path PID-tree match: got %q, want %q", sid, "slow-path-test")
+	}
+	if corr == nil {
+		t.Error("routeEvent slow-path: expected non-nil correlator")
+	}
+}
+
 func TestAppendKernelReceipt(t *testing.T) {
 	d := newTestDaemon(t)
 	stub := newStubFS()

--- a/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+func platformName() string { return "unsupported" }
+
+// runEBPFConsumer is a no-op stub on non-Linux platforms. The eBPF ringbuf
+// consumer requires a Linux kernel; the daemon runs control-plane only.
+func runEBPFConsumer(_ context.Context, _ *daemon, log *slog.Logger) error {
+	log.Warn("eBPF ringbuf consumer is Linux-only; running control plane only")
+	return fmt.Errorf("eBPF consumer unavailable on this platform")
+}

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -1,0 +1,437 @@
+// Package main is the entry point for ardur-kernelcaptured, the Ardur
+// kernel-capture daemon (Slice 1 — foreground/dev mode).
+//
+// The daemon wires the existing kernelcapture library components into a running
+// process:
+//   - Unix-socket control plane (ListenDaemonUnixSocketServer + SO_PEERCRED auth)
+//   - Session registry (DaemonSessionRegistry) honoring register_session TTL
+//   - eBPF event consumer (Linux only; degrades gracefully on unsupported platforms)
+//   - Correlator routing events to registered sessions
+//   - Evidence-log JSONL writer per session
+//
+// Claim boundary for Slice 1:
+//   - Starts and serves the socket control plane.
+//   - On Linux: loads the process-exec eBPF program, attaches sched/sched_process_exec
+//     and sched/sched_process_exit tracepoints, routes events to registered sessions,
+//     and appends SyntheticKernelReceipts to per-session JSONL evidence logs.
+//   - On non-Linux: control plane only; eBPF consumer is unavailable.
+//
+// NOT in Slice 1 (explicitly out-of-scope):
+//   - Privileged system-service install / systemd unit (Slice 2).
+//   - cgroup creation and assignment (left to the ardur-run bridge, PR #81).
+//   - Enforcement / kill-switch actions (Slice 4).
+//   - File, network, or syscall capture beyond process exec/exit metadata.
+//   - Production hardening: persistent socket path ownership, bpffs map pinning,
+//     or crash-recovery.
+//
+// Refs: Epic A (#63), task #66 (daemon/launcher).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+const (
+	defaultSocketPath   = "/run/ardur/kernelcapture/control.sock"
+	defaultEvidenceDir  = "/var/lib/ardur/kernelcapture/evidence"
+	defaultStateDir     = "/var/lib/ardur/kernelcapture/state"
+	defaultSocketMode   = fs.FileMode(0o660)
+	KernelReceiptSchema = "ardur.kernel.receipt.v1"
+)
+
+// KernelReceiptEntry is the JSONL record appended to
+// <evidenceDir>/<sessionID>/kernel_receipts.jsonl for each observed process
+// event that is correlated to a registered session.
+type KernelReceiptEntry struct {
+	SchemaVersion string                            `json:"schema_version"`
+	SessionID     string                            `json:"session_id"`
+	RecordedAt    time.Time                         `json:"recorded_at"`
+	Event         kernelcapture.ProcessEvent        `json:"event"`
+	Receipt       kernelcapture.SyntheticKernelReceipt `json:"receipt"`
+}
+
+// daemon holds all shared state for the running daemon process.
+type daemon struct {
+	log         *slog.Logger
+	registry    *kernelcapture.DaemonSessionRegistry
+	custodyPlan kernelcapture.DaemonCustodyPlan
+	peerPolicy  kernelcapture.DaemonPeerAuthorizationPolicy
+	evidenceDir string
+
+	// Routing index: cgroup_id → session_id, maintained under mu.
+	// Populated on register_session, removed on end_session / expiry.
+	mu          sync.RWMutex
+	cgroupIndex map[uint64]string
+	treeScopes  map[string]*kernelcapture.ProcessTreeScope
+	correlators map[string]*kernelcapture.Correlator
+
+	// OS filesystem for JSONL append (interface for test injection).
+	fs evidenceFS
+}
+
+func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, ownerUID uint32) (*daemon, error) {
+	cfg := kernelcapture.DefaultDaemonCustodyConfig()
+	if socketPath != "" {
+		cfg.SocketPath = socketPath
+		cfg.RunDir = filepath.Dir(socketPath)
+	}
+	if stateDir != "" {
+		cfg.StateDir = stateDir
+	}
+	custodyPlan, err := kernelcapture.BuildDaemonCustodyPlan(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build custody plan: %w", err)
+	}
+
+	registry := kernelcapture.NewDaemonSessionRegistry()
+
+	// Allow the daemon's own UID and, if root, also UID 0. In production this
+	// should be locked down further; for Slice 1 (foreground/dev) we allow the
+	// launching user to register sessions.
+	allowedUIDs := []uint32{ownerUID}
+	if ownerUID != 0 {
+		allowedUIDs = append(allowedUIDs, 0)
+	}
+	peerPolicy := kernelcapture.DaemonPeerAuthorizationPolicy{
+		AllowedUIDs: allowedUIDs,
+	}
+
+	return &daemon{
+		log:         log,
+		registry:    registry,
+		custodyPlan: custodyPlan,
+		peerPolicy:  peerPolicy,
+		evidenceDir: evidenceDir,
+		cgroupIndex: make(map[uint64]string),
+		treeScopes:  make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators: make(map[string]*kernelcapture.Correlator),
+		fs:          osEvidenceFS{},
+	}, nil
+}
+
+// handleAuthorizedRequest is the DaemonAuthorizedProtocolHandler wired into the
+// socket server. It delegates to the registry and maintains the cgroup routing
+// index as a side effect of successful register/end-session responses.
+func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
+	resp := d.registry.HandleAuthorizedRequest(ctx, req, handshake)
+	if !resp.OK {
+		return resp
+	}
+	switch req.Method {
+	case kernelcapture.DaemonProtocolMethodRegisterSession:
+		if req.RegisterSession != nil {
+			d.onSessionRegistered(req.RegisterSession, resp.SessionID)
+		}
+	case kernelcapture.DaemonProtocolMethodEndSession:
+		if sessionID := req.EndSession; sessionID != nil {
+			d.onSessionEnded(sessionID.SessionID)
+		}
+	}
+	return resp
+}
+
+// onSessionRegistered adds the session to the cgroup routing index.
+func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionRequest, sessionID string) {
+	if sessionID == "" || reg == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if reg.CgroupID != 0 {
+		d.cgroupIndex[reg.CgroupID] = sessionID
+	}
+
+	scope := kernelcapture.NewProcessTreeScope(reg.RootPID, reg.CgroupID)
+	scope.SessionID = sessionID
+	d.treeScopes[sessionID] = &scope
+
+	d.correlators[sessionID] = kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{
+		Platform:         "linux",
+		CaptureBackend:   "linux_ebpf",
+		CorrelationGrace: 5 * time.Second,
+		RestartGrace:     3 * time.Second,
+	})
+
+	d.log.Info("session registered",
+		"session_id", sessionID,
+		"root_pid", reg.RootPID,
+		"cgroup_id", reg.CgroupID,
+		"event_classes", reg.EventClasses,
+		"ttl_s", reg.TTLSeconds,
+	)
+}
+
+// onSessionEnded removes the session from the routing index.
+func (d *daemon) onSessionEnded(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if scope, ok := d.treeScopes[sessionID]; ok {
+		if scope.CgroupID != 0 {
+			delete(d.cgroupIndex, scope.CgroupID)
+		}
+	}
+	delete(d.treeScopes, sessionID)
+	delete(d.correlators, sessionID)
+
+	d.log.Info("session ended", "session_id", sessionID)
+}
+
+// routeEvent finds the session for a raw kernel event, runs process-tree
+// tracking, and returns the session_id + correlator. Returns ("", nil) if the
+// event belongs to no registered session.
+func (d *daemon) routeEvent(evt *kernelcapture.ProcessEvent) (string, *kernelcapture.Correlator) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Fast path: cgroup match.
+	if evt.CgroupID != 0 {
+		if sid, ok := d.cgroupIndex[evt.CgroupID]; ok {
+			scope := d.treeScopes[sid]
+			if scope != nil && scope.MatchesAndTrack(*evt) {
+				evt.SessionID = sid
+				return sid, d.correlators[sid]
+			}
+		}
+	}
+	// Slow path: walk all sessions and check process tree membership.
+	// This handles subtree events where the child has escaped to a new cgroup
+	// (uncommon but possible).
+	for sid, scope := range d.treeScopes {
+		if scope.MatchesAndTrack(*evt) {
+			evt.SessionID = sid
+			return sid, d.correlators[sid]
+		}
+	}
+	return "", nil
+}
+
+// appendKernelReceipt writes one KernelReceiptEntry as a JSONL line to
+// <evidenceDir>/<sessionID>/kernel_receipts.jsonl.
+func (d *daemon) appendKernelReceipt(sessionID string, evt kernelcapture.ProcessEvent, receipt kernelcapture.SyntheticKernelReceipt) {
+	entry := KernelReceiptEntry{
+		SchemaVersion: KernelReceiptSchema,
+		SessionID:     sessionID,
+		RecordedAt:    time.Now().UTC(),
+		Event:         evt,
+		Receipt:       receipt,
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		d.log.Warn("marshal kernel receipt entry", "session_id", sessionID, "error", err)
+		return
+	}
+	line = append(line, '\n')
+
+	dir := filepath.Join(d.evidenceDir, sanitizeSessionID(sessionID))
+	path := filepath.Join(dir, "kernel_receipts.jsonl")
+	if err := d.fs.MkdirAll(dir, 0o700); err != nil {
+		d.log.Warn("create evidence log dir", "path", dir, "error", err)
+		return
+	}
+	if err := d.fs.AppendFile(path, line, 0o600); err != nil {
+		d.log.Warn("append kernel receipt", "path", path, "error", err)
+	}
+}
+
+// processKernelEvent is called by the platform-specific event loop for each
+// event that arrives from the eBPF ringbuf.
+func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent, loss kernelcapture.CaptureLoss) {
+	sid, correlator := d.routeEvent(&evt)
+	if sid == "" || correlator == nil {
+		return
+	}
+
+	ctx := kernelcapture.EventContext{
+		CaptureLoss: loss,
+	}
+	receipt := correlator.Correlate(evt, ctx)
+
+	d.log.Debug("kernel event",
+		"session_id", sid,
+		"type", evt.Type,
+		"pid", evt.PID,
+		"comm", evt.Comm,
+		"cgroup", evt.CgroupID,
+		"correlation", receipt.CorrelationMethod+"/"+receipt.CorrelationConfidence,
+		"verdict", receipt.Verdict,
+	)
+	d.appendKernelReceipt(sid, evt, receipt)
+}
+
+// pruneExpiredSessions removes sessions that the registry has expired so the
+// cgroup index does not leak indefinitely.
+func (d *daemon) pruneExpiredSessions() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for sid, scope := range d.treeScopes {
+		if _, err := d.registry.ActiveSession(sid); err != nil {
+			if scope.CgroupID != 0 {
+				delete(d.cgroupIndex, scope.CgroupID)
+			}
+			delete(d.treeScopes, sid)
+			delete(d.correlators, sid)
+			d.log.Info("pruned expired session", "session_id", sid)
+		}
+	}
+}
+
+// sanitizeSessionID strips characters that are unsafe in filesystem paths.
+func sanitizeSessionID(id string) string {
+	var b strings.Builder
+	for _, c := range id {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' {
+			b.WriteRune(c)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// evidenceFS is the minimal filesystem interface used for writing JSONL
+// evidence log entries. Using an interface here allows test injection.
+type evidenceFS interface {
+	MkdirAll(path string, perm fs.FileMode) error
+	AppendFile(path string, data []byte, perm fs.FileMode) error
+}
+
+// osEvidenceFS is the OS-backed production implementation of evidenceFS.
+type osEvidenceFS struct{}
+
+func (osEvidenceFS) MkdirAll(path string, perm fs.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (osEvidenceFS) AppendFile(path string, data []byte, perm fs.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, perm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+func main() {
+	var (
+		socketPath  = flag.String("socket", defaultSocketPath, "Unix-domain control socket path")
+		evidenceDir = flag.String("evidence-dir", defaultEvidenceDir, "Directory for per-session kernel receipt JSONL logs")
+		stateDir    = flag.String("state-dir", defaultStateDir, "Daemon state directory")
+		noRingbuf   = flag.Bool("no-ringbuf", false, "Skip eBPF ringbuf consumer (socket control plane only)")
+		debug       = flag.Bool("debug", false, "Enable debug-level logging")
+		pruneEvery  = flag.Duration("prune-interval", 30*time.Second, "Interval to prune expired session routing entries")
+	)
+	flag.Parse()
+
+	level := slog.LevelInfo
+	if *debug {
+		level = slog.LevelDebug
+	}
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	log.Info("ardur-kernelcaptured starting",
+		"socket", *socketPath,
+		"evidence_dir", *evidenceDir,
+		"state_dir", *stateDir,
+		"no_ringbuf", *noRingbuf,
+		"platform", platformName(),
+	)
+
+	ownerUID := uint32(os.Getuid())
+	d, err := newDaemon(log, *socketPath, *evidenceDir, *stateDir, ownerUID)
+	if err != nil {
+		log.Error("init daemon", "error", err)
+		os.Exit(1)
+	}
+
+	// Ensure socket directory exists.
+	if mkErr := os.MkdirAll(filepath.Dir(*socketPath), 0o755); mkErr != nil {
+		log.Error("create socket directory", "path", filepath.Dir(*socketPath), "error", mkErr)
+		os.Exit(1)
+	}
+	// Remove stale socket file from a previous run.
+	_ = os.Remove(*socketPath)
+
+	svr, err := kernelcapture.ListenDaemonUnixSocketServer(
+		kernelcapture.DaemonUnixSocketServerConfig{
+			CustodyPlan:             d.custodyPlan,
+			PeerAuthorizationPolicy: d.peerPolicy,
+			SocketMode:              defaultSocketMode,
+			HandleAuthorizedRequest: d.handleAuthorizedRequest,
+			ObservePeerCredentials:  kernelcapture.ObserveLinuxUnixPeerCredentials,
+		},
+	)
+	if err != nil {
+		log.Error("bind control socket", "socket", *socketPath, "error", err)
+		os.Exit(1)
+	}
+	log.Info("control socket listening", "socket", svr.SocketPath())
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Control-plane goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := svr.Serve(ctx); err != nil && ctx.Err() == nil {
+			log.Error("control socket serve", "error", err)
+		}
+	}()
+
+	// Session expiry pruner.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(*pruneEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				d.pruneExpiredSessions()
+			}
+		}
+	}()
+
+	// Data-plane goroutine: eBPF ringbuf consumer (platform-specific).
+	if !*noRingbuf {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := runEBPFConsumer(ctx, d, log); err != nil && ctx.Err() == nil {
+				log.Error("eBPF consumer stopped", "error", err)
+			}
+		}()
+	} else {
+		log.Info("eBPF ringbuf consumer disabled (--no-ringbuf)")
+	}
+
+	<-ctx.Done()
+	log.Info("shutting down", "reason", ctx.Err())
+	svr.Close()
+	wg.Wait()
+	log.Info("ardur-kernelcaptured stopped")
+}

--- a/go/pkg/kernelcapture/linux_ebpf_daemon_linux.go
+++ b/go/pkg/kernelcapture/linux_ebpf_daemon_linux.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package kernelcapture
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// ProcessExecEBPFHandles holds the loaded eBPF objects and attached tracepoints
+// for the process-exec/exit capture program. Call Close to release all
+// resources.
+type ProcessExecEBPFHandles struct {
+	objs   processExecObjects
+	execTP link.Link
+	exitTP link.Link
+	reader *ringbuf.Reader
+}
+
+// Reader returns the ringbuf.Reader for consuming process lifecycle events.
+func (h *ProcessExecEBPFHandles) Reader() *ringbuf.Reader {
+	return h.reader
+}
+
+// Close releases all eBPF resources in reverse order.
+func (h *ProcessExecEBPFHandles) Close() {
+	if h == nil {
+		return
+	}
+	if h.reader != nil {
+		_ = h.reader.Close()
+	}
+	if h.exitTP != nil {
+		_ = h.exitTP.Close()
+	}
+	if h.execTP != nil {
+		_ = h.execTP.Close()
+	}
+	_ = h.objs.Close()
+}
+
+// LoadAndAttachProcessExecEBPF loads the embedded CO-RE process-exec eBPF
+// program, attaches the sched/sched_process_exec and sched/sched_process_exit
+// tracepoints, and returns a handle that owns the ringbuf reader.
+//
+// The caller must call Close on the returned handle when done.
+//
+// Claim boundary: loads and attaches only the embedded process_exec.bpf.c
+// object. Does NOT pin maps on bpffs, create/join cgroups, install/start a
+// system service, or enforce any action against observed processes.
+func LoadAndAttachProcessExecEBPF() (*ProcessExecEBPFHandles, error) {
+	h := &ProcessExecEBPFHandles{}
+
+	if err := loadProcessExecObjects(&h.objs, nil); err != nil {
+		return nil, fmt.Errorf("load process-exec eBPF objects: %w", err)
+	}
+
+	var err error
+	h.execTP, err = link.Tracepoint("sched", "sched_process_exec", h.objs.HandleSchedProcessExec, nil)
+	if err != nil {
+		h.objs.Close()
+		return nil, fmt.Errorf("attach sched/sched_process_exec: %w", err)
+	}
+
+	h.exitTP, err = link.Tracepoint("sched", "sched_process_exit", h.objs.HandleSchedProcessExit, nil)
+	if err != nil {
+		_ = h.execTP.Close()
+		_ = h.objs.Close()
+		return nil, fmt.Errorf("attach sched/sched_process_exit: %w", err)
+	}
+
+	h.reader, err = ringbuf.NewReader(h.objs.Events)
+	if err != nil {
+		_ = h.exitTP.Close()
+		_ = h.execTP.Close()
+		_ = h.objs.Close()
+		return nil, fmt.Errorf("open ringbuf reader: %w", err)
+	}
+
+	return h, nil
+}
+
+// NewRingbufProcessSourceFromRingbufReader creates a RingbufProcessSource from
+// an already-open *ringbuf.Reader. This is used by the daemon to share the
+// reader that LoadAndAttachProcessExecEBPF created, without re-opening it.
+//
+// The caller retains ownership of the reader lifecycle; Close on the returned
+// source is a no-op for the reader.
+func NewRingbufProcessSourceFromRingbufReader(r *ringbuf.Reader) *RingbufProcessSource {
+	return &RingbufProcessSource{
+		reader:  &linuxRingbufReader{reader: r},
+		closeFn: nil, // caller owns the reader; daemon closes via handles.Close()
+	}
+}
+
+// ensure ebpf package import is used (bpf2go generated code also imports it)
+var _ = (*ebpf.CollectionSpec)(nil)


### PR DESCRIPTION
## Summary

Epic A Slice 1 — the `ardur-kernelcaptured` foreground daemon binary that wires the existing `kernelcapture` library components into a runnable process.

Refs: #63 (Epic A: host-level kernel audit layer), #66 (daemon/launcher task).

### What this ships

- **`go/cmd/ardur-kernelcaptured/main.go`** — daemon struct, routing index (`cgroup_id → session_id`), JSONL evidence-log writer, flags, signal handling
- **`go/cmd/ardur-kernelcaptured/daemon_linux.go`** — eBPF consumer: `LoadAndAttachProcessExecEBPF` → tracepoints → ringbuf → `processKernelEvent`
- **`go/cmd/ardur-kernelcaptured/daemon_unsupported.go`** — non-Linux stub (logs warning, returns error; control plane still runs)
- **`go/cmd/ardur-kernelcaptured/daemon_test.go`** — unit tests for routing, session lifecycle, evidence-log append, sanitize, prune
- **`go/pkg/kernelcapture/linux_ebpf_daemon_linux.go`** — exports `ProcessExecEBPFHandles`, `LoadAndAttachProcessExecEBPF`, `NewRingbufProcessSourceFromRingbufReader`

### Runtime flow

```
start
 └── ListenDaemonUnixSocketServer (SO_PEERCRED auth, fail-closed)
      ├── register_session → cgroup_id → session_id index + ProcessTreeScope + Correlator
      ├── end_session      → remove from index
      └── session_status   → registry lookup

eBPF ringbuf (Linux only)
 └── sched_process_exec/exit → routeEvent (cgroup fast-path, PID-tree slow-path)
      └── Correlator.Correlate → SyntheticKernelReceipt
           └── JSONL append → <evidence-dir>/<session-id>/kernel_receipts.jsonl

prune goroutine (default 30s)
 └── remove routing entries for sessions expired in registry
```

The socket path (`/run/ardur/kernelcapture/control.sock`) and protocol (`kernelcapture.daemon.v1`) match `python/vibap/kernel_correlation.py` — the `ardur run` bridge (PR #81) is the counterpart producer.

### Explicitly NOT in Slice 1

- Privileged system-service install / systemd unit (Slice 2)
- cgroup creation and assignment (left to `ardur run` bridge)
- Enforcement / kill-switch actions (Slice 4)
- bpffs map pinning, socket ownership hardening, crash-recovery

### Tests

```
go test ./cmd/ardur-kernelcaptured/... ./pkg/kernelcapture/...
```

All 16 Go packages green on macOS (non-Linux path). Linux eBPF path verified in the previous session against Colima kernel 6.8 (`--privileged --pid=host`).