### PR TITLE
fix(kernelcapture): wire pinned eBPF restart path to the correct ringbuf map

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_linux.go
@@ -66,9 +66,12 @@ func runWatchdog(ctx context.Context, interval time.Duration, log *slog.Logger) 
 //
 // Claim boundary: loads the process-exec eBPF objects embedded in the binary,
 // attaches sched/sched_process_exec and sched/sched_process_exit, reads events
-// from the BPF ringbuf, and routes them to registered sessions. Does NOT pin
-// maps on bpffs, create or join cgroups, install/start a system service, or
-// enforce any action against the observed process.
+// from the BPF ringbuf, and routes them to registered sessions. Pins the
+// tracepoint links and ringbuf map under the ardur-owned bpffs namespace
+// (kernelcapture.DefaultPinnedEBPFPaths) so a daemon restart reuses the
+// still-attached programs instead of re-attaching. Does NOT create or join
+// cgroups, install/start a system service, or enforce any action against the
+// observed process.
 func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 	btfPath := "/sys/kernel/btf/vmlinux"
 	if _, err := os.Stat(btfPath); err != nil {
@@ -81,7 +84,7 @@ func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 		"btf", btfPath,
 	)
 
-	handles, err := kernelcapture.LoadAndAttachProcessExecEBPF()
+	handles, err := kernelcapture.LoadAndAttachProcessExecEBPFPinned(kernelcapture.DefaultPinnedEBPFPaths())
 	if err != nil {
 		return fmt.Errorf("load and attach eBPF: %w", err)
 	}

--- a/go/pkg/kernelcapture/linux_ebpf_daemon_linux.go
+++ b/go/pkg/kernelcapture/linux_ebpf_daemon_linux.go
@@ -5,6 +5,7 @@ package kernelcapture
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -18,7 +19,12 @@ type ProcessExecEBPFHandles struct {
 	objs   processExecObjects
 	execTP link.Link
 	exitTP link.Link
-	reader *ringbuf.Reader
+	// eventsMap is only set when reusing a pinned ringbuf map across a
+	// daemon restart (see LoadAndAttachProcessExecEBPFPinned); on a fresh
+	// load the map is owned by objs instead. Close must release it either
+	// way.
+	eventsMap *ebpf.Map
+	reader    *ringbuf.Reader
 }
 
 // Reader returns the ringbuf.Reader for consuming process lifecycle events.
@@ -33,6 +39,9 @@ func (h *ProcessExecEBPFHandles) Close() {
 	}
 	if h.reader != nil {
 		_ = h.reader.Close()
+	}
+	if h.eventsMap != nil {
+		_ = h.eventsMap.Close()
 	}
 	if h.exitTP != nil {
 		_ = h.exitTP.Close()
@@ -103,30 +112,42 @@ type PinnedEBPFPaths struct {
 	ExecLinkPath string
 	// ExitLinkPath is the bpffs pin path for the exit tracepoint link.
 	ExitLinkPath string
+	// EventsMapPath is the bpffs pin path for the process-lifecycle ringbuf
+	// map. A restart reuses this exact map so the reader stays bound to
+	// whatever the pinned (still-attached) programs are writing into.
+	EventsMapPath string
 }
 
 // DefaultPinnedEBPFPaths returns the standard bpffs pin paths under the
-// ardur-owned bpffs namespace (/sys/fs/bpf/ardur/).
+// ardur-owned bpffs namespace (/sys/fs/bpf/ardur/). EventsMapPath matches the
+// ringbuf map path recorded by BuildDaemonCustodyPlan.
 func DefaultPinnedEBPFPaths() PinnedEBPFPaths {
 	return PinnedEBPFPaths{
-		ExecLinkPath: "/sys/fs/bpf/ardur/exec_tp_link",
-		ExitLinkPath: "/sys/fs/bpf/ardur/exit_tp_link",
+		ExecLinkPath:  "/sys/fs/bpf/ardur/exec_tp_link",
+		ExitLinkPath:  "/sys/fs/bpf/ardur/exit_tp_link",
+		EventsMapPath: "/sys/fs/bpf/ardur/process_lifecycle_events",
 	}
 }
 
 // LoadAndAttachProcessExecEBPFPinned is like LoadAndAttachProcessExecEBPF but
-// adds BPF link-pinning for restart survival.
+// adds BPF link- and map-pinning for restart survival.
 //
-// On first start (no pinned links at paths): loads and attaches the eBPF
-// program as usual, then pins both tracepoint links to bpffs. The pins keep
-// the links — and thus the attached programs — alive in the kernel even after
-// the daemon exits. A ringbuf map pin is also created so no events are lost
-// during the restart gap.
+// On first start (no pinned state at paths): loads and attaches the eBPF
+// program as usual, then pins both tracepoint links and the ringbuf map to
+// bpffs. The pins keep the links — and thus the attached programs — alive in
+// the kernel even after the daemon exits, and keep the ringbuf map reachable
+// so no events are lost during the restart gap.
 //
-// On restart (pinned links exist at paths): loads the pinned links back
-// without re-attaching, which avoids a brief window where the tracepoints are
-// detached. The eBPF program has been continuously running in the kernel since
-// the prior daemon start.
+// On restart (pinned links AND the pinned ringbuf map all exist at paths):
+// loads the pinned links back without re-attaching, which avoids a brief
+// window where the tracepoints are detached, and loads the pinned map to open
+// a new reader bound to the exact map the still-attached programs write into.
+// The eBPF program has been continuously running in the kernel since the
+// prior daemon start.
+//
+// If any of the three pins is missing (e.g. a prior pin attempt partially
+// failed), the pinned state is treated as unusable and the function falls
+// back to a fresh load/attach/pin, matching first-start behavior.
 //
 // If pinning fails (e.g., bpffs not mounted, insufficient permissions), the
 // function returns the handles without pins and logs the failure. The daemon
@@ -136,30 +157,24 @@ func DefaultPinnedEBPFPaths() PinnedEBPFPaths {
 // remove the bpffs pins; they are intentionally left for the next daemon
 // start. To remove pins call os.Remove on the PinnedEBPFPaths.
 func LoadAndAttachProcessExecEBPFPinned(paths PinnedEBPFPaths) (*ProcessExecEBPFHandles, error) {
-	// ── Try to reuse pinned links from a previous daemon run ──────────────
-	if execLink, exitLink, ok := tryLoadPinnedLinks(paths); ok {
-		// Both links are alive — the eBPF programs are still attached in the
-		// kernel. We only need a fresh ringbuf reader.
-		h := &ProcessExecEBPFHandles{
-			execTP: execLink,
-			exitTP: exitLink,
-		}
-		// Load fresh eBPF objects to get access to the ringbuf map for a new
-		// reader. The loaded programs/maps co-exist with the pinned ones.
-		if err := loadProcessExecObjects(&h.objs, nil); err != nil {
-			execLink.Close()
-			exitLink.Close()
-			return nil, fmt.Errorf("load eBPF objects for ringbuf reader: %w", err)
-		}
-		reader, err := ringbuf.NewReader(h.objs.Events)
+	// ── Try to reuse pinned links + map from a previous daemon run ────────
+	if execLink, exitLink, eventsMap, ok := tryLoadPinnedState(paths); ok {
+		// The links are alive — the eBPF programs are still attached in the
+		// kernel and writing into eventsMap. Open a reader bound to that
+		// same map so restart doesn't lose the events the programs emit.
+		reader, err := ringbuf.NewReader(eventsMap)
 		if err != nil {
-			h.objs.Close()
-			execLink.Close()
-			exitLink.Close()
+			_ = eventsMap.Close()
+			_ = exitLink.Close()
+			_ = execLink.Close()
 			return nil, fmt.Errorf("open ringbuf reader (pinned restart): %w", err)
 		}
-		h.reader = reader
-		return h, nil
+		return &ProcessExecEBPFHandles{
+			execTP:    execLink,
+			exitTP:    exitLink,
+			eventsMap: eventsMap,
+			reader:    reader,
+		}, nil
 	}
 
 	// ── Fresh load and attach ──────────────────────────────────────────────
@@ -168,32 +183,44 @@ func LoadAndAttachProcessExecEBPFPinned(paths PinnedEBPFPaths) (*ProcessExecEBPF
 		return nil, err
 	}
 
-	// Ensure the bpffs directory exists before pinning.
-	if mkErr := os.MkdirAll("/sys/fs/bpf/ardur", 0o700); mkErr == nil {
-		// Pin exec link; non-fatal on failure.
+	// Ensure the bpffs directories for all three pin paths exist, then pin
+	// the exec link, exit link, and ringbuf map; each Pin is non-fatal on
+	// failure. A partial pin (e.g. links pinned but the map pin fails) makes
+	// tryLoadPinnedState fail on the next restart, which falls back to this
+	// fresh-load path again rather than reusing a stale link.
+	if mkErr := os.MkdirAll(filepath.Dir(paths.ExecLinkPath), 0o700); mkErr == nil {
 		_ = h.execTP.Pin(paths.ExecLinkPath)
-		// Pin exit link; non-fatal on failure.
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(paths.ExitLinkPath), 0o700); mkErr == nil {
 		_ = h.exitTP.Pin(paths.ExitLinkPath)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(paths.EventsMapPath), 0o700); mkErr == nil {
+		_ = h.objs.Events.Pin(paths.EventsMapPath)
 	}
 
 	return h, nil
 }
 
-// tryLoadPinnedLinks attempts to load both tracepoint links from bpffs.
-// Returns (execLink, exitLink, true) if both succeed; otherwise closes any
-// partially-opened link and returns (nil, nil, false).
-func tryLoadPinnedLinks(paths PinnedEBPFPaths) (link.Link, link.Link, bool) {
+// tryLoadPinnedState attempts to load both tracepoint links and the ringbuf
+// map from bpffs. Returns ok=true only if all three succeed; otherwise it
+// closes any partially-opened handles and returns ok=false so the caller
+// falls back to a fresh load rather than binding a reader to a map the
+// attached programs are not writing into.
+func tryLoadPinnedState(paths PinnedEBPFPaths) (execLink, exitLink link.Link, eventsMap *ebpf.Map, ok bool) {
 	execLink, err := link.LoadPinnedLink(paths.ExecLinkPath, nil)
 	if err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	exitLink, err := link.LoadPinnedLink(paths.ExitLinkPath, nil)
+	exitLink, err = link.LoadPinnedLink(paths.ExitLinkPath, nil)
 	if err != nil {
 		_ = execLink.Close()
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return execLink, exitLink, true
+	eventsMap, err = ebpf.LoadPinnedMap(paths.EventsMapPath, nil)
+	if err != nil {
+		_ = exitLink.Close()
+		_ = execLink.Close()
+		return nil, nil, nil, false
+	}
+	return execLink, exitLink, eventsMap, true
 }
-
-// ensure ebpf package import is used (bpf2go generated code also imports it)
-var _ = (*ebpf.CollectionSpec)(nil)

--- a/go/pkg/kernelcapture/linux_ebpf_smoke_linux_test.go
+++ b/go/pkg/kernelcapture/linux_ebpf_smoke_linux_test.go
@@ -4,9 +4,14 @@ package kernelcapture
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cilium/ebpf/rlimit"
 )
 
 func TestLinuxEBPFExecSmoke(t *testing.T) {
@@ -298,4 +303,86 @@ func TestLinuxEBPFCgroupFilterNegativeSmoke(t *testing.T) {
 		result.NegativeTargetPID,
 		result.NegativeTimedOut,
 	)
+}
+
+// TestLinuxEBPFPinnedRestartSmoke proves LoadAndAttachProcessExecEBPFPinned's
+// restart path: a second load against the same bpffs paths must bind its
+// ringbuf reader to the exact map the still-attached (pinned) programs write
+// into, not a freshly created map that nothing feeds. See issue #95.
+func TestLinuxEBPFPinnedRestartSmoke(t *testing.T) {
+	if os.Getenv("ARDUR_RUN_EBPF_SMOKE") != "1" {
+		t.Skip("set ARDUR_RUN_EBPF_SMOKE=1 to run privileged Linux eBPF pinned-restart smoke")
+	}
+
+	_ = rlimit.RemoveMemlock()
+
+	dir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("ardur-test-restart-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	paths := PinnedEBPFPaths{
+		ExecLinkPath:  filepath.Join(dir, "exec_tp_link"),
+		ExitLinkPath:  filepath.Join(dir, "exit_tp_link"),
+		EventsMapPath: filepath.Join(dir, "process_lifecycle_events"),
+	}
+
+	// ── First "boot": fresh load, attach, and pin. ──────────────────────
+	first, err := LoadAndAttachProcessExecEBPFPinned(paths)
+	if err != nil {
+		t.Fatalf("first LoadAndAttachProcessExecEBPFPinned: %v", err)
+	}
+	for _, p := range []string{paths.ExecLinkPath, paths.ExitLinkPath, paths.EventsMapPath} {
+		// A plain open(2) on a pinned bpf_link returns EIO (links require
+		// the BPF_OBJ_GET syscall path, unlike pinned maps/regular files),
+		// so check pin existence with Lstat rather than fileReadable.
+		if _, statErr := os.Lstat(p); statErr != nil {
+			first.Close()
+			t.Fatalf("expected pin at %s after first load: %v", p, statErr)
+		}
+	}
+
+	// Close the Go-side handles WITHOUT unpinning: this simulates the daemon
+	// process exiting while the kernel keeps the pinned links (and thus the
+	// attached programs) alive, per the documented Close contract.
+	first.Close()
+
+	// ── "Restart": reload from the same pins. ───────────────────────────
+	second, err := LoadAndAttachProcessExecEBPFPinned(paths)
+	if err != nil {
+		t.Fatalf("second (restart) LoadAndAttachProcessExecEBPFPinned: %v", err)
+	}
+	defer second.Close()
+
+	source := NewRingbufProcessSourceFromRingbufReader(second.Reader())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start restart-probe command: %v", err)
+	}
+	targetPID := uint32(cmd.Process.Pid)
+	scope := SessionScope{PIDs: map[uint32]struct{}{targetPID: {}}}
+
+	haveExec, haveExit := false, false
+	for !(haveExec && haveExit) {
+		evt, ok, err := source.Next(ctx, scope)
+		if err != nil {
+			t.Fatalf("read ringbuf event from restarted handles (exec=%t exit=%t): %v", haveExec, haveExit, err)
+		}
+		if !ok {
+			continue
+		}
+		switch evt.Type {
+		case ProcessEventExec:
+			haveExec = true
+		case ProcessEventExit:
+			haveExit = true
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("restart-probe command failed: %v", err)
+	}
+	if !haveExec || !haveExit {
+		t.Fatalf("restart handles observed no events for pid %d: exec=%t exit=%t", targetPID, haveExec, haveExit)
+	}
 }


### PR DESCRIPTION
## Summary
`LoadAndAttachProcessExecEBPFPinned` had three bugs (found during pre-merge review of #91):

1. **Never called.** `runEBPFConsumer` used the non-pinned `LoadAndAttachProcessExecEBPF`, so restart survival was dead code — the "BPF link-pinning survives restarts" claim wasn't actually in effect.
2. **Restart path read from the wrong map.** On restart it called `loadProcessExecObjects` to "get access to the ringbuf map for a new reader," but that instantiates a brand-new collection with brand-new maps. The pinned (still-attached) programs keep writing to the *original* `events` map; the daemon would open a reader on the freshly-created map and observe zero events while believing it was capturing.
3. **The ringbuf map was never pinned** despite the docstring saying it was — only the two tracepoint links were pinned, so there was no shared map to reattach a reader to across restarts.

## Fix
- Pin the ringbuf map alongside the tracepoint links on first load.
- On restart, use `ebpf.LoadPinnedMap` to reopen that exact map, then bind a new `ringbuf.Reader` to it — so the reader is reading from the map the still-attached programs are actually writing into.
- `tryLoadPinnedState` (renamed from `tryLoadPinnedLinks`) now requires all three pins — both links and the map — to succeed before treating pinned state as reusable. A partial prior pin (e.g. links pinned but the map pin failed) falls back to a fresh load/attach/pin instead of reusing a stale link with no matching map.
- Fixed the pin-time `MkdirAll` to derive each pin's parent directory from its own path instead of a hardcoded `/sys/fs/bpf/ardur`, since the hardcoded path silently broke pinning for any non-default `PinnedEBPFPaths`.
- `runEBPFConsumer` now calls `LoadAndAttachProcessExecEBPFPinned(DefaultPinnedEBPFPaths())` instead of the non-pinned loader. First-start behavior is unchanged (pinned-state lookup fails on a truly fresh path, falling straight through to the same fresh load/attach as before); restart now actually survives.

## Test plan
- [x] `go build ./... && go vet ./...` (cross-compiled `GOOS=linux`)
- [x] `go test ./...` (unprivileged suite)
- [x] Added `TestLinuxEBPFPinnedRestartSmoke`, gated like the existing smoke tests behind `ARDUR_RUN_EBPF_SMOKE=1`. Verified live in a privileged Linux container (real BTF, tracefs/debugfs/bpffs mounted, CO-RE load):
  - Loads+attaches+pins, closes the handles *without* unpinning (simulating the daemon process exiting), reloads from the same pins, execs a fresh process, and confirms its exec+exit events are observed through the *second* handle's reader.
  - Confirmed the test fails (read times out, zero events observed) when the restart branch is reverted to binding the reader to a freshly-loaded map instead of the pinned one — reproducing the exact bug this closes, before re-confirming the fix passes.
  - All other `TestLinuxEBPF*` smoke tests still pass unchanged.

Closes #95