### PR TITLE
ci: make go-cve gate blocking (remove continue-on-error)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,9 +123,6 @@ jobs:
   go-cve:
     name: Go CVE scan
     runs-on: ubuntu-latest
-    # Non-blocking until the raw commit check-run is promoted to a hard gate.
-    # Findings are real and tracked — the gate is no longer blind.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from the `go-cve` job so `govulncheck ./...` is a hard gate on PRs to `main`/`dev`.

## Why now

`go/go.mod` was already bumped to `go 1.26.4` and `golang.org/x/net v0.55.0` in 51133b4. Running `govulncheck ./...` under Go 1.26.4 (matching CI `setup-go`) reports **0 reachable vulnerabilities** — the 19 stdlib CVEs previously found were all in `go1.25.4` stdlib (fixed by ≤ `go1.25.11`, included in `go1.26.4`). The gate is now safe to harden.

## Verification

```
govulncheck ./...  → No vulnerabilities found (0 reachable)
go test -count=1 ./...  → 13/13 packages ok
go vet ./...            → exit 0
```

All run under Go 1.26.4.