### PR TITLE
fix(benchcheck): gitignore bench-results and fix make clean's output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ _internal/
 go/operator
 go/webhook
 
+# `make bench` output (go/cmd/benchcheck writes here; see the `bench` target).
+go/bench-results/
+
 # Hugo site build output.
 site/public/
 site/resources/_gen/

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,4 @@ clean: ## Remove build artifacts
 	find $(PYDIR) -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find $(PYDIR) -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find $(PYDIR) -type d -name '*.egg-info' -exec rm -rf {} + 2>/dev/null || true
-	rm -rf bench-results
+	rm -rf $(GODIR)/bench-results


### PR DESCRIPTION
## Summary
- `make bench` writes to `go/bench-results/` (the `cd $(GODIR)` in the `bench` target happens before benchcheck's default relative `-out bench-results` is resolved), but `.gitignore` had no entry for it, so the output dir showed up as untracked and could be accidentally committed.
- `make clean` ran `rm -rf bench-results` from the repo root, which never matched the real `go/bench-results/` output location.

## Fix
- Add `go/bench-results/` to `.gitignore`.
- Fix `clean` to `rm -rf $(GODIR)/bench-results`.

## Test plan
- [x] `make bench` — output lands in `go/bench-results/`, confirmed absent from `git status --short`.
- [x] `make clean` — confirmed `go/bench-results/` is removed.

Closes #93