### PR TITLE
feat(run): wire apply_policy — lowered BPF plans reach the kernelcapture daemon

### DIFF
--- a/python/tests/test_kernel_correlation.py
+++ b/python/tests/test_kernel_correlation.py
@@ -272,3 +272,94 @@ def test_session_status_response_without_enforcement_key(sockdir: Path) -> None:
         daemon.close()
 
     assert "enforcement" not in resp
+
+
+# ── apply_policy (Slice 4.2 wiring) ─────────────────────────────────────────────
+
+
+def test_apply_policy_encodes_and_sends_lowered_plan(sockdir: Path) -> None:
+    """The plan is encoded into the exact wire shape the Go daemon expects."""
+    from vibap.bpf_lower import lower_to_bpf_policy_plan
+    from vibap.bpf_types import ACT_ALLOWLIST, ACT_DENY, ENFORCE_MODE_ENFORCE, OP_EXEC, OP_FILE_READ
+
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": True,
+            "method": "apply_policy",
+            "session_id": "sess-apply-1",
+            "status": "applied",
+        },
+    )
+    daemon.start()
+    plan = lower_to_bpf_policy_plan(
+        forbidden_tools=["bash"],
+        resource_scope=["/data"],
+        enforce_mode=ENFORCE_MODE_ENFORCE,
+    )
+    try:
+        client = kc.KernelCaptureClient(sock)
+        resp = client.apply_policy(session_id="sess-apply-1", plan=plan, generation=1)
+    finally:
+        daemon.close()
+
+    assert resp["status"] == "applied"
+    assert daemon.received is not None
+    assert daemon.received["method"] == "apply_policy"
+    payload = daemon.received["apply_policy"]
+    assert payload["session_id"] == "sess-apply-1"
+    assert payload["generation"] == 1
+    assert payload["enforce_mode"] == ENFORCE_MODE_ENFORCE
+    assert payload["path_allow"] == ["/data"]
+    assert "net_allow" not in payload  # omitted (empty) rather than sent as []
+
+    op_by_code = {entry["op"]: entry for entry in payload["op_policies"]}
+    assert op_by_code[OP_EXEC]["action"] == ACT_DENY  # forbidden_tools:bash -> OP_EXEC deny
+    assert op_by_code[OP_FILE_READ]["action"] == ACT_ALLOWLIST  # resource_scope -> allowlist
+
+
+def test_apply_policy_raises_on_daemon_rejection(sockdir: Path) -> None:
+    from vibap.bpf_lower import lower_to_bpf_policy_plan
+
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": False,
+            "method": "apply_policy",
+            "error": "apply_policy generation must be non-zero (0 is reserved for uninitialized)",
+        },
+    )
+    daemon.start()
+    plan = lower_to_bpf_policy_plan(forbidden_tools=["bash"])
+    try:
+        client = kc.KernelCaptureClient(sock)
+        with pytest.raises(kc.DaemonProtocolError, match="generation must be non-zero"):
+            client.apply_policy(session_id="sess-1", plan=plan, generation=1)
+    finally:
+        daemon.close()
+
+
+def test_apply_policy_raises_unavailable_when_daemon_absent(tmp_path: Path) -> None:
+    from vibap.bpf_lower import lower_to_bpf_policy_plan
+
+    plan = lower_to_bpf_policy_plan(forbidden_tools=["bash"])
+    client = kc.KernelCaptureClient(tmp_path / "absent.sock")
+    with pytest.raises(kc.DaemonUnavailable):
+        client.apply_policy(session_id="sess-1", plan=plan, generation=1)
+
+
+def test_apply_policy_validates_inputs(tmp_path: Path) -> None:
+    from vibap.bpf_lower import lower_to_bpf_policy_plan
+
+    plan = lower_to_bpf_policy_plan(forbidden_tools=["bash"])
+    client = kc.KernelCaptureClient(tmp_path / "x.sock")
+    with pytest.raises(ValueError, match="session_id"):
+        client.apply_policy(session_id="", plan=plan, generation=1)
+    with pytest.raises(ValueError, match="generation"):
+        client.apply_policy(session_id="s", plan=plan, generation=0)
+    with pytest.raises(ValueError, match="generation"):
+        client.apply_policy(session_id="s", plan=plan, generation=-1)

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -28,6 +28,7 @@ from vibap.receipt import verify_chain
 from vibap.run_bridge import (
     ClaudeCodeAdapter,
     EnvProxyAdapter,
+    KernelPolicyEnforcementError,
     RunContext,
     TransparentInterceptAdapter,
     _kernel_enforcement_claim,
@@ -89,6 +90,91 @@ def _hermetic_kernel_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     fake_cgroup_root.mkdir()
     monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(fake_cgroup_root))
     monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(tmp_path / "no-such-daemon.sock"))
+
+
+class _FakeKernelDaemon:
+    """A multi-turn AF_UNIX stand-in for the kernelcapture daemon.
+
+    Unlike a one-shot fake, this accepts a full ``ardur run`` sequence —
+    ``register_session``, ``apply_policy``, and (on cleanup) ``end_session`` —
+    each over its own connection (matching ``KernelCaptureClient._roundtrip``,
+    which opens one connection per call), and records every request it saw.
+    """
+
+    def __init__(self, socket_path: Path, responses: dict[str, dict] | None = None) -> None:
+        self.socket_path = socket_path
+        self.responses = responses or {}
+        self.received: list[dict] = []
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(socket_path))
+        self._server.listen(5)
+        self._server.settimeout(0.2)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve_forever, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _serve_forever(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._server.accept()
+            except OSError:
+                continue
+            with conn:
+                buf = b""
+                while b"\n" not in buf:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    buf += chunk
+                line = buf.split(b"\n", 1)[0]
+                try:
+                    request = json.loads(line.decode("utf-8"))
+                except ValueError:
+                    continue
+                self.received.append(request)
+                method = request.get("method")
+                default_response = {
+                    "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                    "ok": True,
+                    "method": method,
+                }
+                response = self.responses.get(method, default_response)
+                conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+        self._server.close()
+
+
+@pytest.fixture
+def sockdir():
+    """A short-pathed temp dir for AF_UNIX sockets.
+
+    AF_UNIX paths are capped (104 bytes on macOS, 108 on Linux); the deep
+    pytest ``tmp_path`` blows past that on macOS, so bind sockets under /tmp.
+    """
+    path = Path(tempfile.mkdtemp(dir="/tmp"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _live_kernel_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, sockdir: Path) -> Path:
+    """Point cgroup v2 + the daemon socket at fakes that look "available".
+
+    Returns the socket path a :class:`_FakeKernelDaemon` should bind to.
+    """
+    fake_cgroup_root = tmp_path / "fake-cgroup"
+    fake_cgroup_root.mkdir()
+    (fake_cgroup_root / "cgroup.controllers").write_text("cpu memory\n", encoding="utf-8")
+    monkeypatch.setenv(kc.CGROUP_ROOT_ENV, str(fake_cgroup_root))
+    socket_path = sockdir / "daemon.sock"
+    monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(socket_path))
+    return socket_path
 
 
 def test_ardur_run_governs_launched_agent_zero_setup(
@@ -174,6 +260,158 @@ def test_ardur_run_denies_when_no_tools_allowed(
     assert result.denials >= 1
     assert result.receipt_count == 3
     assert result.attestation_token
+
+
+# ── kernel policy wiring (Slice 4.2 apply_policy bridge) ────────────────────────
+
+
+def test_ardur_run_applies_kernel_policy_when_daemon_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path, sockdir: Path
+) -> None:
+    """End to end: a real cgroup + a live (fake) daemon get a lowered BPF plan.
+
+    Proves the plan is actually encoded and sent over the socket by the
+    run_bridge orchestration, not just by the client method in isolation.
+    """
+    socket_path = _live_kernel_env(monkeypatch, tmp_path, sockdir)
+    daemon = _FakeKernelDaemon(
+        socket_path,
+        responses={
+            "register_session": {
+                "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                "ok": True,
+                "method": "register_session",
+                "status": "registered",
+            },
+            "apply_policy": {
+                "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                "ok": True,
+                "method": "apply_policy",
+                "status": "applied",
+            },
+        },
+    )
+    daemon.start()
+    try:
+        result = run_governed(
+            command=[sys.executable, str(standin_agent)],
+            mission="Kernel policy applied end to end.",
+            allowed_tools=["Read", "Glob", "Grep"],
+            forbidden_tools=["Bash"],
+            max_tool_calls=10,
+            home=tmp_path / "kernel-home",
+            via="env",
+            enforce=True,
+        )
+    finally:
+        daemon.close()
+
+    assert result.correlation["available"] is True
+    assert result.kernel_policy["applied"] is True
+    assert result.kernel_policy["generation"] == 1
+
+    methods = [req.get("method") for req in daemon.received]
+    assert "register_session" in methods
+    assert "apply_policy" in methods
+    # apply_policy must follow register_session (called "after cgroup registration").
+    assert methods.index("apply_policy") > methods.index("register_session")
+
+    apply_req = next(req["apply_policy"] for req in daemon.received if req.get("method") == "apply_policy")
+    assert apply_req["session_id"] == result.session_id
+    assert apply_req["generation"] == 1
+    assert apply_req["enforce_mode"] == 1  # ENFORCE_MODE_ENFORCE
+
+    from vibap.bpf_types import ACT_DENY, OP_EXEC
+
+    op_by_code = {entry["op"]: entry for entry in apply_req["op_policies"]}
+    assert op_by_code[OP_EXEC]["action"] == ACT_DENY  # forbidden_tools=["Bash"] -> OP_EXEC deny
+
+
+def test_ardur_run_permissive_records_degradation_note_without_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path
+) -> None:
+    """Default (permissive) mode: no daemon -> a recorded note, run still succeeds."""
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    home = tmp_path / "permissive-home"
+
+    result = run_governed(
+        command=[sys.executable, str(standin_agent)],
+        mission="Permissive kernel policy degrades gracefully.",
+        allowed_tools=["Read", "Glob", "Grep"],
+        forbidden_tools=["Bash"],
+        max_tool_calls=10,
+        home=home,
+        via="env",
+        # enforce defaults to False
+    )
+    assert result.exit_code == 0
+    assert result.kernel_policy["applied"] is False
+    assert "kernel policy not applied" in result.kernel_policy["reason"]
+    assert any("kernel policy not applied" in note for note in result.notes)
+
+
+def test_ardur_run_enforce_aborts_when_kernel_daemon_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path
+) -> None:
+    """--enforce with no daemon present: the run aborts loudly, agent is killed."""
+    _hermetic_kernel_env(monkeypatch, tmp_path)
+    home = tmp_path / "enforce-abort-home"
+
+    with pytest.raises(KernelPolicyEnforcementError, match="kernel policy not applied"):
+        run_governed(
+            command=[sys.executable, str(standin_agent)],
+            mission="Enforce mode requires kernel policy or the run must abort.",
+            allowed_tools=["Read"],
+            forbidden_tools=["Bash"],
+            max_tool_calls=10,
+            home=home,
+            via="env",
+            enforce=True,
+        )
+
+
+def test_ardur_run_enforce_aborts_when_daemon_rejects_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, standin_agent: Path, sockdir: Path
+) -> None:
+    """--enforce with a daemon present that rejects apply_policy also aborts."""
+    socket_path = _live_kernel_env(monkeypatch, tmp_path, sockdir)
+    daemon = _FakeKernelDaemon(
+        socket_path,
+        responses={
+            "register_session": {
+                "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                "ok": True,
+                "method": "register_session",
+                "status": "registered",
+            },
+            "apply_policy": {
+                "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                "ok": False,
+                "method": "apply_policy",
+                "error": "no BPF-LSM guard loaded on this host",
+            },
+        },
+    )
+    daemon.start()
+    try:
+        with pytest.raises(KernelPolicyEnforcementError, match="no BPF-LSM guard loaded"):
+            run_governed(
+                command=[sys.executable, str(standin_agent)],
+                mission="Enforce mode aborts on daemon rejection.",
+                allowed_tools=["Read"],
+                forbidden_tools=["Bash"],
+                max_tool_calls=10,
+                home=tmp_path / "enforce-reject-home",
+                via="env",
+                enforce=True,
+            )
+    finally:
+        daemon.close()
+
+    methods = [req.get("method") for req in daemon.received]
+    assert methods.count("apply_policy") == 1
+    # Cleanup still runs (finally-block end_session) even though the run aborted.
+    assert "end_session" in methods
 
 
 def test_run_governed_rejects_empty_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -1957,7 +1957,7 @@ def _run_has_governance_intent(args: argparse.Namespace) -> bool:
     """
     return any(
         getattr(args, name, None) not in (None, False)
-        for name in ("mission", "allowed_tools", "forbidden_tools", "via", "govern")
+        for name in ("mission", "allowed_tools", "forbidden_tools", "via", "govern", "enforce")
     ) or getattr(args, "max_tool_calls", None) is not None
 
 
@@ -3281,6 +3281,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-kernel-correlation",
         action="store_true",
         help="skip eBPF daemon/cgroup correlation even when available",
+    )
+    run.add_argument(
+        "--enforce",
+        action="store_true",
+        help="abort the run if kernel-level BPF policy enforcement cannot be installed "
+        "(default: permissive — degrade to hook/proxy governance with a recorded note)",
     )
     run.add_argument("command", nargs=argparse.REMAINDER, help="command to run after --")
     run.set_defaults(func=cmd_run)

--- a/python/vibap/kernel_correlation.py
+++ b/python/vibap/kernel_correlation.py
@@ -22,6 +22,18 @@ Wire protocol (one JSON object + ``\\n`` per message, JSON-line framed):
     response: {"protocol_version": "kernelcapture.daemon.v1", "ok": true,
                "method": "register_session", "session_id": ..., "status": ...}
 
+``apply_policy`` (Slice 4.2, go/pkg/kernelcapture/daemon_protocol.go) installs a
+lowered ``bpf_lower.BpfPolicyPlan`` into the six BPF enforcement maps for the
+session's cgroup:
+
+    request:  {"protocol_version": "kernelcapture.daemon.v1",
+               "method": "apply_policy",
+               "apply_policy": {"session_id": ..., "op_policies": [...],
+                                "path_allow": [...], "net_allow": [...],
+                                "generation": ..., "enforce_mode": ...}}
+    response: {"protocol_version": "kernelcapture.daemon.v1", "ok": true,
+               "method": "apply_policy", "session_id": ...}
+
 The daemon authenticates the peer at the socket layer (SO_PEERCRED on Linux),
 so the client carries no token. Daemon-owned path fields and peer-identity
 fields are rejected by the daemon if a client tries to smuggle them in; this
@@ -36,7 +48,10 @@ import socket
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .bpf_lower import BpfPolicyPlan
 
 # Must track go/pkg/kernelcapture/daemon_protocol.go.
 DAEMON_PROTOCOL_VERSION = "kernelcapture.daemon.v1"
@@ -170,6 +185,48 @@ class KernelCaptureClient:
                 "protocol_version": DAEMON_PROTOCOL_VERSION,
                 "method": "register_session",
                 "register_session": register,
+            }
+        )
+
+    def apply_policy(
+        self,
+        *,
+        session_id: str,
+        plan: BpfPolicyPlan,
+        generation: int,
+    ) -> dict[str, Any]:
+        """Install a lowered BPF policy plan for ``session_id``'s cgroup.
+
+        Encodes ``plan`` (the ``bpf_lower.lower_to_bpf_policy_plan`` output)
+        into the wire-format ``DaemonApplyPolicyRequest`` the Go daemon expects
+        (``go/pkg/kernelcapture/daemon_protocol.go``). ``generation`` must be a
+        positive, per-session-monotonic counter: the BPF program treats 0 as
+        "uninitialized" and the daemon rejects it. Deep validation (op/action/
+        enforce_mode enum values, duplicate ops, absolute paths) happens
+        daemon-side; a rejection surfaces as :class:`DaemonProtocolError`.
+        """
+        if not session_id:
+            raise ValueError("session_id is required")
+        if generation <= 0:
+            raise ValueError("generation must be a positive integer")
+        apply_policy: dict[str, Any] = {
+            "session_id": session_id,
+            "op_policies": [
+                {"op": entry.op, "action": entry.action, "enforce_mode": entry.enforce_mode}
+                for entry in plan.op_policies
+            ],
+            "generation": int(generation),
+            "enforce_mode": plan.enforce_mode,
+        }
+        if plan.path_allow:
+            apply_policy["path_allow"] = list(plan.path_allow)
+        if plan.net_allow:
+            apply_policy["net_allow"] = list(plan.net_allow)
+        return self._roundtrip(
+            {
+                "protocol_version": DAEMON_PROTOCOL_VERSION,
+                "method": "apply_policy",
+                "apply_policy": apply_policy,
             }
         )
 

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -39,9 +39,12 @@ import urllib.request
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from . import kernel_correlation as kc
+
+if TYPE_CHECKING:
+    from .passport import MissionPassport
 
 # Environment-variable contract the bridge exports to the launched agent. The
 # proxy-routed path (EnvProxyAdapter) and any cooperating agent read these.
@@ -57,6 +60,12 @@ DEFAULT_MAX_TOOL_CALLS = 250
 DEFAULT_MAX_DURATION_S = 86400
 
 VALID_VIA_MODES = ("auto", "env", "claude-code", "intercept")
+
+
+class KernelPolicyEnforcementError(RuntimeError):
+    """Raised when ``--enforce`` requires kernel-level BPF policy and it cannot
+    be installed (daemon absent, cgroup uncorrelated, or the daemon rejected
+    the plan). Callers must treat this as a hard abort of the run."""
 
 
 # ── agent adapters ─────────────────────────────────────────────────────────────
@@ -359,6 +368,7 @@ class GovernanceRunResult:
     receipts_path: str
     receipt_count: int
     correlation: dict[str, Any]
+    kernel_policy: dict[str, Any]
     notes: list[str] = field(default_factory=list)
 
 
@@ -480,6 +490,74 @@ def _kernel_enforcement_claim(
     return enforcement
 
 
+def _apply_kernel_policy(
+    *,
+    session_id: str,
+    passport: "MissionPassport",
+    correlation: kc.CorrelationResult,
+    enforce: bool,
+) -> dict[str, Any]:
+    """Lower the passport's policy and push it to the daemon's BPF maps.
+
+    Loud-abort contract: when ``enforce`` is True, any failure to install
+    kernel-level enforcement — the cgroup never got correlated with the
+    daemon, or the daemon rejected the plan — raises
+    :class:`KernelPolicyEnforcementError` so the caller aborts the run instead
+    of letting the agent proceed unguarded. When ``enforce`` is False the same
+    failures degrade to a recorded reason in the returned dict; the hook/proxy
+    path still governs the run.
+
+    ``bpf_lower`` (and the mission compiler it builds on) is only imported
+    once a live daemon correlation exists. That keeps the common degraded
+    path — no kernelcapture daemon on the host, the default on most installs
+    — free of the mission-compiler's optional dependencies (e.g.
+    ``biscuit-python``, a ``[dev]`` extra) so a plain ``ardur run`` never pays
+    for kernel-enforcement machinery it isn't using.
+    """
+    if not correlation.available:
+        reason = f"kernel policy not applied: {correlation.reason}"
+        if enforce:
+            raise KernelPolicyEnforcementError(reason)
+        return {"applied": False, "reason": reason, "tier2_ops": []}
+
+    from .bpf_lower import lower_to_bpf_policy_plan
+    from .bpf_types import ENFORCE_MODE_ENFORCE, ENFORCE_MODE_PERMISSIVE
+
+    plan = lower_to_bpf_policy_plan(
+        allowed_side_effect_classes=passport.allowed_side_effect_classes,
+        forbidden_tools=passport.forbidden_tools,
+        allowed_tools=passport.allowed_tools,
+        resource_scope=passport.resource_scope,
+        enforce_mode=ENFORCE_MODE_ENFORCE if enforce else ENFORCE_MODE_PERMISSIVE,
+    )
+    tier2_ops = list(plan.tier2_ops)
+
+    if not plan.op_policies and not plan.path_allow and not plan.net_allow:
+        return {
+            "applied": False,
+            "reason": "mission has no kernel-enforceable policy dimensions",
+            "tier2_ops": tier2_ops,
+        }
+
+    generation = 1  # first (and only) apply for this fresh session/cgroup pair.
+    try:
+        kc.KernelCaptureClient(kc.daemon_socket_path()).apply_policy(
+            session_id=session_id, plan=plan, generation=generation
+        )
+    except (kc.DaemonUnavailable, kc.DaemonProtocolError, ValueError) as exc:
+        reason = f"kernel policy apply rejected: {exc}"
+        if enforce:
+            raise KernelPolicyEnforcementError(reason) from exc
+        return {"applied": False, "reason": reason, "tier2_ops": tier2_ops}
+
+    return {
+        "applied": True,
+        "reason": "kernel BPF policy installed",
+        "generation": generation,
+        "tier2_ops": tier2_ops,
+    }
+
+
 # ── main entry ─────────────────────────────────────────────────────────────────
 
 
@@ -496,6 +574,7 @@ def run_governed(
     agent_id: str = DEFAULT_AGENT_ID,
     env: dict[str, str] | None = None,
     enable_kernel_correlation: bool = True,
+    enforce: bool = False,
     cwd: Path | None = None,
     stdout: Any | None = None,
     stderr: Any | None = None,
@@ -503,8 +582,11 @@ def run_governed(
     """Launch ``command`` under a fresh, fully-governed Ardur session.
 
     Returns a :class:`GovernanceRunResult` once the agent exits. Raises
-    ``ValueError`` for invalid input (empty command, bad ``via``) and
-    ``NotImplementedError`` for the scaffolded intercept path.
+    ``ValueError`` for invalid input (empty command, bad ``via``),
+    ``NotImplementedError`` for the scaffolded intercept path, and
+    :class:`KernelPolicyEnforcementError` when ``enforce=True`` and
+    kernel-level BPF policy enforcement could not be installed — the launched
+    agent is killed before the error propagates.
     """
     from .passport import MissionPassport, generate_keypair, issue_passport
 
@@ -620,6 +702,24 @@ def run_governed(
         )
         daemon_registered = correlation.available
 
+        # 5b. Push the mission's lowered BPF policy to the daemon now that the
+        # cgroup is registered. Under --enforce a failure here kills the agent
+        # and aborts the run; under permissive it degrades to a recorded note.
+        try:
+            kernel_policy = _apply_kernel_policy(
+                session_id=session_id,
+                passport=passport,
+                correlation=correlation,
+                enforce=enforce,
+            )
+        except KernelPolicyEnforcementError as exc:
+            notes.append(f"ENFORCE abort: {exc}")
+            proc.kill()
+            proc.wait()
+            raise
+        if not kernel_policy["applied"]:
+            notes.append(kernel_policy["reason"])
+
         # 6. Wait for the agent to exit (bounded by the mission duration budget).
         try:
             exit_code = proc.wait(timeout=max_duration_s)
@@ -672,6 +772,7 @@ def run_governed(
         receipts_path=str(receipts_path),
         receipt_count=_count_lines(receipts_path),
         correlation=correlation.to_dict(),
+        kernel_policy=dict(kernel_policy),
         notes=notes,
     )
     return result
@@ -712,6 +813,7 @@ def format_summary(result: GovernanceRunResult) -> str:
         f"  receipts      {result.receipt_count} signed → {result.receipts_path}",
         f"  attestation   {result.attestation_digest}",
         f"  kernel link   {result.correlation.get('reason')}",
+        f"  kernel policy {result.kernel_policy.get('reason')}",
         f"  agent exit    {result.exit_code}",
     ]
     for note in result.notes:
@@ -787,10 +889,14 @@ def run_governed_cli(args: Any) -> int:
             home=getattr(args, "home", None),
             via=getattr(args, "via", None) or "auto",
             enable_kernel_correlation=not getattr(args, "no_kernel_correlation", False),
+            enforce=bool(getattr(args, "enforce", False)),
         )
     except NotImplementedError as exc:
         print(f"ardur run: {exc}", file=sys.stderr)
         return 2
+    except KernelPolicyEnforcementError as exc:
+        print(f"ardur run: --enforce requires kernel-level policy enforcement: {exc}", file=sys.stderr)
+        return 3
     except ValueError as exc:
         print(f"ardur run: {exc}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary

Epic A (#63), plan E2. The gap: nothing in Python ever called `apply_policy`, so `bpf_lower`'s lowered `BpfPolicyPlan` objects never reached the daemon and Slice 4.2 enforcement was dead code end to end — a mission could declare `forbidden_tools`/`resource_scope` and the BPF-LSM guard would never see it.

- `python/vibap/kernel_correlation.py`: `KernelCaptureClient.apply_policy()` — encodes a `BpfPolicyPlan` into the wire-format `DaemonApplyPolicyRequest` the Go daemon expects (`go/pkg/kernelcapture/daemon_protocol.go`, from PR #92).
- `python/vibap/run_bridge.py`: `_apply_kernel_policy()` orchestrates the call after cgroup registration succeeds (`register_session`). New `--enforce` flag on `ardur run`:
  - **ENFORCE** (`--enforce`): daemon absent, cgroup uncorrelated, or the daemon rejects the plan → `KernelPolicyEnforcementError`, the launched agent is killed immediately, the run aborts loudly.
  - **PERMISSIVE** (default): the same failures degrade to a recorded note in `GovernanceRunResult.kernel_policy` / `result.notes`; the hook/proxy path keeps governing.
- `python/vibap/cli.py`: `--enforce` flag wired into the `run` subparser and into `_run_has_governance_intent`.

## Packaging note (found + fixed while wiring this up)

`bpf_lower` → `mission_compile` imports `biscuit_auth` unconditionally, and `biscuit-python` is a `[dev]`-only extra, not a core dependency. A naive call site would make every `ardur run` — even the common case with no kernelcapture daemon on the host — require `biscuit-python` at runtime. `_apply_kernel_policy` defers the `bpf_lower` import until *after* confirming a live daemon correlation, so the degraded (no-daemon) path never touches it. Verified by running the full degraded path in a venv built without `[dev]` extras (`biscuit_auth` never enters `sys.modules`).

## ⚠️ Merge order

This depends on PR #92 (`feat/epicA-slice4.2-lsm`) for the `DaemonApplyPolicyRequest`/`apply_policy` Go-side protocol and daemon handler. **This PR should merge after #92.** The Python side here is independently testable against a mocked daemon socket and doesn't touch any Go files.

## Test plan

- [x] New tests in `test_kernel_correlation.py`: `apply_policy` encodes the plan into the correct wire shape, round-trips through a fake daemon, raises `DaemonProtocolError` on rejection, raises `DaemonUnavailable` when the socket is absent, validates `session_id`/`generation` inputs.
- [x] New tests in `test_run_bridge.py`: end-to-end happy path against a multi-method fake daemon (proves `apply_policy` is actually sent, after `register_session`, with the correctly-lowered op policies); permissive-mode degradation note when no daemon is present; `--enforce` abort when the daemon is absent; `--enforce` abort when the daemon rejects the plan (agent killed, cleanup still runs).
- [x] Full existing suite: `pytest tests/` → 1155 passed, 2 pre-existing failures unrelated to this change (`test_provider_adapter_fixtures.py`, confirmed failing on a clean `origin/dev` checkout before this branch existed), 32 skipped.
- [x] `ruff check` clean on all changed files.
- [x] Verified the no-daemon path never imports `biscuit_auth` in a venv built without `[dev]` extras.