### PR TITLE
feat(enforcement): Slice 4.2 — BPF-LSM enforcement bridge

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
@@ -1,0 +1,248 @@
+//go:build linux
+
+package main
+
+// daemon_guard_linux.go — BPF-LSM guard program integration for the daemon (Linux only).
+//
+// Slice 4.2: loads process_guard.bpf.c (BPF-LSM), populates d.policyMaps so
+// that handleApplyPolicy can write to the BPF enforcement maps, and consumes
+// the enforce_events ringbuf to produce BpfEnforceEvent records that are
+// correlated against registered sessions and appended to evidence logs.
+//
+// Graceful degrade: if BPF-LSM is unavailable (BTF missing, "bpf" not in the
+// active LSM list, or capability failure), the guard is skipped with a warning.
+// The exec tracepoint consumer (daemon_linux.go/runEBPFConsumer) and the socket
+// control plane continue to operate normally.
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// EnforceReceiptSchema is the schema version tag written into per-session
+// enforce_events JSONL files.
+const EnforceReceiptSchema = "ardur.enforce.receipt.v1"
+
+// EnforceReceiptEntry is the JSONL record appended to
+// <evidenceDir>/<sessionID>/enforce_events.jsonl for each enforcement event.
+type EnforceReceiptEntry struct {
+	SchemaVersion string                          `json:"schema_version"`
+	SessionID     string                          `json:"session_id"`
+	RecordedAt    time.Time                       `json:"recorded_at"`
+	Event         kernelcapture.BpfEnforceEvent   `json:"event"`
+	Verdict       string                          `json:"verdict"`
+}
+
+// runGuardConsumer loads the process_guard BPF-LSM program and streams
+// enforce_events to registered sessions until ctx is cancelled.
+//
+// Returns nil on graceful context cancellation; returns a non-nil error if
+// the guard fails to load (in which case the daemon degrades gracefully —
+// enforcement is unavailable but the exec tracepoint consumer still runs).
+func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
+	// Preflight: check BTF and BPF-LSM availability.
+	preflightReport := kernelcapture.InspectBPFLSMPreflight()
+	for _, f := range preflightReport.Findings {
+		switch f.Verdict {
+		case kernelcapture.DaemonPreflightVerdictFail:
+			return fmt.Errorf("BPF-LSM preflight failed (%s): %s; %s", f.CheckName, f.Details, f.Remediation)
+		case kernelcapture.DaemonPreflightVerdictWarn:
+			log.Warn("BPF-LSM preflight warning",
+				"check", f.CheckName, "detail", f.Details, "remediation", f.Remediation)
+		}
+	}
+
+	handles, err := kernelcapture.LoadAndAttachProcessGuardEBPF()
+	if err != nil {
+		return fmt.Errorf("load process_guard BPF-LSM: %w", err)
+	}
+	defer func() {
+		// Clear policy maps reference so subsequent apply_policy calls fail safely.
+		d.policyMaps = kernelcapture.PolicyMaps{}
+		handles.Close()
+	}()
+
+	// Expose maps to the daemon for apply_policy calls.
+	d.policyMaps = kernelcapture.PolicyMapsFromHandles(handles)
+
+	log.Info("BPF-LSM process_guard loaded",
+		"hooks", "bprm_check_security, lsm.s/file_open, socket_connect",
+	)
+
+	return consumeEnforceEvents(ctx, handles.Reader(), d, log)
+}
+
+// consumeEnforceEvents reads raw BPfEnforceEvent structs from the ringbuf,
+// decodes them, correlates them to registered sessions, and appends evidence.
+func consumeEnforceEvents(ctx context.Context, reader *ringbuf.Reader, d *daemon, log *slog.Logger) error {
+	var dropped uint64
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		record, err := reader.Read()
+		if err != nil {
+			if err == io.EOF || err == ringbuf.ErrClosed {
+				return nil
+			}
+			if strings.Contains(err.Error(), "context canceled") || strings.Contains(err.Error(), "deadline exceeded") {
+				return ctx.Err()
+			}
+			return fmt.Errorf("enforce_events ringbuf read: %w", err)
+		}
+
+		if record.LostSamples > 0 {
+			dropped += record.LostSamples
+			log.Warn("enforce_events ringbuf lost samples", "lost", record.LostSamples, "total_dropped", dropped)
+		}
+
+		ev, err := decodeEnforceEvent(record.RawSample)
+		if err != nil {
+			log.Warn("decode enforce_event failed", "error", err)
+			continue
+		}
+
+		d.processEnforceEvent(ev, log)
+	}
+}
+
+// decodeEnforceEvent deserialises the raw bytes from the BPF ringbuf into a
+// BpfEnforceEvent. The layout must exactly match struct ardur_enforce_event
+// in process_guard.bpf.c:
+//
+//	cgroup_id  u64     (8)
+//	pid        u32     (4)
+//	op         u32     (4)
+//	action     u32     (4)
+//	mode       u32     (4)
+//	observed   u64     (8)
+//	comm       [16]u8  (16)
+//	path       [256]u8 (256)
+//
+// Total: 304 bytes.
+func decodeEnforceEvent(raw []byte) (kernelcapture.BpfEnforceEvent, error) {
+	const fixedSize = 8 + 4 + 4 + 4 + 4 + 8 + 16 + 256 // 304 bytes
+	if len(raw) < fixedSize {
+		return kernelcapture.BpfEnforceEvent{}, fmt.Errorf("enforce_event too short: %d < %d", len(raw), fixedSize)
+	}
+
+	r := bytes.NewReader(raw)
+	var ev kernelcapture.BpfEnforceEvent
+
+	var cgroupID uint64
+	var pid, op, action, mode uint32
+	var observedNS uint64
+	var comm [16]byte
+	var path [256]byte
+
+	if err := binary.Read(r, binary.NativeEndian, &cgroupID); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &pid); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &op); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &action); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &mode); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &observedNS); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &comm); err != nil {
+		return ev, err
+	}
+	if err := binary.Read(r, binary.NativeEndian, &path); err != nil {
+		return ev, err
+	}
+
+	ev.CgroupID = cgroupID
+	ev.PID = pid
+	ev.Op = kernelcapture.BpfOp(op)
+	ev.ActionTaken = kernelcapture.BpfAction(action)
+	ev.EnforceMode = kernelcapture.BpfEnforceMode(mode)
+	ev.ObservedNS = observedNS
+	ev.Comm = strings.TrimRight(string(comm[:]), "\x00")
+	ev.Path = strings.TrimRight(string(path[:]), "\x00")
+
+	return ev, nil
+}
+
+// processEnforceEvent routes one enforce_event to the appropriate registered
+// session and appends an EnforceReceiptEntry to the evidence log.
+func (d *daemon) processEnforceEvent(ev kernelcapture.BpfEnforceEvent, log *slog.Logger) {
+	d.mu.RLock()
+	sid, ok := d.cgroupIndex[ev.CgroupID]
+	d.mu.RUnlock()
+	if !ok {
+		return // event for a non-registered cgroup; ignore
+	}
+
+	verdict := enforceEventVerdict(ev)
+	log.Debug("enforce event",
+		"session_id", sid,
+		"cgroup_id", ev.CgroupID,
+		"pid", ev.PID,
+		"op", ev.Op,
+		"action", ev.ActionTaken,
+		"mode", ev.EnforceMode,
+		"comm", ev.Comm,
+		"verdict", verdict,
+	)
+
+	entry := EnforceReceiptEntry{
+		SchemaVersion: EnforceReceiptSchema,
+		SessionID:     sid,
+		RecordedAt:    time.Now().UTC(),
+		Event:         ev,
+		Verdict:       verdict,
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Warn("marshal enforce receipt", "error", err)
+		return
+	}
+	line = append(line, '\n')
+
+	dir := filepath.Join(d.evidenceDir, sanitizeSessionID(sid))
+	path := filepath.Join(dir, "enforce_events.jsonl")
+	if err := d.fs.MkdirAll(dir, 0o700); err != nil {
+		log.Warn("create evidence dir for enforce receipt", "path", dir, "error", err)
+		return
+	}
+	if err := d.fs.AppendFile(path, line, 0o600); err != nil {
+		log.Warn("append enforce receipt", "path", path, "error", err)
+	}
+}
+
+// enforceEventVerdict maps a BpfEnforceEvent to a SyntheticKernelReceipt verdict.
+func enforceEventVerdict(ev kernelcapture.BpfEnforceEvent) string {
+	switch ev.ActionTaken {
+	case kernelcapture.BpfActionDeny:
+		if ev.EnforceMode == kernelcapture.BpfEnforceModeEnforce {
+			return kernelcapture.SyntheticKernelReceiptVerdictDenied
+		}
+		return kernelcapture.SyntheticKernelReceiptVerdictBlocked
+	case kernelcapture.BpfActionAllowlist:
+		// ACT_ALLOWLIST in an event means "target not in allowlist, logged only"
+		return kernelcapture.SyntheticKernelReceiptVerdictBlocked
+	default:
+		return kernelcapture.SyntheticKernelReceiptVerdictCompliant
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
@@ -10,9 +10,14 @@ import (
 
 func platformName() string { return "unsupported" }
 
-// runEBPFConsumer is a no-op stub on non-Linux platforms. The eBPF ringbuf
-// consumer requires a Linux kernel; the daemon runs control-plane only.
+// runEBPFConsumer is a no-op stub on non-Linux platforms.
 func runEBPFConsumer(_ context.Context, _ *daemon, log *slog.Logger) error {
 	log.Warn("eBPF ringbuf consumer is Linux-only; running control plane only")
 	return fmt.Errorf("eBPF consumer unavailable on this platform")
+}
+
+// runGuardConsumer is a no-op stub on non-Linux platforms.
+func runGuardConsumer(_ context.Context, _ *daemon, log *slog.Logger) error {
+	log.Warn("BPF-LSM guard is Linux-only; enforcement unavailable on this platform")
+	return fmt.Errorf("BPF-LSM guard unavailable on this platform")
 }

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -83,6 +83,11 @@ type daemon struct {
 
 	// OS filesystem for JSONL append (interface for test injection).
 	fs evidenceFS
+
+	// policyMaps holds the writable BPF map handles for the process_guard
+	// enforcement program. On non-Linux platforms PolicyMaps is a zero struct and
+	// ApplyPolicyMaps / RemovePolicyMaps return an error immediately.
+	policyMaps kernelcapture.PolicyMaps
 }
 
 func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, ownerUID uint32) (*daemon, error) {
@@ -129,6 +134,11 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 // socket server. It delegates to the registry and maintains the cgroup routing
 // index as a side effect of successful register/end-session responses.
 func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
+	// apply_policy is handled locally — the registry has no BPF awareness.
+	if req.Method == kernelcapture.DaemonProtocolMethodApplyPolicy {
+		return d.handleApplyPolicy(req)
+	}
+
 	resp := d.registry.HandleAuthorizedRequest(ctx, req, handshake)
 	if !resp.OK {
 		return resp
@@ -144,6 +154,48 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 		}
 	}
 	return resp
+}
+
+// handleApplyPolicy validates the session, resolves its cgroup_id, and writes
+// the policy into the BPF enforcement maps.
+func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kernelcapture.DaemonProtocolResponse {
+	ap := req.ApplyPolicy
+	errResp := func(msg string) kernelcapture.DaemonProtocolResponse {
+		return kernelcapture.DaemonProtocolResponse{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+			OK:              false,
+			Error:           msg,
+		}
+	}
+
+	record, err := d.registry.ActiveSession(ap.SessionID)
+	if err != nil {
+		return errResp(fmt.Sprintf("session not found or not active: %v", err))
+	}
+	if record.CgroupID == 0 {
+		return errResp("session has no cgroup_id; cannot apply BPF policy")
+	}
+
+	if err := kernelcapture.ApplyPolicyMaps(d.policyMaps, record.CgroupID, *ap); err != nil {
+		d.log.Error("apply_policy failed", "session_id", ap.SessionID, "cgroup_id", record.CgroupID, "error", err)
+		return errResp(fmt.Sprintf("apply policy maps: %v", err))
+	}
+
+	d.log.Info("policy applied",
+		"session_id", ap.SessionID,
+		"cgroup_id", record.CgroupID,
+		"generation", ap.Generation,
+		"op_policies", len(ap.OpPolicies),
+		"path_allow", len(ap.PathAllow),
+		"net_allow", len(ap.NetAllow),
+	)
+	return kernelcapture.DaemonProtocolResponse{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		OK:              true,
+		SessionID:       ap.SessionID,
+	}
 }
 
 // onSessionRegistered adds the session to the cgroup routing index.
@@ -178,7 +230,7 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 	)
 }
 
-// onSessionEnded removes the session from the routing index.
+// onSessionEnded removes the session from the routing index and clears BPF maps.
 func (d *daemon) onSessionEnded(sessionID string) {
 	if sessionID == "" {
 		return
@@ -189,6 +241,11 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	if scope, ok := d.treeScopes[sessionID]; ok {
 		if scope.CgroupID != 0 {
 			delete(d.cgroupIndex, scope.CgroupID)
+			// Best-effort: remove enforcement state from BPF maps.
+			if err := kernelcapture.RemovePolicyMaps(d.policyMaps, scope.CgroupID); err != nil {
+				d.log.Warn("remove policy maps on session end",
+					"session_id", sessionID, "cgroup_id", scope.CgroupID, "error", err)
+			}
 		}
 	}
 	delete(d.treeScopes, sessionID)
@@ -516,7 +573,7 @@ func main() {
 		}
 	}()
 
-	// Data-plane goroutine: eBPF ringbuf consumer (platform-specific).
+	// Data-plane goroutine: eBPF exec/exit tracepoint ringbuf consumer.
 	if !*noRingbuf {
 		wg.Add(1)
 		go func() {
@@ -525,8 +582,19 @@ func main() {
 				log.Error("eBPF consumer stopped", "error", err)
 			}
 		}()
+
+		// BPF-LSM enforcement consumer: loads process_guard, populates policyMaps.
+		// Degrades gracefully on kernels without BPF-LSM (warn, not fatal).
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := runGuardConsumer(ctx, d, log); err != nil && ctx.Err() == nil {
+				log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
+					"error", err)
+			}
+		}()
 	} else {
-		log.Info("eBPF ringbuf consumer disabled (--no-ringbuf)")
+		log.Info("eBPF ringbuf consumers disabled (--no-ringbuf)")
 	}
 
 	<-ctx.Done()

--- a/go/pkg/kernelcapture/bpf_policy_apply_linux.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_linux.go
@@ -1,0 +1,353 @@
+//go:build linux
+
+package kernelcapture
+
+// bpf_policy_apply_linux.go — daemon-side BPF map write path (Linux only).
+//
+// ApplyPolicyMaps writes one full policy generation into the six BPF maps used
+// by process_guard.bpf.c. The write order is:
+//   1. cgroup_op_policy  — per-op action/enforce-mode entries
+//   2. cgroup_path_allow — path LPM trie entries
+//   3. cgroup_net_allow  — network CIDR LPM trie entries
+//   4. cgroup_managed    — governed flag + generation (LAST, atomic gate)
+//
+// The BPF program ignores cgroup_op_policy entries whose generation does not
+// match the current cgroup_managed generation, so stale entries from prior
+// cycles are effectively invisible until the managed record is updated.
+//
+// This file is compiled only on Linux because it references processGuardMaps
+// from the bpf2go-generated processguard_bpfel.go (which must be present after
+// running `go generate ./go/pkg/kernelcapture/...` on a Linux host with clang
+// and Linux kernel headers installed).
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// ProcessGuardHandles holds the loaded BPF objects for the process_guard program.
+// Call LoadAndAttachProcessGuardEBPF to obtain one; call Close when done.
+type ProcessGuardHandles struct {
+	objs           processGuardObjects
+	bprmLink       link.Link
+	fileOpenLink   link.Link
+	socketConnLink link.Link
+	reader         *ringbuf.Reader
+}
+
+// Reader returns the ringbuf reader for enforce_events. The caller must not
+// close it independently; Close() on the handles cleans it up.
+func (h *ProcessGuardHandles) Reader() *ringbuf.Reader { return h.reader }
+
+// Close releases all BPF objects in reverse-acquisition order.
+func (h *ProcessGuardHandles) Close() {
+	if h.reader != nil {
+		h.reader.Close()
+	}
+	if h.socketConnLink != nil {
+		h.socketConnLink.Close()
+	}
+	if h.fileOpenLink != nil {
+		h.fileOpenLink.Close()
+	}
+	if h.bprmLink != nil {
+		h.bprmLink.Close()
+	}
+	h.objs.Close()
+}
+
+// PolicyMaps is a thin view of the BPF maps needed for policy writes.
+// Extracted from ProcessGuardHandles so map-write logic can be unit-tested
+// with manually constructed *ebpf.Map objects.
+type PolicyMaps struct {
+	CgroupOpPolicy  *ebpf.Map
+	CgroupPathAllow *ebpf.Map
+	CgroupNetAllow  *ebpf.Map
+	CgroupManaged   *ebpf.Map
+	KillSwitch      *ebpf.Map
+}
+
+// PolicyMapsFromHandles extracts the writable map set from loaded handles.
+func PolicyMapsFromHandles(h *ProcessGuardHandles) PolicyMaps {
+	return PolicyMaps{
+		CgroupOpPolicy:  h.objs.CgroupOpPolicy,
+		CgroupPathAllow: h.objs.CgroupPathAllow,
+		CgroupNetAllow:  h.objs.CgroupNetAllow,
+		CgroupManaged:   h.objs.CgroupManaged,
+		KillSwitch:      h.objs.KillSwitch,
+	}
+}
+
+// LoadAndAttachProcessGuardEBPF loads the process_guard BPF object, attaches
+// the three LSM hooks, and opens the enforce_events ringbuf reader.
+//
+// Requires CAP_BPF (or CAP_SYS_ADMIN on older kernels), CONFIG_BPF_LSM=y,
+// and "bpf" listed in /sys/kernel/security/lsm (or the lsm= kernel cmdline).
+func LoadAndAttachProcessGuardEBPF() (*ProcessGuardHandles, error) {
+	h := &ProcessGuardHandles{}
+
+	if err := loadProcessGuardObjects(&h.objs, nil); err != nil {
+		return nil, fmt.Errorf("kernelcapture: load process_guard objects: %w", err)
+	}
+
+	var err error
+	h.bprmLink, err = link.AttachLSM(link.LSMOptions{
+		Program: h.objs.GuardBprmCheck,
+	})
+	if err != nil {
+		h.objs.Close()
+		return nil, fmt.Errorf("kernelcapture: attach lsm/bprm_check_security: %w", err)
+	}
+
+	h.fileOpenLink, err = link.AttachLSM(link.LSMOptions{
+		Program: h.objs.GuardFileOpen,
+	})
+	if err != nil {
+		h.bprmLink.Close()
+		h.objs.Close()
+		return nil, fmt.Errorf("kernelcapture: attach lsm.s/file_open: %w", err)
+	}
+
+	h.socketConnLink, err = link.AttachLSM(link.LSMOptions{
+		Program: h.objs.GuardSocketConnect,
+	})
+	if err != nil {
+		h.fileOpenLink.Close()
+		h.bprmLink.Close()
+		h.objs.Close()
+		return nil, fmt.Errorf("kernelcapture: attach lsm/socket_connect: %w", err)
+	}
+
+	h.reader, err = ringbuf.NewReader(h.objs.EnforceEvents)
+	if err != nil {
+		h.socketConnLink.Close()
+		h.fileOpenLink.Close()
+		h.bprmLink.Close()
+		h.objs.Close()
+		return nil, fmt.Errorf("kernelcapture: open enforce_events ringbuf: %w", err)
+	}
+
+	return h, nil
+}
+
+// ApplyPolicyMaps writes the policy described by req into maps for cgroupID.
+// cgroupID must be the kernel cgroup_id for the session (from register_session).
+//
+// Write order is generation-atomic: op/path/net entries first, managed gate last.
+// Stale entries from prior generations survive in the map but are invisible to
+// the BPF program until the managed record is updated.
+func ApplyPolicyMaps(maps PolicyMaps, cgroupID uint64, req DaemonApplyPolicyRequest) error {
+	gen := req.Generation
+
+	// 1. Write per-op policy entries.
+	for _, p := range req.OpPolicies {
+		k := cgroupOpKey(cgroupID, p.Op)
+		v := cgroupOpValue(p.Action, p.EnforceMode, gen)
+		if err := maps.CgroupOpPolicy.Put(k, v); err != nil {
+			return fmt.Errorf("kernelcapture: apply_policy cgroup_op_policy put (op=%s): %w", p.Op, err)
+		}
+	}
+
+	// 2. Write path allow trie entries.
+	for _, path := range req.PathAllow {
+		k, err := pathLpmKey(cgroupID, path)
+		if err != nil {
+			return fmt.Errorf("kernelcapture: apply_policy path_allow put (%q): %w", path, err)
+		}
+		var v uint64 = 1
+		if err := maps.CgroupPathAllow.Put(k, &v); err != nil {
+			return fmt.Errorf("kernelcapture: apply_policy cgroup_path_allow put (%q): %w", path, err)
+		}
+	}
+
+	// 3. Write net allow trie entries.
+	for _, cidr := range req.NetAllow {
+		k, err := netLpmKey(cgroupID, cidr)
+		if err != nil {
+			return fmt.Errorf("kernelcapture: apply_policy net_allow put (%q): %w", cidr, err)
+		}
+		var v uint64 = 1
+		if err := maps.CgroupNetAllow.Put(k, &v); err != nil {
+			return fmt.Errorf("kernelcapture: apply_policy cgroup_net_allow put (%q): %w", cidr, err)
+		}
+	}
+
+	// 4. Write cgroup_managed LAST — the BPF program uses this as the gate.
+	// strict flag = 1 when enforce_mode is ENFORCE (fail-closed on no-rule).
+	var flags uint32
+	if req.EnforceMode == BpfEnforceModeEnforce {
+		flags = 1
+	}
+	mk := managedKey(cgroupID)
+	mv := managedValue(flags, gen)
+	if err := maps.CgroupManaged.Put(mk, mv); err != nil {
+		return fmt.Errorf("kernelcapture: apply_policy cgroup_managed put: %w", err)
+	}
+
+	return nil
+}
+
+// RemovePolicyMaps clears all governance entries for cgroupID from the maps.
+// This is called when a session ends to release enforcement state.
+// Errors on individual deletes are collected and returned as a combined error.
+func RemovePolicyMaps(maps PolicyMaps, cgroupID uint64) error {
+	var errs []string
+
+	// Delete managed gate first — BPF program then treats cgroup as ungoverned.
+	mk := managedKey(cgroupID)
+	if err := maps.CgroupManaged.Delete(mk); err != nil && !isNotFound(err) {
+		errs = append(errs, fmt.Sprintf("cgroup_managed: %v", err))
+	}
+
+	// Delete op policy entries for all known ops.
+	for _, op := range []BpfOp{BpfOpExec, BpfOpFileRead, BpfOpFileWrite, BpfOpNetConnect, BpfOpExternalSend} {
+		k := cgroupOpKey(cgroupID, op)
+		if err := maps.CgroupOpPolicy.Delete(k); err != nil && !isNotFound(err) {
+			errs = append(errs, fmt.Sprintf("cgroup_op_policy (op=%s): %v", op, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("kernelcapture: remove_policy_maps for cgroup %d: %s", cgroupID, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// SetKillSwitch writes the global kill-switch value.
+// engaged=true suspends all enforcement (all ops pass through); false re-enables.
+func SetKillSwitch(maps PolicyMaps, engaged bool) error {
+	var v uint32
+	if engaged {
+		v = 1
+	}
+	idx := uint32(KillSwitchIndex)
+	if err := maps.KillSwitch.Put(&idx, &v); err != nil {
+		return fmt.Errorf("kernelcapture: set kill_switch: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// BPF map key/value serialization helpers
+// ---------------------------------------------------------------------------
+
+// cgroupOpKeyLayout must exactly match struct ardur_cgroup_op_key in process_guard.bpf.c.
+// Layout: cgroup_id(8) + op(4) = 12 bytes, no padding needed (u64 then u32 then implicit 4-byte pad to 16).
+// We use unsafe.Sizeof to let cilium/ebpf derive the size; the struct is plain POD.
+type cgroupOpKeyLayout struct {
+	CgroupID uint64
+	Op       uint32
+	_        [4]byte // padding to 16 bytes (hash map needs power-of-2 key size)
+}
+
+type cgroupOpValueLayout struct {
+	Action      uint32
+	EnforceMode uint32
+	Generation  uint32
+	_           [4]byte // padding
+}
+
+func cgroupOpKey(cgroupID uint64, op BpfOp) unsafe.Pointer {
+	k := cgroupOpKeyLayout{CgroupID: cgroupID, Op: uint32(op)}
+	return unsafe.Pointer(&k)
+}
+
+func cgroupOpValue(action BpfAction, enforceMode BpfEnforceMode, gen uint32) unsafe.Pointer {
+	v := cgroupOpValueLayout{Action: uint32(action), EnforceMode: uint32(enforceMode), Generation: gen}
+	return unsafe.Pointer(&v)
+}
+
+// managedKeyLayout matches struct ardur_managed_key: cgroup_raw[8].
+type managedKeyLayout struct {
+	CgroupRaw [8]byte
+}
+
+// managedValueLayout matches struct ardur_managed_value: flags(4) + generation(4).
+type managedValueLayout struct {
+	Flags      uint32
+	Generation uint32
+}
+
+func managedKey(cgroupID uint64) unsafe.Pointer {
+	var k managedKeyLayout
+	binary.NativeEndian.PutUint64(k.CgroupRaw[:], cgroupID)
+	return unsafe.Pointer(&k)
+}
+
+func managedValue(flags, generation uint32) unsafe.Pointer {
+	v := managedValueLayout{Flags: flags, Generation: generation}
+	return unsafe.Pointer(&v)
+}
+
+// pathLpmKeyLayout matches struct ardur_path_lpm_key: prefixlen(4) + cgroup_raw[8] + path[256].
+const bpfPathLen = 256
+
+type pathLpmKeyLayout struct {
+	Prefixlen uint32
+	CgroupRaw [8]byte
+	Path      [bpfPathLen]byte
+}
+
+func pathLpmKey(cgroupID uint64, pathPrefix string) (unsafe.Pointer, error) {
+	if !strings.HasPrefix(pathPrefix, "/") {
+		return nil, fmt.Errorf("path must be absolute, got %q", pathPrefix)
+	}
+	pathBytes := []byte(pathPrefix)
+	if len(pathBytes) > bpfPathLen-1 {
+		pathBytes = pathBytes[:bpfPathLen-1]
+	}
+
+	var k pathLpmKeyLayout
+	binary.NativeEndian.PutUint64(k.CgroupRaw[:], cgroupID)
+	copy(k.Path[:], pathBytes)
+	// prefixlen: 64 bits for cgroup_raw + path prefix bytes (excluding null terminator)
+	k.Prefixlen = 64 + uint32(len(pathBytes))*8
+	return unsafe.Pointer(&k), nil
+}
+
+// netLpmKeyLayout matches struct ardur_net_lpm_key: prefixlen(4) + cgroup_raw[8] + addr[16].
+type netLpmKeyLayout struct {
+	Prefixlen uint32
+	CgroupRaw [8]byte
+	Addr      [16]byte
+}
+
+func netLpmKey(cgroupID uint64, cidr string) (unsafe.Pointer, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		// Try parsing as bare host address.
+		ip := net.ParseIP(cidr)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid CIDR/IP %q: %w", cidr, err)
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			ipNet = &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}
+		} else {
+			ipNet = &net.IPNet{IP: ip.To16(), Mask: net.CIDRMask(128, 128)}
+		}
+	}
+
+	var k netLpmKeyLayout
+	binary.NativeEndian.PutUint64(k.CgroupRaw[:], cgroupID)
+
+	prefixBits, _ := ipNet.Mask.Size()
+	if ip4 := ipNet.IP.To4(); ip4 != nil {
+		copy(k.Addr[:4], ip4)
+		k.Prefixlen = 64 + uint32(prefixBits)
+	} else {
+		copy(k.Addr[:], ipNet.IP.To16())
+		k.Prefixlen = 64 + uint32(prefixBits)
+	}
+	return unsafe.Pointer(&k), nil
+}
+
+func isNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found")
+}

--- a/go/pkg/kernelcapture/bpf_policy_apply_unsupported.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_unsupported.go
@@ -1,0 +1,43 @@
+//go:build !linux
+
+package kernelcapture
+
+// bpf_policy_apply_unsupported.go — stub for non-Linux platforms.
+//
+// BPF map writes require Linux; these types and functions exist solely so that
+// non-Linux builds (macOS CI, unit tests) can import the package without
+// resolution errors for the shared protocol types defined in daemon_protocol.go.
+
+import "fmt"
+
+// ProcessGuardHandles is an opaque stub on unsupported platforms.
+type ProcessGuardHandles struct{}
+
+// Close is a no-op on unsupported platforms.
+func (h *ProcessGuardHandles) Close() {}
+
+// PolicyMaps is an opaque stub on unsupported platforms.
+type PolicyMaps struct{}
+
+// PolicyMapsFromHandles returns a zero-value stub.
+func PolicyMapsFromHandles(_ *ProcessGuardHandles) PolicyMaps { return PolicyMaps{} }
+
+// LoadAndAttachProcessGuardEBPF always returns an error on unsupported platforms.
+func LoadAndAttachProcessGuardEBPF() (*ProcessGuardHandles, error) {
+	return nil, fmt.Errorf("kernelcapture: process_guard BPF-LSM is not supported on this platform")
+}
+
+// ApplyPolicyMaps always returns an error on unsupported platforms.
+func ApplyPolicyMaps(_ PolicyMaps, _ uint64, _ DaemonApplyPolicyRequest) error {
+	return fmt.Errorf("kernelcapture: BPF policy maps are not supported on this platform")
+}
+
+// RemovePolicyMaps always returns an error on unsupported platforms.
+func RemovePolicyMaps(_ PolicyMaps, _ uint64) error {
+	return fmt.Errorf("kernelcapture: BPF policy maps are not supported on this platform")
+}
+
+// SetKillSwitch always returns an error on unsupported platforms.
+func SetKillSwitch(_ PolicyMaps, _ bool) error {
+	return fmt.Errorf("kernelcapture: kill_switch map is not supported on this platform")
+}

--- a/go/pkg/kernelcapture/daemon_preflight.go
+++ b/go/pkg/kernelcapture/daemon_preflight.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -21,6 +22,14 @@ const (
 	DaemonPreflightPathSocket     = "socket"
 	DaemonPreflightPathBPFFSDir   = "bpffs_dir"
 	DaemonPreflightPathRingbufMap = "bpffs_map"
+
+	// BPF-LSM / BTF detection check names.
+	DaemonPreflightCheckBTFVmlinux = "btf_vmlinux"
+	DaemonPreflightCheckBPFLSM    = "bpflsm_active"
+
+	// Kernel paths inspected for BPF-LSM capability.
+	KernelBTFVmlinuxPath   = "/sys/kernel/btf/vmlinux"
+	KernelLSMActivePath    = "/sys/kernel/security/lsm"
 )
 
 // DaemonPreflightReport is a read-only inspection result for the future
@@ -312,6 +321,101 @@ func daemonPreflightModeType(mode fs.FileMode) string {
 	default:
 		return "file"
 	}
+}
+
+// InspectBPFLSMPreflight checks whether the running kernel exposes BTF and
+// has BPF-LSM active. It is a non-mutating, read-only inspection and never
+// loads BPF programs, attaches hooks, or modifies kernel state.
+//
+// The returned findings use the standard DaemonPreflightFinding shape so that
+// callers can mix them with the path-custody findings from
+// InspectDaemonCustodyPreflight. CanContinue is false if any finding is a
+// hard failure; a warn verdict indicates degraded-but-functional operation
+// (e.g. BTF present but BPF-LSM not active — seccomp enforcement still works).
+func InspectBPFLSMPreflight(optFns ...DaemonPreflightOption) DaemonPreflightReport {
+	opts := daemonPreflightOptions{fs: osDaemonPreflightFS{}}
+	for _, fn := range optFns {
+		if fn != nil {
+			fn(&opts)
+		}
+	}
+	report := DaemonPreflightReport{
+		Mode: "bpflsm_capability_check",
+		WorksNow: []string{
+			"read-only BTF and BPF-LSM capability inspection",
+		},
+		NotClaimed: []string{
+			"BPF program loading or attachment",
+			"LSM hook installation",
+		},
+	}
+
+	// Check 1: /sys/kernel/btf/vmlinux — required for CO-RE BPF programs.
+	btfFinding := DaemonPreflightFinding{
+		CheckName: DaemonPreflightCheckBTFVmlinux,
+		Path:      KernelBTFVmlinuxPath,
+	}
+	if _, err := opts.fs.Stat(KernelBTFVmlinuxPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err) {
+			btfFinding.Verdict = DaemonPreflightVerdictFail
+			btfFinding.Details = "BTF vmlinux not present; CO-RE BPF programs cannot load (need CONFIG_DEBUG_INFO_BTF=y)"
+			btfFinding.Remediation = "enable CONFIG_DEBUG_INFO_BTF=y in kernel config or use a distribution kernel with BTF support"
+		} else {
+			btfFinding.Verdict = DaemonPreflightVerdictFail
+			btfFinding.Details = fmt.Sprintf("stat %s: %v", KernelBTFVmlinuxPath, err)
+			btfFinding.Remediation = "check kernel and securityfs mount state"
+		}
+	} else {
+		btfFinding.Verdict = DaemonPreflightVerdictPass
+		btfFinding.Details = "BTF vmlinux present; CO-RE BPF programs can load"
+	}
+	report.Findings = append(report.Findings, btfFinding)
+
+	// Check 2: /sys/kernel/security/lsm — must list "bpf" to attach BPF-LSM hooks.
+	lsmFinding := DaemonPreflightFinding{
+		CheckName: DaemonPreflightCheckBPFLSM,
+		Path:      KernelLSMActivePath,
+	}
+	lsmContent, lsmErr := os.ReadFile(KernelLSMActivePath)
+	if lsmErr != nil {
+		if errors.Is(lsmErr, fs.ErrNotExist) || os.IsNotExist(lsmErr) {
+			lsmFinding.Verdict = DaemonPreflightVerdictWarn
+			lsmFinding.Details = "securityfs not mounted or LSM list unavailable; BPF-LSM status unknown"
+			lsmFinding.Remediation = "mount securityfs: mount -t securityfs securityfs /sys/kernel/security"
+		} else {
+			lsmFinding.Verdict = DaemonPreflightVerdictWarn
+			lsmFinding.Details = fmt.Sprintf("read %s: %v", KernelLSMActivePath, lsmErr)
+			lsmFinding.Remediation = "check kernel security subsystem configuration"
+		}
+	} else {
+		active := strings.TrimSpace(string(lsmContent))
+		lsmFinding.Details = fmt.Sprintf("active LSMs: %s", active)
+		hasBPF := false
+		for _, lsm := range strings.Split(active, ",") {
+			if strings.TrimSpace(lsm) == "bpf" {
+				hasBPF = true
+				break
+			}
+		}
+		if hasBPF {
+			lsmFinding.Verdict = DaemonPreflightVerdictPass
+			lsmFinding.Details += " — bpf LSM is active; BPF-LSM hooks can be attached"
+		} else {
+			lsmFinding.Verdict = DaemonPreflightVerdictWarn
+			lsmFinding.Details += " — bpf LSM not active; BPF-LSM hooks will fail to attach"
+			lsmFinding.Remediation = "add lsm=...,bpf to kernel command line (e.g. in GRUB_CMDLINE_LINUX) or enable CONFIG_BPF_LSM=y and reboot"
+		}
+	}
+	report.Findings = append(report.Findings, lsmFinding)
+
+	report.CanContinue = true
+	for _, f := range report.Findings {
+		if f.Verdict == DaemonPreflightVerdictFail {
+			report.CanContinue = false
+			break
+		}
+	}
+	return report
 }
 
 type osDaemonPreflightFS struct{}

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -16,10 +16,16 @@ const (
 	DaemonProtocolMethodRegisterSession = "register_session"
 	DaemonProtocolMethodEndSession      = "end_session"
 	DaemonProtocolMethodSessionStatus   = "session_status"
+	DaemonProtocolMethodApplyPolicy     = "apply_policy"
 
 	DaemonProtocolEventProcessLifecycle = "process_lifecycle"
 
 	MaxDaemonProtocolTTLSeconds = 24 * 60 * 60
+
+	// MaxDaemonPolicyGeneration is the largest generation value the daemon will
+	// accept in an apply_policy request. Generation 0 is reserved to mean
+	// "uninitialized" in the BPF program; callers must start at 1.
+	MaxDaemonPolicyGeneration = 1<<32 - 1
 )
 
 var ErrDaemonProtocol = errors.New("kernelcapture: invalid daemon protocol message")
@@ -35,6 +41,32 @@ type DaemonProtocolRequest struct {
 	RegisterSession *DaemonRegisterSessionRequest `json:"register_session,omitempty"`
 	EndSession      *DaemonEndSessionRequest      `json:"end_session,omitempty"`
 	SessionStatus   *DaemonSessionStatusRequest   `json:"session_status,omitempty"`
+	ApplyPolicy     *DaemonApplyPolicyRequest     `json:"apply_policy,omitempty"`
+}
+
+// DaemonApplyPolicyRequest installs or replaces the BPF enforcement policy for
+// one session's cgroup. The daemon writes the supplied entries to the six BPF
+// maps in the order: op_policies → path_allow → net_allow → cgroup_managed
+// (generation-atomic, managed flag written last per ValidateCgroupFilterSequence).
+//
+// Generation must be non-zero and strictly increasing relative to the previous
+// apply for this session.  The BPF program uses the generation to detect stale
+// map entries left over from a prior policy cycle.
+type DaemonApplyPolicyRequest struct {
+	SessionID   string             `json:"session_id"`
+	OpPolicies  []DaemonOpPolicy   `json:"op_policies"`
+	PathAllow   []string           `json:"path_allow,omitempty"`
+	NetAllow    []string           `json:"net_allow,omitempty"` // CIDR strings (IPv4 or IPv6)
+	Generation  BpfPolicyGeneration `json:"generation"`
+	EnforceMode BpfEnforceMode     `json:"enforce_mode"` // default mode for no-rule ops
+}
+
+// DaemonOpPolicy is one (op, action, enforce_mode) triple in an apply_policy
+// request. It corresponds to one entry written to cgroup_op_policy BPF hash map.
+type DaemonOpPolicy struct {
+	Op          BpfOp          `json:"op"`
+	Action      BpfAction      `json:"action"`
+	EnforceMode BpfEnforceMode `json:"enforce_mode"`
 }
 
 type DaemonHealthRequest struct{}
@@ -137,7 +169,9 @@ func DecodeDaemonProtocolResponse(data []byte) (DaemonProtocolResponse, error) {
 		return DaemonProtocolResponse{}, fmt.Errorf("%w: unsupported response protocol version %q", ErrDaemonProtocol, resp.ProtocolVersion)
 	}
 	switch resp.Method {
-	case "", DaemonProtocolMethodHealth, DaemonProtocolMethodRegisterSession, DaemonProtocolMethodEndSession, DaemonProtocolMethodSessionStatus:
+	case "", DaemonProtocolMethodHealth, DaemonProtocolMethodRegisterSession,
+		DaemonProtocolMethodEndSession, DaemonProtocolMethodSessionStatus,
+		DaemonProtocolMethodApplyPolicy:
 	default:
 		return DaemonProtocolResponse{}, fmt.Errorf("%w: unknown response method %q", ErrDaemonProtocol, resp.Method)
 	}
@@ -150,30 +184,77 @@ func ValidateDaemonProtocolRequest(req DaemonProtocolRequest) error {
 	}
 	switch req.Method {
 	case DaemonProtocolMethodHealth:
-		if req.Health == nil || req.RegisterSession != nil || req.EndSession != nil || req.SessionStatus != nil {
+		if req.Health == nil || req.RegisterSession != nil || req.EndSession != nil || req.SessionStatus != nil || req.ApplyPolicy != nil {
 			return fmt.Errorf("%w: health request must include only health payload", ErrDaemonProtocol)
 		}
 	case DaemonProtocolMethodRegisterSession:
-		if req.RegisterSession == nil || req.Health != nil || req.EndSession != nil || req.SessionStatus != nil {
+		if req.RegisterSession == nil || req.Health != nil || req.EndSession != nil || req.SessionStatus != nil || req.ApplyPolicy != nil {
 			return fmt.Errorf("%w: register_session request must include only register_session payload", ErrDaemonProtocol)
 		}
 		return validateDaemonRegisterSession(*req.RegisterSession)
 	case DaemonProtocolMethodEndSession:
-		if req.EndSession == nil || req.Health != nil || req.RegisterSession != nil || req.SessionStatus != nil {
+		if req.EndSession == nil || req.Health != nil || req.RegisterSession != nil || req.SessionStatus != nil || req.ApplyPolicy != nil {
 			return fmt.Errorf("%w: end_session request must include only end_session payload", ErrDaemonProtocol)
 		}
 		if strings.TrimSpace(req.EndSession.SessionID) == "" {
 			return fmt.Errorf("%w: end_session session_id is required", ErrDaemonProtocol)
 		}
 	case DaemonProtocolMethodSessionStatus:
-		if req.SessionStatus == nil || req.Health != nil || req.RegisterSession != nil || req.EndSession != nil {
+		if req.SessionStatus == nil || req.Health != nil || req.RegisterSession != nil || req.EndSession != nil || req.ApplyPolicy != nil {
 			return fmt.Errorf("%w: session_status request must include only session_status payload", ErrDaemonProtocol)
 		}
 		if strings.TrimSpace(req.SessionStatus.SessionID) == "" {
 			return fmt.Errorf("%w: session_status session_id is required", ErrDaemonProtocol)
 		}
+	case DaemonProtocolMethodApplyPolicy:
+		if req.ApplyPolicy == nil || req.Health != nil || req.RegisterSession != nil || req.EndSession != nil || req.SessionStatus != nil {
+			return fmt.Errorf("%w: apply_policy request must include only apply_policy payload", ErrDaemonProtocol)
+		}
+		return validateDaemonApplyPolicy(*req.ApplyPolicy)
 	default:
 		return fmt.Errorf("%w: unknown method %q", ErrDaemonProtocol, req.Method)
+	}
+	return nil
+}
+
+func validateDaemonApplyPolicy(req DaemonApplyPolicyRequest) error {
+	if strings.TrimSpace(req.SessionID) == "" {
+		return fmt.Errorf("%w: apply_policy session_id is required", ErrDaemonProtocol)
+	}
+	if req.Generation == 0 {
+		return fmt.Errorf("%w: apply_policy generation must be non-zero (0 is reserved for uninitialized)", ErrDaemonProtocol)
+	}
+	seenOps := map[BpfOp]struct{}{}
+	for i, p := range req.OpPolicies {
+		switch p.Op {
+		case BpfOpExec, BpfOpFileRead, BpfOpFileWrite, BpfOpNetConnect, BpfOpExternalSend:
+		default:
+			return fmt.Errorf("%w: apply_policy op_policies[%d]: unknown op %d", ErrDaemonProtocol, i, p.Op)
+		}
+		if _, dup := seenOps[p.Op]; dup {
+			return fmt.Errorf("%w: apply_policy op_policies[%d]: duplicate op %s", ErrDaemonProtocol, i, p.Op)
+		}
+		seenOps[p.Op] = struct{}{}
+		switch p.Action {
+		case BpfActionAllow, BpfActionDeny, BpfActionAllowlist:
+		default:
+			return fmt.Errorf("%w: apply_policy op_policies[%d]: unknown action %d", ErrDaemonProtocol, i, p.Action)
+		}
+		switch p.EnforceMode {
+		case BpfEnforceModePermissive, BpfEnforceModeEnforce:
+		default:
+			return fmt.Errorf("%w: apply_policy op_policies[%d]: unknown enforce_mode %d", ErrDaemonProtocol, i, p.EnforceMode)
+		}
+	}
+	for i, p := range req.PathAllow {
+		if !strings.HasPrefix(p, "/") {
+			return fmt.Errorf("%w: apply_policy path_allow[%d]: path %q must be absolute", ErrDaemonProtocol, i, p)
+		}
+	}
+	switch req.EnforceMode {
+	case BpfEnforceModePermissive, BpfEnforceModeEnforce:
+	default:
+		return fmt.Errorf("%w: apply_policy unknown enforce_mode %d", ErrDaemonProtocol, req.EnforceMode)
 	}
 	return nil
 }

--- a/go/pkg/kernelcapture/daemon_protocol_apply_policy_test.go
+++ b/go/pkg/kernelcapture/daemon_protocol_apply_policy_test.go
@@ -1,0 +1,254 @@
+package kernelcapture_test
+
+// daemon_protocol_apply_policy_test.go — protocol encode/decode/validate tests
+// for the apply_policy method (Slice 4.2).
+//
+// These tests exercise the protocol layer only: JSON round-trip, validation
+// rules, and error messages. No BPF maps, kernel state, or Linux-only code is
+// used; the suite runs on macOS and Linux alike.
+
+import (
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// validApplyPolicyReq returns a minimal valid apply_policy request for tests
+// that need a clean baseline.
+func validApplyPolicyReq() kernelcapture.DaemonApplyPolicyRequest {
+	return kernelcapture.DaemonApplyPolicyRequest{
+		SessionID:   "ses-test-01",
+		Generation:  1,
+		EnforceMode: kernelcapture.BpfEnforceModePermissive,
+		OpPolicies: []kernelcapture.DaemonOpPolicy{
+			{
+				Op:          kernelcapture.BpfOpExec,
+				Action:      kernelcapture.BpfActionAllow,
+				EnforceMode: kernelcapture.BpfEnforceModePermissive,
+			},
+		},
+	}
+}
+
+func applyPolicyRequest(ap kernelcapture.DaemonApplyPolicyRequest) kernelcapture.DaemonProtocolRequest {
+	return kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy:     &ap,
+	}
+}
+
+func TestApplyPolicy_EncodeDecodRoundTrip(t *testing.T) {
+	t.Parallel()
+	req := applyPolicyRequest(validApplyPolicyReq())
+	data, err := kernelcapture.EncodeDaemonProtocolRequest(req)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := kernelcapture.DecodeDaemonProtocolRequest(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Method != kernelcapture.DaemonProtocolMethodApplyPolicy {
+		t.Errorf("method = %q, want %q", got.Method, kernelcapture.DaemonProtocolMethodApplyPolicy)
+	}
+	if got.ApplyPolicy == nil {
+		t.Fatal("ApplyPolicy payload is nil after decode")
+	}
+	if got.ApplyPolicy.SessionID != "ses-test-01" {
+		t.Errorf("session_id = %q, want %q", got.ApplyPolicy.SessionID, "ses-test-01")
+	}
+	if got.ApplyPolicy.Generation != 1 {
+		t.Errorf("generation = %d, want 1", got.ApplyPolicy.Generation)
+	}
+}
+
+func TestApplyPolicy_WithPathAndNetAllow(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.PathAllow = []string{"/data/", "/tmp/ardur/"}
+	ap.NetAllow = []string{"10.0.0.0/8", "192.168.1.0/24"}
+	ap.OpPolicies = append(ap.OpPolicies, kernelcapture.DaemonOpPolicy{
+		Op:          kernelcapture.BpfOpNetConnect,
+		Action:      kernelcapture.BpfActionAllowlist,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+	})
+	req := applyPolicyRequest(ap)
+	data, err := kernelcapture.EncodeDaemonProtocolRequest(req)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := kernelcapture.DecodeDaemonProtocolRequest(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.ApplyPolicy.PathAllow) != 2 {
+		t.Errorf("path_allow len = %d, want 2", len(got.ApplyPolicy.PathAllow))
+	}
+	if len(got.ApplyPolicy.NetAllow) != 2 {
+		t.Errorf("net_allow len = %d, want 2", len(got.ApplyPolicy.NetAllow))
+	}
+}
+
+func TestApplyPolicy_ValidationEmptySessionID(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.SessionID = ""
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for empty session_id, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationGenerationZero(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.Generation = 0
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for generation=0, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationRelativePath(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.PathAllow = []string{"relative/path"}
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for relative path in path_allow, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationUnknownOp(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.OpPolicies = []kernelcapture.DaemonOpPolicy{
+		{Op: 99, Action: kernelcapture.BpfActionAllow, EnforceMode: kernelcapture.BpfEnforceModePermissive},
+	}
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for unknown op, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationDuplicateOp(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.OpPolicies = []kernelcapture.DaemonOpPolicy{
+		{Op: kernelcapture.BpfOpExec, Action: kernelcapture.BpfActionAllow, EnforceMode: kernelcapture.BpfEnforceModePermissive},
+		{Op: kernelcapture.BpfOpExec, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+	}
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for duplicate op, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationUnknownAction(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.OpPolicies = []kernelcapture.DaemonOpPolicy{
+		{Op: kernelcapture.BpfOpExec, Action: 99, EnforceMode: kernelcapture.BpfEnforceModePermissive},
+	}
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for unknown action, got nil")
+	}
+}
+
+func TestApplyPolicy_ValidationUnknownEnforceMode(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	ap.EnforceMode = 99
+	_, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap))
+	if err == nil {
+		t.Fatal("expected error for unknown enforce_mode, got nil")
+	}
+}
+
+func TestApplyPolicy_MutualExclusionWithOtherPayloads(t *testing.T) {
+	t.Parallel()
+	ap := validApplyPolicyReq()
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy:     &ap,
+		Health:          &kernelcapture.DaemonHealthRequest{},
+	}
+	if err := kernelcapture.ValidateDaemonProtocolRequest(req); err == nil {
+		t.Fatal("expected error when apply_policy + health are both set")
+	}
+}
+
+func TestApplyPolicy_AllOpsValid(t *testing.T) {
+	t.Parallel()
+	ops := []kernelcapture.BpfOp{
+		kernelcapture.BpfOpExec,
+		kernelcapture.BpfOpFileRead,
+		kernelcapture.BpfOpFileWrite,
+		kernelcapture.BpfOpNetConnect,
+		kernelcapture.BpfOpExternalSend,
+	}
+	for _, op := range ops {
+		ap := kernelcapture.DaemonApplyPolicyRequest{
+			SessionID:   "ses-allops",
+			Generation:  1,
+			EnforceMode: kernelcapture.BpfEnforceModePermissive,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: op, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+		}
+		if _, err := kernelcapture.EncodeDaemonProtocolRequest(applyPolicyRequest(ap)); err != nil {
+			t.Errorf("op %s: unexpected encode error: %v", op, err)
+		}
+	}
+}
+
+func TestApplyPolicy_ResponseDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	resp := kernelcapture.DaemonProtocolResponse{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		OK:              true,
+		SessionID:       "ses-test-01",
+	}
+	data, err := kernelcapture.EncodeDaemonProtocolResponse(resp)
+	if err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+	got, err := kernelcapture.DecodeDaemonProtocolResponse(data)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.OK {
+		t.Errorf("OK = false, want true")
+	}
+	if got.Method != kernelcapture.DaemonProtocolMethodApplyPolicy {
+		t.Errorf("method = %q, want %q", got.Method, kernelcapture.DaemonProtocolMethodApplyPolicy)
+	}
+}
+
+func TestApplyPolicy_ErrorResponse(t *testing.T) {
+	t.Parallel()
+	resp := kernelcapture.DaemonProtocolResponse{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		OK:              false,
+		Error:           "session not found or not active",
+	}
+	data, err := kernelcapture.EncodeDaemonProtocolResponse(resp)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := kernelcapture.DecodeDaemonProtocolResponse(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OK {
+		t.Errorf("OK = true, want false")
+	}
+	if got.Error == "" {
+		t.Errorf("Error is empty, want non-empty")
+	}
+}

--- a/go/pkg/kernelcapture/process_guard.bpf.c
+++ b/go/pkg/kernelcapture/process_guard.bpf.c
@@ -1,0 +1,449 @@
+//go:build ignore
+
+// process_guard.bpf.c — BPF-LSM enforcement program for Ardur agent governance.
+//
+// Compiled by bpf2go into embedded object files. Enforces per-cgroup op policies
+// loaded by the daemon via apply_policy. This is the kernel half of Epic A —
+// it converts a DENY action stored in the policy maps into a prevented syscall.
+//
+// Hooks:
+//   lsm/bprm_check_security — exec policy (OP_EXEC)
+//   lsm.s/file_open         — file open policy (OP_FILE_READ / OP_FILE_WRITE)
+//   lsm/socket_connect      — network policy (OP_NET_CONNECT)
+//
+// Map write ordering (enforced by daemon apply_policy):
+//   1. Write cgroup_op_policy, cgroup_path_allow, cgroup_net_allow entries.
+//   2. Write cgroup_managed LAST (generation-atomic gate).
+//
+// Until cgroup_managed is written, the cgroup is ungoverned and all ops pass.
+
+#include <linux/bpf.h>
+#include <linux/types.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+// ---------------------------------------------------------------------------
+// Constants — must match bpf_enforce_types.go and bpf_types.py
+// ---------------------------------------------------------------------------
+
+#define ARDUR_ACT_ALLOW     0
+#define ARDUR_ACT_DENY      1
+#define ARDUR_ACT_ALLOWLIST 2
+
+#define ARDUR_ENFORCE_PERMISSIVE 0
+#define ARDUR_ENFORCE_ENFORCE    1
+
+#define ARDUR_OP_EXEC          1
+#define ARDUR_OP_FILE_READ     2
+#define ARDUR_OP_FILE_WRITE    3
+#define ARDUR_OP_NET_CONNECT   4
+
+// cgroup_managed flags
+#define ARDUR_MANAGED_STRICT   1  // bit 0: deny on no-rule (fail-closed)
+
+// kill_switch array index
+#define ARDUR_KILL_SWITCH_IDX  0
+// kill_switch value: 0 = enforcement active, 1 = kill switch engaged (pass all)
+#define ARDUR_KILL_SWITCH_OFF  0
+#define ARDUR_KILL_SWITCH_ON   1
+
+// Path buffer size — matches BpfEnforceEvent.Path in bpf_enforce_types.go
+#define ARDUR_PATH_LEN 256
+
+// Network constants
+#define AF_INET  2
+#define AF_INET6 10
+
+// O_ACCMODE mask (open mode bits)
+#define O_ACCMODE 3
+
+// ---------------------------------------------------------------------------
+// Kernel struct definitions (CO-RE with preserve_access_index)
+// ---------------------------------------------------------------------------
+
+struct linux_binprm {
+	const char *filename;
+} __attribute__((preserve_access_index));
+
+struct path {
+	void *mnt;
+	void *dentry;
+} __attribute__((preserve_access_index));
+
+struct file {
+	struct path f_path;
+	unsigned int f_flags;
+} __attribute__((preserve_access_index));
+
+struct socket {
+	short type;
+} __attribute__((preserve_access_index));
+
+// ---------------------------------------------------------------------------
+// BPF map key/value structs
+// ---------------------------------------------------------------------------
+
+// cgroup_op_policy key: {cgroup_id, op}
+// C layout must match CgroupOpMapKey in bpf_enforce_types.go.
+// __u64 then __u32 → 12 bytes, natural alignment OK (no padding needed for hash).
+struct ardur_cgroup_op_key {
+	__u64 cgroup_id;
+	__u32 op;
+};
+
+// cgroup_op_policy value: {action, enforce_mode, generation}
+struct ardur_cgroup_op_value {
+	__u32 action;
+	__u32 enforce_mode;
+	__u32 generation;
+};
+
+// cgroup_managed key: raw 8 bytes for cgroup_id (avoids __u64 alignment at offset 4)
+struct ardur_managed_key {
+	__u8 cgroup_raw[8];
+};
+
+// cgroup_managed value: {flags, generation}
+// flags bit 0 = ARDUR_MANAGED_STRICT.  generation must match op-policy entries.
+struct ardur_managed_value {
+	__u32 flags;
+	__u32 generation;
+};
+
+// Path LPM trie key: {prefixlen, cgroup_raw[8], path[ARDUR_PATH_LEN]}
+// prefixlen in bits = 64 (cgroup scope) + path_bytes * 8.
+struct ardur_path_lpm_key {
+	__u32 prefixlen;
+	__u8  cgroup_raw[8];
+	char  path[ARDUR_PATH_LEN];
+};
+
+// Net LPM trie key: {prefixlen, cgroup_raw[8], addr[16]}
+// prefixlen in bits = 64 (cgroup scope) + CIDR prefix length.
+// IPv4 stored as 4 bytes in addr[0..3] (network byte order); remaining bytes 0.
+// IPv6 stored as 16 bytes in addr[0..15] (network byte order).
+struct ardur_net_lpm_key {
+	__u32 prefixlen;
+	__u8  cgroup_raw[8];
+	__u8  addr[16];
+};
+
+// Ringbuf event emitted on each policy decision for a governed cgroup.
+struct ardur_enforce_event {
+	__u64 cgroup_id;
+	__u32 pid;
+	__u32 op;
+	__u32 action_taken;
+	__u32 enforce_mode;
+	__u64 observed_ns;
+	char  comm[16];
+	char  path[ARDUR_PATH_LEN];
+};
+
+// ---------------------------------------------------------------------------
+// BPF maps
+// ---------------------------------------------------------------------------
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key,   struct ardur_cgroup_op_key);
+	__type(value, struct ardur_cgroup_op_value);
+} cgroup_op_policy SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__uint(max_entries, 4096);
+	__type(key,   struct ardur_path_lpm_key);
+	__type(value, __u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cgroup_path_allow SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__uint(max_entries, 1024);
+	__type(key,   struct ardur_net_lpm_key);
+	__type(value, __u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cgroup_net_allow SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 4096);
+	__type(key,   struct ardur_managed_key);
+	__type(value, struct ardur_managed_value);
+} cgroup_managed SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key,   __u32);
+	__type(value, __u32);
+} kill_switch SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 14);  // 16 KB
+} enforce_events SEC(".maps");
+
+// Per-CPU scratch map for the path LPM key — avoids a 272-byte BPF stack alloc.
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key,   __u32);
+	__type(value, struct ardur_path_lpm_key);
+} path_lpm_scratch SEC(".maps");
+
+// Per-CPU scratch map for the net LPM key.
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key,   __u32);
+	__type(value, struct ardur_net_lpm_key);
+} net_lpm_scratch SEC(".maps");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static __always_inline int kill_switch_is_on(void)
+{
+	__u32 idx = ARDUR_KILL_SWITCH_IDX;
+	__u32 *v = bpf_map_lookup_elem(&kill_switch, &idx);
+	return v && *v == ARDUR_KILL_SWITCH_ON;
+}
+
+static __always_inline struct ardur_managed_value *
+lookup_managed(__u64 cgroup_id)
+{
+	struct ardur_managed_key k;
+	__builtin_memcpy(k.cgroup_raw, &cgroup_id, 8);
+	return bpf_map_lookup_elem(&cgroup_managed, &k);
+}
+
+static __always_inline struct ardur_cgroup_op_value *
+lookup_op_policy(__u64 cgroup_id, __u32 op, __u32 active_generation)
+{
+	struct ardur_cgroup_op_key k = {.cgroup_id = cgroup_id, .op = op};
+	struct ardur_cgroup_op_value *v = bpf_map_lookup_elem(&cgroup_op_policy, &k);
+	if (!v || v->generation != active_generation)
+		return NULL;
+	return v;
+}
+
+// path_is_allowed looks the supplied path up in the cgroup_path_allow LPM trie.
+// Uses the per-CPU scratch map to avoid large stack allocations.
+// Returns 1 if the path is explicitly allowed, 0 otherwise.
+static int path_is_allowed(__u64 cgroup_id, const char *path_src, int path_len)
+{
+	if (path_len <= 0)
+		return 0;
+
+	__u32 scratch_idx = 0;
+	struct ardur_path_lpm_key *lk =
+		bpf_map_lookup_elem(&path_lpm_scratch, &scratch_idx);
+	if (!lk)
+		return 0;
+
+	__builtin_memset(lk, 0, sizeof(*lk));
+	__builtin_memcpy(lk->cgroup_raw, &cgroup_id, 8);
+
+	int copy_len = path_len < ARDUR_PATH_LEN ? path_len : ARDUR_PATH_LEN;
+	bpf_probe_read_kernel(lk->path, copy_len & (ARDUR_PATH_LEN - 1), path_src);
+
+	// prefixlen: 64 bits for cgroup_raw + path bytes (excluding null terminator)
+	int prefix_bytes = copy_len > 0 ? copy_len - 1 : 0;
+	lk->prefixlen = 64 + ((__u32)prefix_bytes) * 8;
+
+	__u64 *allowed = bpf_map_lookup_elem(&cgroup_path_allow, lk);
+	return allowed && *allowed != 0;
+}
+
+// net_is_allowed looks the IP address up in the cgroup_net_allow LPM trie.
+// addr_bytes: pointer to the raw address bytes (network byte order).
+// addr_len:   4 for IPv4, 16 for IPv6.
+// Returns 1 if the address is explicitly allowed, 0 otherwise.
+static int net_is_allowed(__u64 cgroup_id, const __u8 *addr_bytes, int addr_len)
+{
+	__u32 scratch_idx = 0;
+	struct ardur_net_lpm_key *lk =
+		bpf_map_lookup_elem(&net_lpm_scratch, &scratch_idx);
+	if (!lk)
+		return 0;
+
+	__builtin_memset(lk, 0, sizeof(*lk));
+	__builtin_memcpy(lk->cgroup_raw, &cgroup_id, 8);
+
+	int copy_len = addr_len < 16 ? addr_len : 16;
+	bpf_probe_read_kernel(lk->addr, copy_len & 15, addr_bytes);
+
+	// prefixlen: 64 bits for cgroup scope + full address length for host lookup.
+	// LPM trie will find the longest stored prefix ≤ this.
+	lk->prefixlen = 64 + ((__u32)addr_len) * 8;
+
+	__u64 *allowed = bpf_map_lookup_elem(&cgroup_net_allow, lk);
+	return allowed && *allowed != 0;
+}
+
+// emit_event writes one decision record to the enforce_events ringbuf.
+// path_src may be NULL for network ops.
+static __always_inline void emit_event(
+	__u64 cgroup_id, __u32 op, __u32 action, __u32 enforce_mode,
+	const char *path_src)
+{
+	struct ardur_enforce_event *ev =
+		bpf_ringbuf_reserve(&enforce_events, sizeof(*ev), 0);
+	if (!ev)
+		return;
+	__builtin_memset(ev, 0, sizeof(*ev));
+	ev->cgroup_id    = cgroup_id;
+	ev->pid          = (__u32)(bpf_get_current_pid_tgid() >> 32);
+	ev->op           = op;
+	ev->action_taken = action;
+	ev->enforce_mode = enforce_mode;
+	ev->observed_ns  = bpf_ktime_get_ns();
+	bpf_get_current_comm(ev->comm, sizeof(ev->comm));
+	if (path_src)
+		bpf_probe_read_kernel_str(ev->path, sizeof(ev->path), path_src);
+	bpf_ringbuf_submit(ev, 0);
+}
+
+// decide returns 0 (allow) or -1 (-EPERM, deny) and emits an event.
+// For allowlist ops, path_src/path_len carry the path or addr string for the LPM check.
+static int decide(
+	__u64 cgroup_id, __u32 op,
+	const char *path_src, int path_len,
+	const __u8 *addr_bytes, int addr_len)
+{
+	if (kill_switch_is_on())
+		return 0;
+
+	struct ardur_managed_value *mv = lookup_managed(cgroup_id);
+	if (!mv)
+		return 0;  // cgroup not governed — untouched
+
+	struct ardur_cgroup_op_value *pol =
+		lookup_op_policy(cgroup_id, op, mv->generation);
+
+	if (!pol) {
+		// No rule for this op in the active generation
+		if (mv->flags & ARDUR_MANAGED_STRICT) {
+			emit_event(cgroup_id, op, ARDUR_ACT_DENY, ARDUR_ENFORCE_ENFORCE, path_src);
+			return -1;  // -EPERM: fail-closed
+		}
+		emit_event(cgroup_id, op, ARDUR_ACT_ALLOW, ARDUR_ENFORCE_PERMISSIVE, path_src);
+		return 0;
+	}
+
+	if (pol->action == ARDUR_ACT_DENY) {
+		emit_event(cgroup_id, op, ARDUR_ACT_DENY, pol->enforce_mode, path_src);
+		if (pol->enforce_mode == ARDUR_ENFORCE_ENFORCE)
+			return -1;  // -EPERM
+		return 0;  // permissive: log only
+	}
+
+	if (pol->action == ARDUR_ACT_ALLOWLIST) {
+		int ok = 0;
+		if (op == ARDUR_OP_NET_CONNECT && addr_bytes && addr_len > 0)
+			ok = net_is_allowed(cgroup_id, addr_bytes, addr_len);
+		else if (path_src && path_len > 0)
+			ok = path_is_allowed(cgroup_id, path_src, path_len);
+
+		if (!ok) {
+			emit_event(cgroup_id, op, ARDUR_ACT_DENY, pol->enforce_mode, path_src);
+			if (pol->enforce_mode == ARDUR_ENFORCE_ENFORCE)
+				return -1;
+			return 0;
+		}
+		emit_event(cgroup_id, op, ARDUR_ACT_ALLOW, pol->enforce_mode, path_src);
+		return 0;
+	}
+
+	// ACT_ALLOW or unrecognised: pass
+	emit_event(cgroup_id, op, ARDUR_ACT_ALLOW, pol->enforce_mode, path_src);
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// LSM hooks
+// ---------------------------------------------------------------------------
+
+// guard_bprm_check — intercepts execve/execveat.
+// Reads the executable path via bpf_probe_read_kernel_str on bprm->filename.
+SEC("lsm/bprm_check_security")
+int BPF_PROG(guard_bprm_check, struct linux_binprm *bprm, int ret)
+{
+	if (ret != 0)
+		return ret;
+
+	__u64 cgroup_id = bpf_get_current_cgroup_id();
+
+	char exec_path[ARDUR_PATH_LEN];
+	__builtin_memset(exec_path, 0, sizeof(exec_path));
+	const char *filename = BPF_CORE_READ(bprm, filename);
+	long pret = bpf_probe_read_kernel_str(exec_path, sizeof(exec_path), filename);
+	int path_len = pret > 0 ? (int)pret : 0;
+
+	return decide(cgroup_id, ARDUR_OP_EXEC,
+	              exec_path, path_len, NULL, 0);
+}
+
+// guard_file_open — intercepts open(2)/openat(2) etc.
+// Uses lsm.s (sleepable) to call bpf_d_path for the full resolved path.
+// Distinguishes read vs write by examining f_flags & O_ACCMODE.
+SEC("lsm.s/file_open")
+int BPF_PROG(guard_file_open, struct file *file, int ret)
+{
+	if (ret != 0)
+		return ret;
+
+	__u64 cgroup_id = bpf_get_current_cgroup_id();
+
+	unsigned int flags = BPF_CORE_READ(file, f_flags);
+	__u32 op = ((flags & O_ACCMODE) == 0) ? ARDUR_OP_FILE_READ : ARDUR_OP_FILE_WRITE;
+
+	char path_buf[ARDUR_PATH_LEN];
+	__builtin_memset(path_buf, 0, sizeof(path_buf));
+	long pret = bpf_d_path(&file->f_path, path_buf, sizeof(path_buf));
+	int path_len = pret > 0 ? (int)pret : 0;
+
+	return decide(cgroup_id, op, path_buf, path_len, NULL, 0);
+}
+
+// guard_socket_connect — intercepts connect(2).
+// Reads sa_family and extracts the raw IP address for net LPM lookup.
+SEC("lsm/socket_connect")
+int BPF_PROG(guard_socket_connect, struct socket *sock,
+             struct sockaddr *address, int addrlen, int ret)
+{
+	if (ret != 0)
+		return ret;
+
+	__u64 cgroup_id = bpf_get_current_cgroup_id();
+
+	__u16 sa_family = 0;
+	bpf_probe_read_kernel(&sa_family, sizeof(sa_family), &address->sa_family);
+
+	__u8 addr_buf[16];
+	__builtin_memset(addr_buf, 0, sizeof(addr_buf));
+	int addr_len = 0;
+
+	if (sa_family == AF_INET) {
+		// sin_addr.s_addr is at offset 4 in struct sockaddr_in (after sin_family + sin_port)
+		bpf_probe_read_kernel(addr_buf, 4, (char *)address + 4);
+		addr_len = 4;
+	} else if (sa_family == AF_INET6) {
+		// sin6_addr is at offset 8 in struct sockaddr_in6 (after sin6_family + sin6_port + sin6_flowinfo)
+		bpf_probe_read_kernel(addr_buf, 16, (char *)address + 8);
+		addr_len = 16;
+	} else {
+		// Non-IP socket (e.g. AF_UNIX): pass unconditionally.
+		return 0;
+	}
+
+	return decide(cgroup_id, ARDUR_OP_NET_CONNECT,
+	              NULL, 0, addr_buf, addr_len);
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/go/pkg/kernelcapture/process_guard_generate.go
+++ b/go/pkg/kernelcapture/process_guard_generate.go
@@ -1,0 +1,3 @@
+package kernelcapture
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target bpfel processGuard process_guard.bpf.c -- -I/usr/include

--- a/go/pkg/kernelcapture/types.go
+++ b/go/pkg/kernelcapture/types.go
@@ -186,6 +186,26 @@ type CorrelatorOptions struct {
 	CorrelationGrace time.Duration
 }
 
+// SyntheticKernelReceiptVerdict values for the Verdict field.
+const (
+	// SyntheticKernelReceiptVerdictCompliant means the observed kernel behaviour
+	// matched the active mission policy without intervention.
+	SyntheticKernelReceiptVerdictCompliant = "compliant"
+
+	// SyntheticKernelReceiptVerdictInsufficientEvidence means the correlator
+	// could not establish attribution with sufficient confidence.
+	SyntheticKernelReceiptVerdictInsufficientEvidence = "insufficient_evidence"
+
+	// SyntheticKernelReceiptVerdictDenied means the BPF-LSM enforcement layer
+	// returned -EPERM to the agent process (the syscall was blocked).
+	SyntheticKernelReceiptVerdictDenied = "denied"
+
+	// SyntheticKernelReceiptVerdictBlocked means an allowed but allowlisted op
+	// was observed targeting a path/network destination outside the allowlist;
+	// the event was logged but the syscall was not killed (permissive mode).
+	SyntheticKernelReceiptVerdictBlocked = "blocked"
+)
+
 // SyntheticKernelReceipt is the kernel-effect synthetic receipt projection.
 type SyntheticKernelReceipt struct {
 	EventID               string      `json:"event_id"`


### PR DESCRIPTION
## Summary

- **`process_guard.bpf.c`** — three LSM hooks (`bprm_check_security`, `lsm.s/file_open`, `socket_connect`) backed by six BPF maps that enforce per-cgroup op policies written by the daemon. Kill-switch → cgroup_managed gate → per-op lookup → DENY = -EPERM in ENFORCE mode. Path LPM (via `bpf_d_path`) and net CIDR LPM supported. Every decision emits an `enforce_events` ringbuf record.
- **`apply_policy` protocol method** — `DaemonApplyPolicyRequest` with op_policies, path_allow, net_allow, generation. Generation-atomic write order: op/path/net first, `cgroup_managed` last. Validated: non-zero generation, no duplicate ops, absolute paths only.
- **Daemon integration** — `handleApplyPolicy` resolves session→cgroup_id→`ApplyPolicyMaps`; `runGuardConsumer` (Linux) loads guard program and exposes `policyMaps`; degrades gracefully without BPF-LSM. `RemovePolicyMaps` on session end. `enforce_events` ringbuf consumed to per-session JSONL evidence logs with `denied`/`blocked` verdicts.
- **`InspectBPFLSMPreflight`** — checks `/sys/kernel/btf/vmlinux` (CO-RE) and `/sys/kernel/security/lsm` (`bpf` active) with pass/warn/fail verdicts.
- 11 new protocol tests (macOS-safe); Go suite all green; Python bpf_lower 74 golden tests pass.

## Compile note

`process_guard_generate.go` requires `go generate ./go/pkg/kernelcapture/...` on a Linux host with `clang` + Linux kernel headers + `libbpf-dev` to produce `processguard_bpfel.go`/`.o`. `bpf_policy_apply_linux.go` compiles only on Linux where that generated file exists. The CI kernel-in-loop smoke test (Colima) is the target for exercising the full path; the protocol/policy-write layer is exercised by the macOS-safe tests already in this PR.

## Test plan

- [ ] Go unit tests pass: `cd go && go test ./...`
- [ ] Python bpf_lower tests pass: `cd python && pytest tests/test_bpf_lower.py -q`
- [ ] Linux: `go generate ./go/pkg/kernelcapture/...` (needs clang + Linux headers)
- [ ] Linux (Colima, privileged): `ardur-kernelcaptured --no-ringbuf=false` loads guard, logs `BPF-LSM process_guard loaded`
- [ ] Linux (Colima): `apply_policy` with DENY exec → `execve` returns EPERM
- [ ] Linux (Colima): kill-switch engaged → all ops pass through

Refs: Epic A #63