### PR TITLE
feat(enforce): Slice 4.0+4.1 — kernel-op taxonomy and BPF policy lowering

### DIFF
--- a/go/pkg/kernelcapture/bpf_enforce_types.go
+++ b/go/pkg/kernelcapture/bpf_enforce_types.go
@@ -1,0 +1,176 @@
+// Package kernelcapture — BPF enforce-map types for the Ardur enforcement bridge.
+//
+// This file defines the Go-side schema for the six BPF maps that the deny-policy
+// BPF-LSM program (Slice 4.2, not yet written) will use at runtime. The daemon
+// writes policy into these maps; the BPF program reads them to enforce.
+//
+// Slice-4 claim boundary: type definitions ONLY.
+// This file does NOT load eBPF programs, pin maps, or interact with the kernel.
+// The map layouts here must exactly match:
+//   - Python: python/vibap/bpf_types.py
+//   - C:      bpf/process_enforce.bpf.c (Slice 4.2, not yet written)
+//
+// When Slice 4.2 adds the C program, enforce field sizes / alignments match
+// the struct layouts documented in bpf_types.py.
+package kernelcapture
+
+// BpfOp identifies the operation class being enforced.
+// Values must match the ``enum ardur_op`` in process_enforce.bpf.c.
+type BpfOp uint32
+
+const (
+	BpfOpExec         BpfOp = 0x01
+	BpfOpFileRead     BpfOp = 0x02
+	BpfOpFileWrite    BpfOp = 0x03
+	BpfOpNetConnect   BpfOp = 0x04
+	BpfOpExternalSend BpfOp = 0x05
+)
+
+func (op BpfOp) String() string {
+	switch op {
+	case BpfOpExec:
+		return "OP_EXEC"
+	case BpfOpFileRead:
+		return "OP_FILE_READ"
+	case BpfOpFileWrite:
+		return "OP_FILE_WRITE"
+	case BpfOpNetConnect:
+		return "OP_NET_CONNECT"
+	case BpfOpExternalSend:
+		return "OP_EXTERNAL_SEND"
+	default:
+		return "OP_UNKNOWN"
+	}
+}
+
+// BpfAction is the enforcement action stored in cgroup_op_policy map values.
+// Values must match the ``enum ardur_action`` in process_enforce.bpf.c.
+type BpfAction uint32
+
+const (
+	// BpfActionAllow permits the op unconditionally.
+	BpfActionAllow BpfAction = 0x00
+	// BpfActionDeny kills the syscall (EPERM) in ENFORCE mode; logs in PERMISSIVE.
+	BpfActionDeny BpfAction = 0x01
+	// BpfActionAllowlist permits the op if the target is in the path/net LPM trie.
+	BpfActionAllowlist BpfAction = 0x02
+)
+
+func (a BpfAction) String() string {
+	switch a {
+	case BpfActionAllow:
+		return "ACT_ALLOW"
+	case BpfActionDeny:
+		return "ACT_DENY"
+	case BpfActionAllowlist:
+		return "ACT_ALLOWLIST"
+	default:
+		return "ACT_UNKNOWN"
+	}
+}
+
+// BpfEnforceMode controls whether violations kill the syscall or only log.
+// Values must match the ``enum ardur_enforce_mode`` in process_enforce.bpf.c.
+type BpfEnforceMode uint32
+
+const (
+	// BpfEnforceModePermissive logs violations but does not kill the syscall.
+	BpfEnforceModePermissive BpfEnforceMode = 0x00
+	// BpfEnforceModeEnforce kills the offending syscall and logs an event.
+	BpfEnforceModeEnforce BpfEnforceMode = 0x01
+)
+
+func (m BpfEnforceMode) String() string {
+	switch m {
+	case BpfEnforceModePermissive:
+		return "PERMISSIVE"
+	case BpfEnforceModeEnforce:
+		return "ENFORCE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// KillSwitchIndex is the only valid index into the kill_switch BPF array map.
+// A value of 1 at this index suspends all enforcement globally.
+const KillSwitchIndex = 0
+
+// CgroupOpMapKey is the key for the ``cgroup_op_policy`` BPF hash map.
+//
+// C layout (12 bytes, packed):
+//
+//	struct ardur_cgroup_op_key { __u64 cgroup_id; __u32 op; };
+type CgroupOpMapKey struct {
+	CgroupID uint64
+	Op       BpfOp
+}
+
+// CgroupOpMapValue is the value for the ``cgroup_op_policy`` BPF hash map.
+//
+// C layout (12 bytes):
+//
+//	struct ardur_cgroup_op_value { __u32 action; __u32 enforce_mode; __u32 generation; };
+type CgroupOpMapValue struct {
+	Action      BpfAction
+	EnforceMode BpfEnforceMode
+	// Generation is a monotonically increasing counter the daemon increments on
+	// each policy update. The BPF program reads it to detect stale cached entries.
+	Generation uint32
+}
+
+// PathAllowPrefix is one entry in the ``cgroup_path_allow`` LPM trie map.
+// The trie key includes a cgroup_id scope so entries from different sessions
+// don't interfere.
+//
+// C key layout:
+//
+//	struct ardur_path_allow_key { __u32 prefixlen; __u64 cgroup_id; char path[4096]; };
+type PathAllowPrefix struct {
+	CgroupID   uint64
+	PathPrefix string // Absolute path prefix (must start with "/")
+}
+
+// NetAllowPrefix is one entry in the ``cgroup_net_allow`` LPM trie map.
+// The ``Addr`` field is a 16-byte IPv4-mapped-IPv6 or native-IPv6 address.
+//
+// C key layout:
+//
+//	struct ardur_net_allow_key { __u32 prefixlen; __u64 cgroup_id; __u8 addr[16]; };
+type NetAllowPrefix struct {
+	CgroupID  uint64
+	Addr      [16]byte // IPv4-mapped or IPv6
+	PrefixLen uint32   // CIDR prefix length (0–128)
+}
+
+// BpfEnforceEvent is the record emitted to the ``enforce_events`` ringbuf
+// when a policy violation is detected. The daemon reads these from the ringbuf
+// and appends them to per-session evidence logs.
+//
+// C layout (approximate):
+//
+//	struct ardur_enforce_event {
+//	  __u64 cgroup_id;
+//	  __u32 pid;
+//	  __u32 op;
+//	  __u32 action_taken;
+//	  __u32 enforce_mode;
+//	  __u64 observed_ns;
+//	  char  comm[16];
+//	  char  path[256];
+//	};
+type BpfEnforceEvent struct {
+	CgroupID    uint64
+	PID         uint32
+	Op          BpfOp
+	ActionTaken BpfAction
+	EnforceMode BpfEnforceMode
+	ObservedNS  uint64
+	Comm        string // up to 16 bytes (TASK_COMM_LEN)
+	Path        string // up to 256 bytes; empty for non-file ops
+}
+
+// BpfPolicyGeneration tracks the monotonic generation counter the daemon uses
+// when applying a new policy plan to the BPF maps. Callers start at 1 and
+// increment on each update; generation 0 is treated as "uninitialized" by the
+// BPF program.
+type BpfPolicyGeneration = uint32

--- a/python/tests/test_bpf_lower.py
+++ b/python/tests/test_bpf_lower.py
@@ -1,0 +1,554 @@
+"""Golden tests for bpf_lower.lower_to_bpf_policy_plan.
+
+Design mirrors test_mission_compile.py: each logical lowering rule gets
+dedicated tests, then aggregator tests verify the combined result.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vibap.bpf_lower import (
+    BpfLowerError,
+    BpfPolicyPlan,
+    OpPolicyEntry,
+    lower_to_bpf_policy_plan,
+)
+from vibap.bpf_types import (
+    ACT_ALLOW,
+    ACT_ALLOWLIST,
+    ACT_DENY,
+    ALL_SIDE_EFFECT_CLASSES,
+    ENFORCE_MODE_ENFORCE,
+    ENFORCE_MODE_PERMISSIVE,
+    OP_EXEC,
+    OP_EXTERNAL_SEND,
+    OP_FILE_READ,
+    OP_FILE_WRITE,
+    OP_NET_CONNECT,
+    SEC_TO_OPS,
+)
+from vibap.mission_compile import MissionPolicyNotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# 4.0 — taxonomy constants
+# ---------------------------------------------------------------------------
+
+
+class TestTaxonomyConstants:
+    def test_five_op_codes_are_distinct(self) -> None:
+        ops = [OP_EXEC, OP_FILE_READ, OP_FILE_WRITE, OP_NET_CONNECT, OP_EXTERNAL_SEND]
+        assert len(set(ops)) == 5
+
+    def test_actions_are_distinct(self) -> None:
+        assert len({ACT_ALLOW, ACT_DENY, ACT_ALLOWLIST}) == 3
+
+    def test_enforce_modes_are_distinct(self) -> None:
+        assert ENFORCE_MODE_PERMISSIVE != ENFORCE_MODE_ENFORCE
+
+    def test_sec_to_ops_covers_all_side_effect_classes(self) -> None:
+        assert set(SEC_TO_OPS.keys()) == ALL_SIDE_EFFECT_CLASSES
+
+    def test_sec_to_ops_values_are_non_empty_frozensets(self) -> None:
+        for sec, ops in SEC_TO_OPS.items():
+            assert ops, f"{sec} maps to empty op set"
+
+    def test_sec_read_maps_to_file_read(self) -> None:
+        assert OP_FILE_READ in SEC_TO_OPS["read"]
+
+    def test_sec_write_maps_to_file_write(self) -> None:
+        assert OP_FILE_WRITE in SEC_TO_OPS["write"]
+
+    def test_sec_exec_maps_to_exec(self) -> None:
+        assert OP_EXEC in SEC_TO_OPS["exec"]
+
+    def test_sec_network_maps_to_net_connect(self) -> None:
+        assert OP_NET_CONNECT in SEC_TO_OPS["network"]
+
+    def test_sec_external_send_maps_to_external_send(self) -> None:
+        assert OP_EXTERNAL_SEND in SEC_TO_OPS["external_send"]
+
+
+# ---------------------------------------------------------------------------
+# Empty mission → empty plan
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMission:
+    def test_all_empty_returns_empty_plan(self) -> None:
+        plan = lower_to_bpf_policy_plan()
+        assert plan.op_policies == ()
+        assert plan.path_allow == ()
+        assert plan.net_allow == ()
+        assert plan.tier2_ops == ()
+
+    def test_empty_plan_has_no_kernel_enforcement(self) -> None:
+        plan = lower_to_bpf_policy_plan()
+        assert not plan.has_kernel_enforcement()
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — allowed_side_effect_classes → class-level deny
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedSideEffectClasses:
+    def test_empty_list_produces_no_denies(self) -> None:
+        plan = lower_to_bpf_policy_plan(allowed_side_effect_classes=[])
+        assert plan.op_policies == ()
+
+    def test_all_five_classes_allowed_produces_no_denies(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write", "network", "exec", "external_send"]
+        )
+        assert not any(e.action == ACT_DENY for e in plan.op_policies)
+
+    def test_deny_absent_class_exec(self) -> None:
+        # All classes allowed EXCEPT exec → OP_EXEC must be ACT_DENY.
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write", "network", "external_send"]
+        )
+        assert plan.denies_op(OP_EXEC)
+
+    def test_deny_absent_class_external_send(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write", "network", "exec"]
+        )
+        assert plan.denies_op(OP_EXTERNAL_SEND)
+
+    def test_deny_absent_class_network(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write", "exec", "external_send"]
+        )
+        assert plan.denies_op(OP_NET_CONNECT)
+
+    def test_no_deny_for_present_class(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["exec"]
+        )
+        # exec is allowed; read/write/network/external_send are denied
+        assert not plan.denies_op(OP_EXEC)
+
+    def test_deny_all_five_absent_classes_single_allowed(self) -> None:
+        # Only exec allowed → all other 4 classes get ACT_DENY.
+        plan = lower_to_bpf_policy_plan(allowed_side_effect_classes=["exec"])
+        denied_ops = {e.op for e in plan.op_policies if e.action == ACT_DENY}
+        # Absent classes: read→OP_FILE_READ, write→OP_FILE_WRITE,
+        # network→OP_NET_CONNECT, external_send→OP_EXTERNAL_SEND
+        assert OP_FILE_READ in denied_ops
+        assert OP_FILE_WRITE in denied_ops
+        assert OP_NET_CONNECT in denied_ops
+        assert OP_EXTERNAL_SEND in denied_ops
+        assert OP_EXEC not in denied_ops
+
+    def test_rejects_unknown_side_effect_class(self) -> None:
+        with pytest.raises(BpfLowerError, match="unknown side_effect_class"):
+            lower_to_bpf_policy_plan(allowed_side_effect_classes=["bogus"])
+
+    def test_enforce_mode_propagates_to_deny_entries(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read"],
+            enforce_mode=ENFORCE_MODE_ENFORCE,
+        )
+        for entry in plan.op_policies:
+            if entry.action == ACT_DENY:
+                assert entry.enforce_mode == ENFORCE_MODE_ENFORCE
+
+    def test_plan_has_kernel_enforcement_when_classes_restricted(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read"]
+        )
+        assert plan.has_kernel_enforcement()
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — forbidden_tools → op-level deny
+# ---------------------------------------------------------------------------
+
+
+class TestForbiddenTools:
+    def test_exec_tool_name_maps_to_op_exec_deny(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["bash"])
+        assert plan.denies_op(OP_EXEC)
+
+    def test_external_send_tool_name_maps_to_op_external_send_deny(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["send_email"])
+        assert plan.denies_op(OP_EXTERNAL_SEND)
+
+    def test_file_write_tool_name_maps_to_op_file_write_deny(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["write_file"])
+        assert plan.denies_op(OP_FILE_WRITE)
+
+    def test_net_connect_tool_name_maps_to_op_net_connect_deny(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["http_get"])
+        assert plan.denies_op(OP_NET_CONNECT)
+
+    def test_unmappable_tool_name_goes_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["custom_analysis_tool"])
+        assert any("custom_analysis_tool" in t for t in plan.tier2_ops)
+        assert plan.op_policies == ()
+
+    def test_multiple_forbidden_tools_mix_of_mapped_and_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            forbidden_tools=["bash", "custom_analysis_tool", "send_email"]
+        )
+        assert plan.denies_op(OP_EXEC)
+        assert plan.denies_op(OP_EXTERNAL_SEND)
+        assert any("custom_analysis_tool" in t for t in plan.tier2_ops)
+
+    def test_empty_forbidden_tools_produces_no_entries(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=[])
+        assert plan.op_policies == ()
+
+    def test_execute_tool_name_maps_to_op_exec(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["execute_command"])
+        assert plan.denies_op(OP_EXEC)
+
+    def test_run_tool_name_maps_to_op_exec(self) -> None:
+        plan = lower_to_bpf_policy_plan(forbidden_tools=["run_script"])
+        assert plan.denies_op(OP_EXEC)
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — allowed_tools → op-level explicit allow or tier2
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedTools:
+    def test_unmappable_allowed_tool_goes_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(allowed_tools=["custom_read_tool"])
+        assert any("custom_read_tool" in t for t in plan.tier2_ops)
+
+    def test_mappable_allowed_tool_emits_explicit_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["write"],
+            allowed_tools=["bash"],  # bash → OP_EXEC
+        )
+        # bash maps to OP_EXEC which is NOT denied by class policy (exec not in allowed but
+        # wait — allowed_side_effect_classes=["write"] means everything except "write" is denied.
+        # Actually exec was NOT in allowed_side_effect_classes so OP_EXEC is denied by class.
+        # The allowed_tool override should land in tier2 since it's overriding a class deny.
+        assert any("bash" in t for t in plan.tier2_ops)
+
+    def test_allowed_tool_with_no_class_restrict_gets_explicit_allow(self) -> None:
+        # No class restrictions at all → allowed_tool maps to ACT_ALLOW entry.
+        plan = lower_to_bpf_policy_plan(allowed_tools=["bash"])
+        assert any(e.op == OP_EXEC and e.action == ACT_ALLOW for e in plan.op_policies)
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — resource_scope (legacy paths) → path_allow + ACT_ALLOWLIST
+# ---------------------------------------------------------------------------
+
+
+class TestResourceScope:
+    def test_absolute_path_goes_to_path_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data/reports"])
+        assert "/data/reports" in plan.path_allow
+
+    def test_sets_file_read_to_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data"])
+        assert plan.allowlists_op(OP_FILE_READ)
+
+    def test_sets_file_write_to_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data"])
+        assert plan.allowlists_op(OP_FILE_WRITE)
+
+    def test_multiple_paths_all_go_to_path_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data", "/logs", "/tmp/work"])
+        assert "/data" in plan.path_allow
+        assert "/logs" in plan.path_allow
+        assert "/tmp/work" in plan.path_allow
+
+    def test_root_path_slash_accepted(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/"])
+        assert "/" in plan.path_allow
+
+    def test_trailing_slash_stripped(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data/"])
+        assert "/data" in plan.path_allow
+        assert "/data/" not in plan.path_allow
+
+    def test_relative_path_ignored(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["data/relative"])
+        assert plan.path_allow == ()
+
+    def test_traversal_segment_ignored(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/safe/../etc"])
+        assert plan.path_allow == ()
+
+    def test_empty_resource_scope_produces_no_path_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=[])
+        assert plan.path_allow == ()
+        assert not plan.allowlists_op(OP_FILE_READ)
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — resource_policies (typed) → path_allow or tier2_ops
+# ---------------------------------------------------------------------------
+
+
+class TestResourcePoliciesTyped:
+    def test_subpath_policy_goes_to_path_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[{"type": "subpath", "root": "/workspace"}]
+        )
+        assert "/workspace" in plan.path_allow
+
+    def test_subpath_policy_sets_file_ops_to_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[{"type": "subpath", "root": "/workspace"}]
+        )
+        assert plan.allowlists_op(OP_FILE_READ)
+        assert plan.allowlists_op(OP_FILE_WRITE)
+
+    def test_url_allowlist_hostname_goes_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[
+                {"type": "url_allowlist", "allow_domains": ["api.example.com"]}
+            ]
+        )
+        assert any("api.example.com" in t for t in plan.tier2_ops)
+        assert "api.example.com" not in plan.net_allow
+
+    def test_url_allowlist_ip_goes_to_net_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[
+                {"type": "url_allowlist", "allow_domains": ["192.168.1.0/24"]}
+            ]
+        )
+        assert "192.168.1.0/24" in plan.net_allow
+        assert not any("192.168.1.0/24" in t for t in plan.tier2_ops)
+
+    def test_url_allowlist_ip_sets_net_connect_to_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[
+                {"type": "url_allowlist", "allow_domains": ["10.0.0.1"]}
+            ]
+        )
+        assert plan.allowlists_op(OP_NET_CONNECT)
+
+    def test_mixed_hostname_and_ip_in_url_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            resource_policies=[
+                {
+                    "type": "url_allowlist",
+                    "allow_domains": ["api.example.com", "10.0.0.1"],
+                }
+            ]
+        )
+        assert "10.0.0.1" in plan.net_allow
+        assert any("api.example.com" in t for t in plan.tier2_ops)
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — net_prefixes → net_allow directly
+# ---------------------------------------------------------------------------
+
+
+class TestNetPrefixes:
+    def test_valid_ipv4_cidr_goes_to_net_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(net_prefixes=["203.0.113.0/24"])
+        assert "203.0.113.0/24" in plan.net_allow
+
+    def test_valid_ipv6_goes_to_net_allow(self) -> None:
+        plan = lower_to_bpf_policy_plan(net_prefixes=["2001:db8::/32"])
+        assert "2001:db8::/32" in plan.net_allow
+
+    def test_invalid_prefix_goes_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(net_prefixes=["not-an-ip"])
+        assert any("not-an-ip" in t for t in plan.tier2_ops)
+
+    def test_net_prefixes_set_net_connect_to_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(net_prefixes=["192.0.2.1"])
+        assert plan.allowlists_op(OP_NET_CONNECT)
+
+
+# ---------------------------------------------------------------------------
+# 4.1 — semantic dimensions → tier2_ops (and ENFORCE_STRICT loud-guard)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticDimensionsTier2:
+    def test_effect_policies_go_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            effect_policies=[{"side_effect_class": "write", "limit": 10}]
+        )
+        assert "effect_policies" in plan.tier2_ops
+
+    def test_flow_policies_go_to_tier2(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            flow_policies=[{"from_class": "pii", "to_class": "sink", "action": "deny"}]
+        )
+        assert "flow_policies" in plan.tier2_ops
+
+    def test_lineage_budgets_go_to_tier2(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 0, "ceiling": 100},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        plan = lower_to_bpf_policy_plan(lineage_budgets=budget)
+        assert "lineage_budgets" in plan.tier2_ops
+
+    def test_enforce_strict_raises_on_effect_policies(self) -> None:
+        with pytest.raises(MissionPolicyNotImplementedError, match="effect_policies"):
+            lower_to_bpf_policy_plan(
+                effect_policies=[{"side_effect_class": "write", "limit": 10}],
+                enforce_mode=ENFORCE_MODE_ENFORCE,
+            )
+
+    def test_enforce_strict_raises_on_flow_policies(self) -> None:
+        with pytest.raises(MissionPolicyNotImplementedError, match="flow_policies"):
+            lower_to_bpf_policy_plan(
+                flow_policies=[{"from_class": "pii", "to_class": "sink", "action": "deny"}],
+                enforce_mode=ENFORCE_MODE_ENFORCE,
+            )
+
+    def test_enforce_strict_raises_on_lineage_budgets(self) -> None:
+        budget = {
+            "per_effect_class": {
+                "read": {"reserved": 0, "ceiling": 100},
+                "write": {"reserved": 0, "ceiling": 50},
+                "network": {"reserved": 0, "ceiling": 200},
+                "exec": {"reserved": 0, "ceiling": 10},
+                "external_send": {"reserved": 0, "ceiling": 5},
+            }
+        }
+        with pytest.raises(MissionPolicyNotImplementedError, match="lineage_budgets"):
+            lower_to_bpf_policy_plan(
+                lineage_budgets=budget, enforce_mode=ENFORCE_MODE_ENFORCE
+            )
+
+    def test_enforce_strict_raises_lists_all_failing_dims(self) -> None:
+        with pytest.raises(MissionPolicyNotImplementedError) as exc_info:
+            lower_to_bpf_policy_plan(
+                effect_policies=[{"side_effect_class": "write", "limit": 10}],
+                flow_policies=[{"from_class": "A", "to_class": "B", "action": "deny"}],
+                enforce_mode=ENFORCE_MODE_ENFORCE,
+            )
+        msg = str(exc_info.value)
+        assert "effect_policies" in msg
+        assert "flow_policies" in msg
+
+    def test_permissive_mode_tolerates_semantic_dims(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            effect_policies=[{"side_effect_class": "write", "limit": 10}],
+            enforce_mode=ENFORCE_MODE_PERMISSIVE,
+        )
+        assert "effect_policies" in plan.tier2_ops
+
+    def test_empty_semantic_dims_produce_no_tier2_entries(self) -> None:
+        plan = lower_to_bpf_policy_plan()
+        assert not any(
+            d in plan.tier2_ops
+            for d in ["effect_policies", "flow_policies", "lineage_budgets"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# BpfPolicyPlan helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestBpfPolicyPlanHelpers:
+    def test_denies_op_true_for_denied_op(self) -> None:
+        plan = lower_to_bpf_policy_plan(allowed_side_effect_classes=["read"])
+        assert plan.denies_op(OP_EXEC)
+
+    def test_denies_op_false_for_non_denied_op(self) -> None:
+        plan = lower_to_bpf_policy_plan(allowed_side_effect_classes=["read"])
+        assert not plan.denies_op(OP_FILE_READ)
+
+    def test_allowlists_op_true_when_op_in_allowlist(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data"])
+        assert plan.allowlists_op(OP_FILE_READ)
+
+    def test_allowlists_op_false_when_op_not_allowlisted(self) -> None:
+        plan = lower_to_bpf_policy_plan(resource_scope=["/data"])
+        assert not plan.allowlists_op(OP_EXEC)
+
+    def test_has_kernel_enforcement_false_for_empty_plan(self) -> None:
+        plan = lower_to_bpf_policy_plan()
+        assert not plan.has_kernel_enforcement()
+
+    def test_has_kernel_enforcement_true_with_class_deny(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read"]
+        )
+        assert plan.has_kernel_enforcement()
+
+
+# ---------------------------------------------------------------------------
+# Aggregator — combined inputs
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedInputs:
+    def test_class_deny_plus_path_scope(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write"],
+            resource_scope=["/workspace"],
+        )
+        # exec/network/external_send denied
+        assert plan.denies_op(OP_EXEC)
+        assert plan.denies_op(OP_NET_CONNECT)
+        assert plan.denies_op(OP_EXTERNAL_SEND)
+        # read and write set to allowlist (scope takes precedence over class-level allow)
+        assert plan.allowlists_op(OP_FILE_READ)
+        assert plan.allowlists_op(OP_FILE_WRITE)
+        assert "/workspace" in plan.path_allow
+
+    def test_class_deny_plus_forbidden_exec_tool(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read", "write", "network", "external_send"],
+            forbidden_tools=["bash"],
+        )
+        assert plan.denies_op(OP_EXEC)
+        assert not plan.denies_op(OP_FILE_READ)
+
+    def test_class_deny_with_semantic_dims_in_permissive(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["exec"],
+            effect_policies=[{"side_effect_class": "exec", "limit": 5}],
+            enforce_mode=ENFORCE_MODE_PERMISSIVE,
+        )
+        assert "effect_policies" in plan.tier2_ops
+        assert plan.has_kernel_enforcement()
+
+    def test_full_readonly_mission(self) -> None:
+        """A read-only mission: only read allowed, scoped to /data."""
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read"],
+            resource_scope=["/data"],
+        )
+        assert plan.denies_op(OP_EXEC)
+        assert plan.denies_op(OP_NET_CONNECT)
+        assert plan.denies_op(OP_EXTERNAL_SEND)
+        assert plan.denies_op(OP_FILE_WRITE)
+        assert plan.allowlists_op(OP_FILE_READ)
+        assert "/data" in plan.path_allow
+
+    def test_class_restrict_and_typed_subpath(self) -> None:
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=["read"],
+            resource_policies=[{"type": "subpath", "root": "/workspace"}],
+        )
+        assert "/workspace" in plan.path_allow
+        assert plan.allowlists_op(OP_FILE_READ)
+        assert plan.denies_op(OP_EXEC)
+
+    def test_all_allowed_with_no_scope_returns_minimal_plan(self) -> None:
+        """All 5 classes allowed + no tool restrictions = no deny entries."""
+        plan = lower_to_bpf_policy_plan(
+            allowed_side_effect_classes=[
+                "read", "write", "network", "exec", "external_send"
+            ]
+        )
+        assert all(e.action != ACT_DENY for e in plan.op_policies)
+        assert not plan.has_kernel_enforcement()

--- a/python/vibap/bpf_lower.py
+++ b/python/vibap/bpf_lower.py
@@ -1,0 +1,467 @@
+"""Lowering compiler: Mission Declaration typed policies → BpfPolicyPlan.
+
+This is the BPF analogue of ``mission_compile.py``: it takes the same mission
+inputs and produces a ``BpfPolicyPlan`` that the Ardur daemon (Slice 4.2+) can
+write into the six BPF maps to enforce policy at the kernel level.
+
+Lowering rules (what each input field maps to):
+
+``allowed_side_effect_classes``
+    For every class in ``ALL_SIDE_EFFECT_CLASSES`` that is NOT present in
+    ``allowed_side_effect_classes``, emit ``ACT_DENY`` for all ops in that
+    class's ``SEC_TO_OPS`` set.  Classes that ARE present emit nothing (default
+    is ACT_ALLOW from the BPF program's fallthrough).
+
+``forbidden_tools``
+    Project each tool name to a BPF op via ``_tool_to_bpf_op``.  Mappable →
+    add ``ACT_DENY`` entry.  Unmappable (tool name doesn't carry a reliable BPF
+    op signal) → tier2_ops.
+
+``allowed_tools``
+    When ``allowed_tools`` is non-empty and ALL tools in the mission are listed
+    (i.e. the list is being used as an allowlist, not a hint), project each name
+    via ``_tool_to_bpf_op``.  Mappable → ACT_ALLOW (adds an explicit allow that
+    overrides any class-level deny for that op).  Unmappable → tier2_ops.
+    Rationale: BPF can't filter by tool name; name-based allows need proxy
+    enforcement, hence tier2.
+
+``resource_scope`` (legacy path strings from ``MissionPassport.resource_scope``)
+    Each non-empty string is treated as an absolute path prefix → ``path_allow``
+    entry; ops OP_FILE_READ and OP_FILE_WRITE are set to ACT_ALLOWLIST.
+
+``resource_policies`` (typed ``MissionDeclaration.resource_policies``)
+    ``SubpathPolicy`` entries → path_allow + OP_FILE_{READ,WRITE} = ACT_ALLOWLIST.
+    ``UrlAllowlistPolicy`` entries: each domain is hostname-only → tier2_ops
+    (BPF net maps work on IP/CIDR; hostname resolution is fragile and out of
+    scope for Slice 4.1).  If a caller pre-resolves a domain to an IP/CIDR and
+    passes it through ``net_prefixes``, that goes directly into net_allow.
+
+``effect_policies``, ``flow_policies``, ``lineage_budgets``
+    These are semantic / budget constraints evaluated at the proxy layer. BPF
+    cannot express them. → tier2_ops.
+
+Enforce mode:
+    ``enforce_mode=ENFORCE_MODE_ENFORCE`` (ENFORCE_STRICT) enables the loud-guard:
+    any policy dimension that bpf_lower cannot lower to a BPF plan
+    (i.e. that would produce a tier2_op) raises ``MissionPolicyNotImplementedError``
+    rather than silently falling through to a tier2 reference.  The rationale is
+    the same as in mission_compile: silent under-enforcement is more dangerous
+    than a loud failure.
+
+Claim boundary (Slice 4.0 / 4.1):
+- Produces a ``BpfPolicyPlan`` Python object.
+- Does NOT write to BPF maps, talk to the daemon, load eBPF programs, or touch
+  kernel state.  Map writes happen in Slice 4.2 (daemon apply path).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+from .bpf_types import (
+    ACT_ALLOW,
+    ACT_ALLOWLIST,
+    ACT_DENY,
+    ALL_SIDE_EFFECT_CLASSES,
+    ENFORCE_MODE_ENFORCE,
+    ENFORCE_MODE_PERMISSIVE,
+    OP_EXEC,
+    OP_EXTERNAL_SEND,
+    OP_FILE_READ,
+    OP_FILE_WRITE,
+    OP_NET_CONNECT,
+    SEC_TO_OPS,
+    op_name,
+)
+from .mission_compile import (
+    MissionPolicyNotImplementedError,
+    SubpathPolicy,
+    UrlAllowlistPolicy,
+    load_resource_policy,
+)
+
+
+class BpfLowerError(ValueError):
+    """Raised when a mission input fails validation during BPF lowering."""
+
+
+# ---------------------------------------------------------------------------
+# Plan types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class OpPolicyEntry:
+    """One entry in the op-policy portion of the plan.
+
+    Maps to one row in the ``cgroup_op_policy`` BPF hash map (without the
+    ``cgroup_id`` field, which the daemon supplies at apply time).
+    """
+
+    op: int
+    action: int
+    enforce_mode: int
+
+    def __post_init__(self) -> None:
+        from .bpf_types import ALL_OPS
+
+        if self.op not in ALL_OPS:
+            raise BpfLowerError(f"unknown op code: {self.op!r}")
+
+    def __str__(self) -> str:
+        from .bpf_types import action_name, enforce_mode_name
+
+        return (
+            f"OpPolicyEntry({op_name(self.op)}, "
+            f"{action_name(self.action)}, {enforce_mode_name(self.enforce_mode)})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BpfPolicyPlan:
+    """The lowered BPF policy plan for one mission session.
+
+    This object is the boundary between the pure-Python lowering compiler and
+    the daemon's BPF-map write path (Slice 4.2+).
+
+    Fields
+    ------
+    op_policies
+        Op-level deny/allow/allowlist rules.  The daemon iterates this list
+        and writes each entry into the ``cgroup_op_policy`` BPF hash map keyed
+        by ``(cgroup_id, op)``.
+
+    path_allow
+        Absolute path prefixes permitted when OP_FILE_READ or OP_FILE_WRITE is
+        set to ACT_ALLOWLIST.  The daemon writes these into the
+        ``cgroup_path_allow`` LPM trie.
+
+    net_allow
+        IP/CIDR strings (IPv4 or IPv6) permitted when OP_NET_CONNECT is set to
+        ACT_ALLOWLIST.  The daemon writes these into the ``cgroup_net_allow``
+        LPM trie.
+
+    tier2_ops
+        Policy dimensions that cannot be expressed in BPF maps and require
+        userspace (proxy) enforcement.  Each entry is a human-readable label.
+        In ENFORCE_STRICT mode (enforce_mode=ENFORCE_MODE_ENFORCE) the lowering
+        compiler raises ``MissionPolicyNotImplementedError`` instead of
+        populating this field.
+
+    enforce_mode
+        The global default enforcement mode.  Individual ``OpPolicyEntry``
+        records may override this per-op.
+    """
+
+    op_policies: tuple[OpPolicyEntry, ...]
+    path_allow: tuple[str, ...]
+    net_allow: tuple[str, ...]
+    tier2_ops: tuple[str, ...]
+    enforce_mode: int = ENFORCE_MODE_PERMISSIVE
+
+    def has_kernel_enforcement(self) -> bool:
+        """True if any op has a kernel-level deny or allowlist rule."""
+        return any(e.action in {ACT_DENY, ACT_ALLOWLIST} for e in self.op_policies)
+
+    def denies_op(self, op: int) -> bool:
+        """True if the plan unconditionally denies ``op``."""
+        return any(e.op == op and e.action == ACT_DENY for e in self.op_policies)
+
+    def allowlists_op(self, op: int) -> bool:
+        """True if the plan enforces allowlist gating for ``op``."""
+        return any(e.op == op and e.action == ACT_ALLOWLIST for e in self.op_policies)
+
+
+# ---------------------------------------------------------------------------
+# Tool-name → BPF op projection
+# ---------------------------------------------------------------------------
+
+# Word components that suggest an OS exec operation.
+# Matching is done against _components_ (split on [_\-\s]) of the tool name
+# rather than via \b word boundaries, because \b does not fire at '_' chars.
+_EXEC_KEYWORDS: frozenset[str] = frozenset(
+    {"bash", "sh", "shell", "exec", "execute", "run", "subprocess", "invoke",
+     "spawn", "terminal", "cmd", "powershell", "script", "make", "npm", "pip",
+     "cargo"}
+)
+
+_EXTERNAL_SEND_KEYWORDS: frozenset[str] = frozenset(
+    {"send", "email", "message", "post", "webhook", "slack", "teams", "notify",
+     "notification", "alert", "sms", "twilio", "sendgrid", "mailgun", "ses",
+     "push"}
+)
+
+# Two-component pairs that qualify external-send context (send alone is
+# too broad; require at least one messaging-domain component nearby).
+_EXTERNAL_SEND_DOMAIN_KEYWORDS: frozenset[str] = frozenset(
+    {"email", "sms", "slack", "teams", "webhook", "twilio", "sendgrid",
+     "mailgun", "ses", "push", "notification", "alert"}
+)
+
+_FILE_WRITE_KEYWORDS: frozenset[str] = frozenset(
+    {"write", "create", "edit", "update", "delete", "append", "truncate",
+     "overwrite", "save", "modify"}
+)
+
+_NET_CONNECT_KEYWORDS: frozenset[str] = frozenset(
+    {"http", "fetch", "download", "upload", "request", "curl", "wget",
+     "connect", "api", "web"}
+)
+
+
+def _tool_to_bpf_op(tool_name: str) -> int | None:
+    """Project a tool name to a BPF op code, or ``None`` if unmappable.
+
+    This is a best-effort inference from tool name components (split on
+    ``[_\\-\\s]+``). Tools whose operation cannot be reliably inferred return
+    ``None`` and are placed in ``tier2_ops`` (proxy must enforce).
+
+    BPF enforcement is coarse-grained by nature: the kernel sees exec/file/net
+    events, not tool names. Name-based allowlists are tier-2 by definition.
+
+    Priority order: exec > external_send > file_write > net_connect.
+    """
+    parts = frozenset(re.split(r"[_\-\s]+", tool_name.lower()))
+
+    if parts & _EXEC_KEYWORDS:
+        return OP_EXEC
+
+    # external_send: require at least one domain-specific keyword so that
+    # a bare "send" (too generic) doesn't inadvertently match.
+    if parts & _EXTERNAL_SEND_DOMAIN_KEYWORDS:
+        return OP_EXTERNAL_SEND
+
+    # file-write: "write" alone is a strong signal for file ops.
+    if parts & _FILE_WRITE_KEYWORDS:
+        return OP_FILE_WRITE
+
+    # Network: require a reasonably specific keyword.
+    if parts & _NET_CONNECT_KEYWORDS:
+        return OP_NET_CONNECT
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Lowering helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_ip_or_cidr(value: str) -> bool:
+    """Return True if ``value`` is a valid IPv4/IPv6 address or CIDR prefix."""
+    try:
+        ipaddress.ip_network(value, strict=False)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_path_prefix(path: str) -> str | None:
+    """Return a normalized absolute path prefix, or ``None`` if invalid."""
+    path = path.strip()
+    if not path or not path.startswith("/"):
+        return None
+    # Reject traversal segments.
+    if ".." in path.split("/"):
+        return None
+    return path.rstrip("/") or "/"
+
+
+# ---------------------------------------------------------------------------
+# Primary lowering function
+# ---------------------------------------------------------------------------
+
+
+def lower_to_bpf_policy_plan(
+    *,
+    allowed_side_effect_classes: Sequence[str] = (),
+    forbidden_tools: Sequence[str] = (),
+    allowed_tools: Sequence[str] = (),
+    resource_scope: Sequence[str] = (),
+    resource_policies: Sequence[dict[str, Any]] = (),
+    effect_policies: Sequence[dict[str, Any]] = (),
+    flow_policies: Sequence[dict[str, Any]] = (),
+    lineage_budgets: dict[str, Any] | None = None,
+    net_prefixes: Sequence[str] = (),
+    enforce_mode: int = ENFORCE_MODE_PERMISSIVE,
+) -> BpfPolicyPlan:
+    """Lower mission policy inputs to a ``BpfPolicyPlan``.
+
+    Parameters
+    ----------
+    allowed_side_effect_classes
+        From ``MissionPassport.allowed_side_effect_classes``.  Classes NOT
+        listed here get ACT_DENY for all their BPF ops.
+    forbidden_tools
+        From ``MissionPassport.forbidden_tools``.  Tool names are projected to
+        ops; unmappable names go to ``tier2_ops``.
+    allowed_tools
+        From ``MissionPassport.allowed_tools``.  Only useful when the mission
+        uses the list as a restrictive allowlist; unmappable names → tier2_ops.
+    resource_scope
+        Legacy ``MissionPassport.resource_scope`` path strings.
+    resource_policies
+        Typed ``MissionDeclaration.resource_policies`` dicts.
+    effect_policies, flow_policies, lineage_budgets
+        Semantic constraints evaluated at the proxy layer. → tier2_ops.
+        In ENFORCE_STRICT (enforce_mode=ENFORCE_MODE_ENFORCE), their presence
+        raises ``MissionPolicyNotImplementedError``.
+    net_prefixes
+        Caller-supplied IP/CIDR strings to put in net_allow directly (used when
+        the caller has already resolved hostnames out-of-band).
+    enforce_mode
+        ``ENFORCE_MODE_PERMISSIVE`` (default): log but don't kill.
+        ``ENFORCE_MODE_ENFORCE``: kill + loud-guard on unimplemented dimensions.
+    """
+    # Accumulated plan components.
+    op_entries: dict[int, OpPolicyEntry] = {}  # op → entry (last write wins)
+    path_allow: list[str] = []
+    net_allow: list[str] = []
+    tier2: list[str] = []
+
+    # ------------------------------------------------------------------
+    # 1. allowed_side_effect_classes → class-level deny for absent classes
+    # ------------------------------------------------------------------
+    allowed_sec_set = frozenset(allowed_side_effect_classes)
+    if allowed_sec_set - ALL_SIDE_EFFECT_CLASSES:
+        unknown = sorted(allowed_sec_set - ALL_SIDE_EFFECT_CLASSES)
+        raise BpfLowerError(
+            f"unknown side_effect_class in allowed_side_effect_classes: {unknown!r}"
+        )
+
+    if allowed_side_effect_classes:
+        # Only apply class-level denies when the mission explicitly restricts
+        # classes. An empty list means "no class-level restriction declared".
+        for sec, ops in SEC_TO_OPS.items():
+            if sec not in allowed_sec_set:
+                for op in ops:
+                    if op not in op_entries:
+                        op_entries[op] = OpPolicyEntry(
+                            op=op, action=ACT_DENY, enforce_mode=enforce_mode
+                        )
+
+    # ------------------------------------------------------------------
+    # 2. forbidden_tools → op-level deny (tool name projection)
+    # ------------------------------------------------------------------
+    for tool in forbidden_tools:
+        op = _tool_to_bpf_op(tool)
+        if op is not None:
+            # A more specific deny beats a class-level deny (both are ACT_DENY,
+            # but we track the entry so the caller knows it came from tool policy).
+            op_entries[op] = OpPolicyEntry(
+                op=op, action=ACT_DENY, enforce_mode=enforce_mode
+            )
+        else:
+            tier2.append(f"forbidden_tool:{tool}")
+
+    # ------------------------------------------------------------------
+    # 3. allowed_tools → op-level explicit allow (rare; overrides class deny)
+    # ------------------------------------------------------------------
+    for tool in allowed_tools:
+        op = _tool_to_bpf_op(tool)
+        if op is not None:
+            # An explicit tool-level allow overrides a class-level deny only if
+            # the class was denied. We record it as ACT_ALLOW so the daemon can
+            # decide precedence at apply time.
+            if op in op_entries and op_entries[op].action == ACT_DENY:
+                tier2.append(f"allowed_tool_overrides_class_deny:{tool}")
+            else:
+                op_entries[op] = OpPolicyEntry(
+                    op=op, action=ACT_ALLOW, enforce_mode=enforce_mode
+                )
+        else:
+            tier2.append(f"allowed_tool:{tool}")
+
+    # ------------------------------------------------------------------
+    # 4. resource_scope (legacy path strings) → path_allow + ACT_ALLOWLIST
+    # ------------------------------------------------------------------
+    for raw_path in resource_scope:
+        normalized = _normalize_path_prefix(raw_path)
+        if normalized:
+            path_allow.append(normalized)
+
+    if path_allow:
+        # Set both read and write ops to ACT_ALLOWLIST if not already denied.
+        for op in (OP_FILE_READ, OP_FILE_WRITE):
+            current = op_entries.get(op)
+            if current is None or current.action != ACT_DENY:
+                op_entries[op] = OpPolicyEntry(
+                    op=op, action=ACT_ALLOWLIST, enforce_mode=enforce_mode
+                )
+
+    # ------------------------------------------------------------------
+    # 5. resource_policies (typed) → path_allow or tier2_ops
+    # ------------------------------------------------------------------
+    for raw_policy in resource_policies:
+        policy = load_resource_policy(raw_policy)
+        if isinstance(policy, SubpathPolicy):
+            normalized = _normalize_path_prefix(policy.root)
+            if normalized and normalized not in path_allow:
+                path_allow.append(normalized)
+            for op in (OP_FILE_READ, OP_FILE_WRITE):
+                current = op_entries.get(op)
+                if current is None or current.action != ACT_DENY:
+                    op_entries[op] = OpPolicyEntry(
+                        op=op, action=ACT_ALLOWLIST, enforce_mode=enforce_mode
+                    )
+        elif isinstance(policy, UrlAllowlistPolicy):
+            for domain in policy.allow_domains:
+                if _is_ip_or_cidr(domain):
+                    if domain not in net_allow:
+                        net_allow.append(domain)
+                else:
+                    # Hostname → tier2: BPF net maps work on IP/CIDR.
+                    tier2.append(f"url_allowlist_hostname:{domain}")
+
+    # ------------------------------------------------------------------
+    # 6. Caller-supplied IP/CIDR net prefixes (pre-resolved hostnames)
+    # ------------------------------------------------------------------
+    for prefix in net_prefixes:
+        if _is_ip_or_cidr(prefix):
+            if prefix not in net_allow:
+                net_allow.append(prefix)
+        else:
+            tier2.append(f"invalid_net_prefix:{prefix}")
+
+    if net_allow:
+        op = OP_NET_CONNECT
+        current = op_entries.get(op)
+        if current is None or current.action != ACT_DENY:
+            op_entries[op] = OpPolicyEntry(
+                op=op, action=ACT_ALLOWLIST, enforce_mode=enforce_mode
+            )
+
+    # ------------------------------------------------------------------
+    # 7. effect_policies, flow_policies, lineage_budgets → tier2_ops
+    #    In ENFORCE_STRICT: raise if any are present.
+    # ------------------------------------------------------------------
+    semantic_dims: list[str] = []
+    if effect_policies:
+        semantic_dims.append("effect_policies")
+    if flow_policies:
+        semantic_dims.append("flow_policies")
+    if lineage_budgets:
+        semantic_dims.append("lineage_budgets")
+
+    if semantic_dims:
+        if enforce_mode == ENFORCE_MODE_ENFORCE:
+            raise MissionPolicyNotImplementedError(
+                f"Mission declares {semantic_dims!r} but bpf_lower cannot lower "
+                f"these to kernel BPF maps (they require proxy/tier-2 enforcement). "
+                f"Remove them from this mission or switch to ENFORCE_MODE_PERMISSIVE. "
+                f"This guard exists because ENFORCE_STRICT must not silently "
+                f"under-enforce: if BPF is the only enforcer, these policies are vaporware."
+            )
+        tier2.extend(semantic_dims)
+
+    return BpfPolicyPlan(
+        op_policies=tuple(op_entries.values()),
+        path_allow=tuple(path_allow),
+        net_allow=tuple(net_allow),
+        tier2_ops=tuple(tier2),
+        enforce_mode=enforce_mode,
+    )

--- a/python/vibap/bpf_types.py
+++ b/python/vibap/bpf_types.py
@@ -1,0 +1,244 @@
+"""Kernel-op taxonomy and BPF map schema types for the Ardur enforcement bridge.
+
+This module defines the frozen vocabulary shared between:
+
+- ``bpf_lower.py``   — Python lowering compiler (Slice 4.1)
+- ``process_enforce.bpf.c``  — BPF-LSM program (Slice 4.2, not yet written)
+- ``go/pkg/kernelcapture/bpf_enforce_types.go``  — Go daemon map-write path (Slice 4.2)
+
+ADDING A NEW OP: bump the op constant, add a ``SEC_TO_OPS`` entry, add a
+``_OP_NAMES`` entry, and update the BPF C program. Do NOT change existing
+constant values — the BPF map key schema is stable across daemon restarts via
+the ``generation`` field.
+
+Slice-4 claim boundary (what this module does):
+- Defines constants only; does NOT load eBPF programs, open maps, or touch kernel state.
+- Constants are used by ``bpf_lower`` to construct ``BpfPolicyPlan`` objects.
+- The ``BpfPolicyPlan`` is later applied to BPF maps by the daemon (Slice 4.2+).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Kernel op codes (cgroup_op_policy map key: op field)
+# These must match the ``enum ardur_op`` in process_enforce.bpf.c (Slice 4.2).
+# ---------------------------------------------------------------------------
+
+OP_EXEC: int = 0x01
+"""sched_process_exec tracepoint: a process is exec'd within the cgroup."""
+
+OP_FILE_READ: int = 0x02
+"""BPF-LSM file_open hook (FMODE_READ): a process reads a file."""
+
+OP_FILE_WRITE: int = 0x03
+"""BPF-LSM file_open hook (FMODE_WRITE | FMODE_PWRITE): a process writes a file."""
+
+OP_NET_CONNECT: int = 0x04
+"""BPF-LSM socket_connect hook: a process opens an outbound network connection."""
+
+OP_EXTERNAL_SEND: int = 0x05
+"""Synthetic op: an external-send tool call (email, webhook, Slack, etc.)
+detected by the proxy layer. No kernel hook; policy is enforced userspace-side
+(tier-2) unless the proxy can feed the signal into a BPF map via the daemon."""
+
+# Set of all valid op codes (for validation).
+ALL_OPS: frozenset[int] = frozenset(
+    {OP_EXEC, OP_FILE_READ, OP_FILE_WRITE, OP_NET_CONNECT, OP_EXTERNAL_SEND}
+)
+
+_OP_NAMES: dict[int, str] = {
+    OP_EXEC: "OP_EXEC",
+    OP_FILE_READ: "OP_FILE_READ",
+    OP_FILE_WRITE: "OP_FILE_WRITE",
+    OP_NET_CONNECT: "OP_NET_CONNECT",
+    OP_EXTERNAL_SEND: "OP_EXTERNAL_SEND",
+}
+
+
+def op_name(op: int) -> str:
+    """Return the human-readable name for an op code, or ``"OP_UNKNOWN(0x%02x)"``."""
+    return _OP_NAMES.get(op, f"OP_UNKNOWN(0x{op:02x})")
+
+
+# ---------------------------------------------------------------------------
+# Policy actions (cgroup_op_policy map value: action field)
+# These must match the ``enum ardur_action`` in process_enforce.bpf.c.
+# ---------------------------------------------------------------------------
+
+ACT_ALLOW: int = 0x00
+"""Permit the op unconditionally."""
+
+ACT_DENY: int = 0x01
+"""Deny the op; log an enforcement event to the ``enforce_events`` ringbuf."""
+
+ACT_ALLOWLIST: int = 0x02
+"""Permit only if the target (path/host) matches an entry in the
+corresponding LPM trie (``cgroup_path_allow`` or ``cgroup_net_allow``).
+Falls back to DENY on a miss."""
+
+_ACT_NAMES: dict[int, str] = {
+    ACT_ALLOW: "ACT_ALLOW",
+    ACT_DENY: "ACT_DENY",
+    ACT_ALLOWLIST: "ACT_ALLOWLIST",
+}
+
+
+def action_name(act: int) -> str:
+    """Return the human-readable name for an action code."""
+    return _ACT_NAMES.get(act, f"ACT_UNKNOWN(0x{act:02x})")
+
+
+# ---------------------------------------------------------------------------
+# Enforcement modes (cgroup_op_policy map value: enforce_mode field)
+# ---------------------------------------------------------------------------
+
+ENFORCE_MODE_PERMISSIVE: int = 0x00
+"""Log the violation but do not kill/deny the syscall. Safe for onboarding."""
+
+ENFORCE_MODE_ENFORCE: int = 0x01
+"""Kill the offending syscall (return -EPERM) and log the event."""
+
+_ENFORCE_MODE_NAMES: dict[int, str] = {
+    ENFORCE_MODE_PERMISSIVE: "ENFORCE_MODE_PERMISSIVE",
+    ENFORCE_MODE_ENFORCE: "ENFORCE_MODE_ENFORCE",
+}
+
+
+def enforce_mode_name(mode: int) -> str:
+    """Return the human-readable name for an enforcement mode."""
+    return _ENFORCE_MODE_NAMES.get(mode, f"ENFORCE_MODE_UNKNOWN(0x{mode:02x})")
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch
+# ---------------------------------------------------------------------------
+
+KILL_SWITCH_INDEX: int = 0
+"""Index into the ``kill_switch`` BPF array map. Value 1 means all enforcement
+is suspended globally (hot-disable without unloading the BPF program)."""
+
+# ---------------------------------------------------------------------------
+# Side-effect class → op mapping
+#
+# Aligns to mission_compile._VALID_SIDE_EFFECT_CLASSES.  Each class maps to
+# one or more BPF op codes.  A class absent from
+# ``allowed_side_effect_classes`` → ACT_DENY for ALL its ops.
+# ---------------------------------------------------------------------------
+
+SEC_TO_OPS: dict[str, frozenset[int]] = {
+    "exec": frozenset({OP_EXEC}),
+    "read": frozenset({OP_FILE_READ}),
+    "write": frozenset({OP_FILE_WRITE}),
+    "network": frozenset({OP_NET_CONNECT}),
+    "external_send": frozenset({OP_EXTERNAL_SEND}),
+}
+
+# All side-effect classes in this taxonomy.
+ALL_SIDE_EFFECT_CLASSES: frozenset[str] = frozenset(SEC_TO_OPS.keys())
+
+# ---------------------------------------------------------------------------
+# BPF map schema types (Python representation of the C struct layout)
+#
+# These dataclasses document what the BPF maps hold.  In Slice 4.2 the daemon
+# will ctypes-pack / struct.pack these into map values; here they are schema
+# documentation only.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CgroupOpKey:
+    """Key for the ``cgroup_op_policy`` BPF hash map.
+
+    C layout (12 bytes, packed)::
+
+        struct ardur_cgroup_op_key {
+            __u64 cgroup_id;   // from bpf_get_current_cgroup_id()
+            __u32 op;          // ardur_op enum value
+        };
+    """
+
+    cgroup_id: int
+    op: int
+
+
+@dataclass(frozen=True, slots=True)
+class CgroupOpValue:
+    """Value for the ``cgroup_op_policy`` BPF hash map.
+
+    C layout (12 bytes, packed)::
+
+        struct ardur_cgroup_op_value {
+            __u32 action;        // ardur_action enum value
+            __u32 enforce_mode;  // ardur_enforce_mode enum value
+            __u32 generation;    // policy generation (for atomic replace)
+        };
+    """
+
+    action: int
+    enforce_mode: int
+    generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class PathAllowKey:
+    """Key for the ``cgroup_path_allow`` LPM trie map.
+
+    C layout::
+
+        struct ardur_path_allow_key {
+            __u32 prefixlen;           // number of significant bits
+            __u64 cgroup_id;           // scoped per cgroup
+            char  path[ARDUR_PATH_MAX]; // null-padded path prefix
+        };
+    """
+
+    cgroup_id: int
+    path_prefix: str
+
+
+@dataclass(frozen=True, slots=True)
+class NetAllowKey:
+    """Key for the ``cgroup_net_allow`` LPM trie map (IPv4 or IPv6).
+
+    C layout::
+
+        struct ardur_net_allow_key {
+            __u32 prefixlen;     // significant bits
+            __u64 cgroup_id;
+            __u8  addr[16];      // IPv4-mapped IPv6 or native IPv6
+        };
+    """
+
+    cgroup_id: int
+    addr: bytes          # 16-byte IPv4-mapped-IPv6 address
+    prefix_len: int      # CIDR prefix length
+
+
+@dataclass(frozen=True, slots=True)
+class EnforceEvent:
+    """Record emitted to the ``enforce_events`` BPF ringbuf on a policy hit.
+
+    C layout::
+
+        struct ardur_enforce_event {
+            __u64 cgroup_id;
+            __u32 pid;
+            __u32 op;
+            __u32 action_taken;    // ACT_DENY applied
+            __u32 enforce_mode;
+            __u64 observed_ns;     // bpf_ktime_get_ns()
+            char  comm[16];        // task_comm
+            char  path[256];       // for OP_FILE_*, empty otherwise
+        };
+    """
+
+    cgroup_id: int
+    pid: int
+    op: int
+    action_taken: int
+    enforce_mode: int
+    observed_ns: int
+    comm: str
+    path: str


### PR DESCRIPTION
## Summary

Epic A Slice 4.0+4.1 — the pure-Python/Go foundation for the enforcement bridge.
No kernel code, no BPF program, no daemon writes yet — just the frozen schema and the lowering compiler.

Refs: #63 (Epic A), depends on / precedes PR #82 (Slice 1 daemon).

### What this ships

#### 4.0 — Kernel-op taxonomy + BPF map schemas

**`python/vibap/bpf_types.py`**
- `OP_EXEC / OP_FILE_READ / OP_FILE_WRITE / OP_NET_CONNECT / OP_EXTERNAL_SEND` constants
- `ACT_ALLOW / ACT_DENY / ACT_ALLOWLIST` and `ENFORCE_MODE_PERMISSIVE / ENFORCE_MODE_ENFORCE`
- `SEC_TO_OPS` mapping from `mission_compile._VALID_SIDE_EFFECT_CLASSES` → BPF ops
- Schema dataclasses: `CgroupOpKey/Value`, `PathAllowKey`, `NetAllowKey`, `EnforceEvent`

**`go/pkg/kernelcapture/bpf_enforce_types.go`**
- Go mirror of the six BPF map schemas: `CgroupOpMapKey/Value`, `PathAllowPrefix`, `NetAllowPrefix`, `BpfEnforceEvent`
- `BpfOp / BpfAction / BpfEnforceMode` typed constants with `String()` methods

#### 4.1 — `python/vibap/bpf_lower.py`

`lower_to_bpf_policy_plan()` → `BpfPolicyPlan(op_policies, path_allow, net_allow, tier2_ops)`

| Input | BPF output |
|---|---|
| `allowed_side_effect_classes` | `ACT_DENY` for ops whose class is absent |
| `forbidden_tools` | `ACT_DENY` for mappable ops; unmappable → `tier2_ops` |
| `allowed_tools` | `ACT_ALLOW` for mappable ops; unmappable → `tier2_ops` |
| `resource_scope` / `SubpathPolicy` | `path_allow` + `ACT_ALLOWLIST` for file ops |
| `UrlAllowlistPolicy` (hostname) | `tier2_ops` — BPF works on IP/CIDR |
| `UrlAllowlistPolicy` (IP/CIDR) | `net_allow` + `ACT_ALLOWLIST` for net ops |
| `effect_policies / flow_policies / lineage_budgets` | `tier2_ops`; `MissionPolicyNotImplementedError` in ENFORCE_STRICT |

ENFORCE_STRICT loud-guard: raises `MissionPolicyNotImplementedError` (same class as `mission_compile`) on any dimension that can't be lowered to BPF. Never silently under-enforces.

**`python/tests/test_bpf_lower.py`** — 74 golden tests covering every lowering rule.

### Explicitly NOT in this slice

- BPF-LSM C program (`process_enforce.bpf.c`) — Slice 4.2
- Daemon BPF-map write path — Slice 4.2
- Kernel enforcement events / ringbuf consumer — Slice 4.3+
- URL hostname resolution to IP — future; caller can pre-resolve and pass via `net_prefixes`

### Tests

```
uv run pytest tests/test_bpf_lower.py tests/test_mission_compile.py  # 74 + 53 = 127 passed
go test ./pkg/kernelcapture/...  # all passing
```