### PR TITLE
feat(enforce): sequence, hash-chain, and attest kernel enforce_events (Epic A E3)

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_enforce.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_enforce.go
@@ -1,0 +1,368 @@
+package main
+
+// daemon_enforce.go — enforce_events processing (Epic A #63, plan E3).
+//
+// This file processes BpfEnforceEvent records once they have been decoded
+// from the enforce_events ringbuf. It does NOT load the BPF-LSM program or
+// open that ringbuf itself: that loader lives behind the Slice 4.2 BPF-LSM
+// bridge, which does not build cleanly yet (blocked pending #92). Once it
+// lands, wiring the data-plane goroutine is a single adapter that satisfies
+// enforceEventReader over *ringbuf.Reader and a call to consumeEnforceEvents
+// from main()'s run loop — exactly how runEBPFConsumer wires the exec/exit
+// tracepoint consumer today.
+//
+// Claim boundary for this file:
+//   - Decodes raw enforce_events ringbuf records into BpfEnforceEvent.
+//   - Routes events through the same per-session Correlator used for
+//     exec/exit events (via d.correlators), so kernel-enforcement denials get
+//     the same PID/cgroup/time-window attribution confidence grading, rather
+//     than a bare cgroup-index lookup.
+//   - Sequences and hash-chains every processed event, including orphans, so
+//     the evidence log can be verified for gaps or tampering
+//     (EnforceReceiptChain).
+//   - Orphaned events — enforce_events for a cgroup with no registered
+//     session — are never dropped: they are appended to a dedicated
+//     hash-chained log (enforceOrphanChain) and counted, not discarded.
+//   - Accounts for ringbuf LostSamples and exposes a per-session enforcement
+//     summary over the session_status daemon protocol response
+//     (DaemonProtocolResponse.Enforcement).
+//
+// NOT in this file:
+//   - Loading process_guard.bpf.c, attaching LSM hooks, or opening the
+//     enforce_events ringbuf (blocked; see #92).
+//   - Writing BPF policy maps (apply_policy).
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// enforceOrphanScope is the pseudo-session-id used for the evidence-log
+// directory and in-memory chain/summary that hold enforce_events which could
+// not be attributed to any registered session.
+const enforceOrphanScope = "_orphan"
+
+// enforceEventRecord is the platform-independent projection of one raw
+// ringbuf record: the decoded bytes plus how many prior samples the kernel
+// ring buffer dropped before this one was read. Keeping this decoupled from
+// github.com/cilium/ebpf/ringbuf.Record lets the processing pipeline below
+// build and be tested on every platform, not just Linux.
+type enforceEventRecord struct {
+	RawSample   []byte
+	LostSamples uint64
+}
+
+// enforceEventReader is satisfied by a thin adapter over *ringbuf.Reader
+// (Linux-only, added when the BPF-LSM loader lands) and by fakes in tests.
+type enforceEventReader interface {
+	Read() (enforceEventRecord, error)
+}
+
+// consumeEnforceEvents reads raw enforce_event records from reader, decodes
+// them, and routes each to processEnforceEvent until ctx is cancelled or the
+// reader is exhausted (io.EOF, signalling a closed reader).
+func consumeEnforceEvents(ctx context.Context, reader enforceEventReader, d *daemon, log *slog.Logger) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		rec, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("enforce_events read: %w", err)
+		}
+
+		if rec.LostSamples > 0 {
+			d.enforceOrphanSummary.RecordLostSamples(rec.LostSamples)
+			log.Warn("enforce_events ringbuf lost samples", "lost", rec.LostSamples)
+		}
+
+		ev, err := decodeEnforceEvent(rec.RawSample)
+		if err != nil {
+			log.Warn("decode enforce_event failed", "error", err)
+			continue
+		}
+
+		d.processEnforceEvent(ev, log)
+	}
+}
+
+// decodeEnforceEvent deserializes the raw bytes from the BPF ringbuf into a
+// BpfEnforceEvent. The layout must exactly match struct ardur_enforce_event
+// in process_guard.bpf.c:
+//
+//	cgroup_id  u64     (8)
+//	pid        u32     (4)
+//	op         u32     (4)
+//	action     u32     (4)
+//	mode       u32     (4)
+//	observed   u64     (8)
+//	comm       [16]u8  (16)
+//	path       [256]u8 (256)
+//
+// Total: 304 bytes. Uses native byte order because the ringbuf memory is
+// written directly by the (same-host, CO-RE) BPF program.
+func decodeEnforceEvent(raw []byte) (kernelcapture.BpfEnforceEvent, error) {
+	const fixedSize = 8 + 4 + 4 + 4 + 4 + 8 + 16 + 256 // 304 bytes
+	if len(raw) < fixedSize {
+		return kernelcapture.BpfEnforceEvent{}, fmt.Errorf("enforce_event too short: %d < %d", len(raw), fixedSize)
+	}
+
+	r := bytes.NewReader(raw)
+	var ev kernelcapture.BpfEnforceEvent
+
+	var cgroupID uint64
+	var pid, op, action, mode uint32
+	var observedNS uint64
+	var comm [16]byte
+	var path [256]byte
+
+	for _, field := range []any{&cgroupID, &pid, &op, &action, &mode, &observedNS, &comm, &path} {
+		if err := binary.Read(r, binary.NativeEndian, field); err != nil {
+			return kernelcapture.BpfEnforceEvent{}, fmt.Errorf("decode enforce_event: %w", err)
+		}
+	}
+
+	ev.CgroupID = cgroupID
+	ev.PID = pid
+	ev.Op = kernelcapture.BpfOp(op)
+	ev.ActionTaken = kernelcapture.BpfAction(action)
+	ev.EnforceMode = kernelcapture.BpfEnforceMode(mode)
+	ev.ObservedNS = observedNS
+	ev.Comm = strings.TrimRight(string(comm[:]), "\x00")
+	ev.Path = strings.TrimRight(string(path[:]), "\x00")
+
+	return ev, nil
+}
+
+// routeEnforceEvent finds the session (and its Correlator) that owns
+// cgroupID. Returns ("", nil) if no registered session claims this cgroup.
+//
+// Unlike routeEvent (used for exec/exit tracepoint events), this only does
+// the cgroup-index fast-path lookup: the BPF-LSM maps are keyed directly by
+// the governed cgroup_id, so there is no subtree-escape ambiguity to resolve
+// with a process-tree walk the way there is for arbitrary tracepoint events.
+func (d *daemon) routeEnforceEvent(cgroupID uint64) (string, *kernelcapture.Correlator) {
+	if cgroupID == 0 {
+		return "", nil
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	sid, ok := d.cgroupIndex[cgroupID]
+	if !ok {
+		return "", nil
+	}
+	return sid, d.correlators[sid]
+}
+
+// bpfEnforceEventToProcessEvent projects a BpfEnforceEvent into the generic
+// ProcessEvent shape the Correlator matches against.
+//
+// ObservedAt is set to the wall-clock time of processing rather than derived
+// from ev.ObservedNS: the BPF program only supplies a monotonic kernel
+// timestamp, and without a monotonic-to-wall-clock anchor point (the daemon
+// does not currently record one) there is no principled way to convert it.
+// Ringbuf consumption latency is sub-millisecond in practice, well inside the
+// multi-second CorrelationGrace window the Correlator uses, so this
+// approximation does not materially affect correlation quality.
+// ObservedMonotonicNS is set from the true kernel value, since restart-gap
+// detection (isWithinRestartGap) compares monotonic clocks directly.
+func bpfEnforceEventToProcessEvent(ev kernelcapture.BpfEnforceEvent, sessionID string) kernelcapture.ProcessEvent {
+	return kernelcapture.ProcessEvent{
+		SessionID:           sessionID,
+		Type:                kernelcapture.ProcessEventEnforce,
+		PID:                 ev.PID,
+		CgroupID:            ev.CgroupID,
+		Comm:                ev.Comm,
+		ObservedAt:          time.Now().UTC(),
+		ObservedMonotonicNS: ev.ObservedNS,
+	}
+}
+
+// enforceEventVerdict maps a BpfEnforceEvent's kernel-observed action to a
+// SyntheticKernelReceipt-style verdict string. This is authoritative — it
+// reflects what the kernel actually did — and is not overridden by
+// correlation ambiguity the way exec/exit verdicts are.
+func enforceEventVerdict(ev kernelcapture.BpfEnforceEvent) string {
+	switch ev.ActionTaken {
+	case kernelcapture.BpfActionDeny, kernelcapture.BpfActionAllowlist:
+		// ACT_ALLOWLIST only reaches userspace as an enforce_event when the
+		// target missed the allowlist, i.e. it is enforced the same as
+		// ACT_DENY.
+		if ev.EnforceMode == kernelcapture.BpfEnforceModeEnforce {
+			return "denied"
+		}
+		return "blocked" // permissive mode: logged, syscall not killed
+	default:
+		return "compliant"
+	}
+}
+
+// enforceEventTier identifies the enforcement backend + mode that produced
+// an event, for the summary's TierCoverage breakdown. Forward-compatible with
+// future tiers (seccomp unotify, plan E4): a non-BPF-LSM tier would key its
+// own events here (e.g. "seccomp:enforce").
+func enforceEventTier(ev kernelcapture.BpfEnforceEvent) string {
+	if ev.EnforceMode == kernelcapture.BpfEnforceModeEnforce {
+		return "bpf_lsm:enforce"
+	}
+	return "bpf_lsm:permissive"
+}
+
+// processEnforceEvent routes one decoded enforce_event to its session's
+// Correlator, sequences and hash-chains a receipt, updates the session's
+// enforcement summary, and appends the receipt to evidence. Events that
+// cannot be attributed to a registered session are routed to the orphan
+// scope instead of being dropped.
+func (d *daemon) processEnforceEvent(ev kernelcapture.BpfEnforceEvent, log *slog.Logger) {
+	verdict := enforceEventVerdict(ev)
+	tier := enforceEventTier(ev)
+
+	sid, correlator := d.routeEnforceEvent(ev.CgroupID)
+	if sid == "" || correlator == nil {
+		d.appendOrphanEnforceReceipt(ev, verdict, tier, log)
+		return
+	}
+
+	procEvt := bpfEnforceEventToProcessEvent(ev, sid)
+	receipt := correlator.Correlate(procEvt, kernelcapture.EventContext{})
+	// The kernel's enforcement action is a fact, independent of how
+	// confidently the event correlates to a specific tool-call receipt.
+	receipt.Verdict = verdict
+
+	entry := kernelcapture.EnforceReceiptEntry{
+		SchemaVersion:         kernelcapture.EnforceReceiptSchema,
+		SessionID:             sid,
+		RecordedAt:            time.Now().UTC(),
+		Event:                 ev,
+		Verdict:               verdict,
+		CorrelationMethod:     receipt.CorrelationMethod,
+		CorrelationConfidence: receipt.CorrelationConfidence,
+		Orphan:                false,
+	}
+
+	d.mu.Lock()
+	chain := d.enforceChains[sid]
+	summary := d.enforceSummaries[sid]
+	d.mu.Unlock()
+	if chain == nil || summary == nil {
+		// Session ended between routing and append; preserve the event
+		// rather than dropping it now that we know it belongs nowhere live.
+		d.appendOrphanEnforceReceipt(ev, verdict, tier, log)
+		return
+	}
+
+	finalized, err := chain.Append(entry)
+	if err != nil {
+		log.Warn("hash-chain enforce receipt", "session_id", sid, "error", err)
+		return
+	}
+	summary.RecordReceipt(finalized, tier)
+
+	log.Debug("enforce event",
+		"session_id", sid,
+		"seq", finalized.Seq,
+		"op", ev.Op,
+		"action", ev.ActionTaken,
+		"mode", ev.EnforceMode,
+		"comm", ev.Comm,
+		"verdict", verdict,
+		"correlation", receipt.CorrelationMethod+"/"+receipt.CorrelationConfidence,
+	)
+	d.appendEnforceReceiptLine(sid, finalized, log)
+}
+
+// appendOrphanEnforceReceipt hash-chains and appends an enforce_event that
+// could not be attributed to any registered session to the shared orphan
+// evidence log, and counts it in the orphan summary. This is the "don't
+// silently drop orphans" path: the event is preserved for forensic review
+// even though it cannot be tied to a governed session.
+func (d *daemon) appendOrphanEnforceReceipt(ev kernelcapture.BpfEnforceEvent, verdict, tier string, log *slog.Logger) {
+	entry := kernelcapture.EnforceReceiptEntry{
+		SchemaVersion: kernelcapture.EnforceReceiptSchema,
+		RecordedAt:    time.Now().UTC(),
+		Event:         ev,
+		Verdict:       verdict,
+		Orphan:        true,
+	}
+	finalized, err := d.enforceOrphanChain.Append(entry)
+	if err != nil {
+		log.Warn("hash-chain orphan enforce receipt", "cgroup_id", ev.CgroupID, "error", err)
+		return
+	}
+	d.enforceOrphanSummary.RecordReceipt(finalized, tier)
+
+	log.Warn("enforce event for unregistered cgroup",
+		"cgroup_id", ev.CgroupID,
+		"pid", ev.PID,
+		"op", ev.Op,
+		"verdict", verdict,
+		"seq", finalized.Seq,
+	)
+	d.appendEnforceReceiptLine(enforceOrphanScope, finalized, log)
+}
+
+// appendEnforceReceiptLine writes one finalized EnforceReceiptEntry as a
+// JSONL line to <evidenceDir>/<scope>/enforce_events.jsonl, where scope is
+// either a sanitized session id or enforceOrphanScope.
+func (d *daemon) appendEnforceReceiptLine(scope string, entry kernelcapture.EnforceReceiptEntry, log *slog.Logger) {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Warn("marshal enforce receipt", "scope", scope, "error", err)
+		return
+	}
+	line = append(line, '\n')
+
+	dir := filepath.Join(d.evidenceDir, sanitizeSessionID(scope))
+	path := filepath.Join(dir, "enforce_events.jsonl")
+	if err := prevalidateKernelReceiptAppendPath(d.fs, d.evidenceDir, dir, path); err != nil {
+		log.Warn("prevalidate enforce receipt path", "path", path, "error", err)
+		return
+	}
+	if err := d.fs.MkdirAll(dir, 0o700); err != nil {
+		log.Warn("create evidence dir for enforce receipt", "path", dir, "error", err)
+		return
+	}
+	if err := d.fs.AppendFile(path, line, 0o600); err != nil {
+		log.Warn("append enforce receipt", "path", path, "error", err)
+	}
+}
+
+// enforceSummaryForScope returns a detached snapshot of the enforcement
+// summary for a session id (or enforceOrphanScope), and whether one exists.
+// The per-session summary's LostSamples is stamped from the shared
+// (session-agnostic) ringbuf loss counter at read time: sample loss happens
+// before any cgroup attribution is possible, so it cannot be charged to one
+// session's accumulator and is reported as pipeline-wide context instead.
+func (d *daemon) enforceSummaryForScope(scope string) (kernelcapture.EnforceEventSummary, bool) {
+	d.mu.RLock()
+	acc, ok := d.enforceSummaries[scope]
+	d.mu.RUnlock()
+	if scope == enforceOrphanScope {
+		acc, ok = d.enforceOrphanSummary, d.enforceOrphanSummary != nil
+	}
+	if !ok || acc == nil {
+		return kernelcapture.EnforceEventSummary{}, false
+	}
+	snap := acc.Snapshot()
+	if scope != enforceOrphanScope && d.enforceOrphanSummary != nil {
+		snap.LostSamples = d.enforceOrphanSummary.Snapshot().LostSamples
+	}
+	return snap, true
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// encodeTestEnforceEvent serializes ev into the exact 304-byte layout
+// decodeEnforceEvent expects, mirroring struct ardur_enforce_event.
+func encodeTestEnforceEvent(t *testing.T, ev kernelcapture.BpfEnforceEvent) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+
+	var comm [16]byte
+	copy(comm[:], ev.Comm)
+	var path [256]byte
+	copy(path[:], ev.Path)
+
+	fields := []any{
+		ev.CgroupID,
+		ev.PID,
+		uint32(ev.Op),
+		uint32(ev.ActionTaken),
+		uint32(ev.EnforceMode),
+		ev.ObservedNS,
+		comm,
+		path,
+	}
+	for _, f := range fields {
+		if err := binary.Write(&buf, binary.NativeEndian, f); err != nil {
+			t.Fatalf("encode test enforce event: %v", err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// fakeEnforceEventReader replays a fixed sequence of records, then returns
+// io.EOF.
+type fakeEnforceEventReader struct {
+	records []enforceEventRecord
+	i       int
+}
+
+func (f *fakeEnforceEventReader) Read() (enforceEventRecord, error) {
+	if f.i >= len(f.records) {
+		return enforceEventRecord{}, io.EOF
+	}
+	rec := f.records[f.i]
+	f.i++
+	return rec, nil
+}
+
+func readEnforceReceiptLines(t *testing.T, stub *stubEvidenceFS, path string) []kernelcapture.EnforceReceiptEntry {
+	t.Helper()
+	stub.mu.Lock()
+	data := append([]byte(nil), stub.appends[path]...)
+	stub.mu.Unlock()
+
+	var out []kernelcapture.EnforceReceiptEntry
+	for _, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry kernelcapture.EnforceReceiptEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal enforce receipt line: %v\n%s", err, line)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func TestProcessEnforceEvent_DeniedEventRoutesThroughCorrelator(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "enforce-session-1",
+		RootPID:      100,
+		CgroupID:     42,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   300,
+	}, "enforce-session-1")
+
+	ev := kernelcapture.BpfEnforceEvent{
+		CgroupID:    42,
+		PID:         100,
+		Op:          kernelcapture.BpfOpFileWrite,
+		ActionTaken: kernelcapture.BpfActionDeny,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		ObservedNS:  123456789,
+		Comm:        "agent",
+		Path:        "/etc/shadow",
+	}
+	d.processEnforceEvent(ev, d.log)
+
+	path := filepath.Join(d.evidenceDir, sanitizeSessionID("enforce-session-1"), "enforce_events.jsonl")
+	entries := readEnforceReceiptLines(t, stub, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 enforce receipt, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Verdict != "denied" {
+		t.Errorf("verdict = %q, want %q", entry.Verdict, "denied")
+	}
+	if entry.Orphan {
+		t.Error("registered session's event was marked orphan")
+	}
+	if entry.SessionID != "enforce-session-1" {
+		t.Errorf("session_id = %q, want %q", entry.SessionID, "enforce-session-1")
+	}
+	// The event routed through the real per-session Correlator (cgroup+PID
+	// match, no registered ToolReceipt) rather than a bare cgroup lookup, so
+	// it must carry a correlation grading, not an empty/bypassed one.
+	if entry.CorrelationMethod == "" || entry.CorrelationConfidence == "" {
+		t.Errorf("expected correlation metadata from the Correlator, got method=%q confidence=%q",
+			entry.CorrelationMethod, entry.CorrelationConfidence)
+	}
+	if entry.Seq != 1 || entry.PrevHash != "" || entry.Hash == "" {
+		t.Errorf("expected first chain entry (seq=1, empty prev_hash, non-empty hash); got %+v", entry)
+	}
+
+	summary, ok := d.enforceSummaryForScope("enforce-session-1")
+	if !ok {
+		t.Fatal("expected an enforcement summary for the registered session")
+	}
+	if summary.TotalEvents != 1 || summary.VerdictCounts["denied"] != 1 {
+		t.Errorf("session summary = %+v, want 1 total denied event", summary)
+	}
+	if summary.TierCoverage["bpf_lsm:enforce"] != 1 {
+		t.Errorf("session summary tier coverage = %+v, want bpf_lsm:enforce=1", summary.TierCoverage)
+	}
+	if summary.OrphanCount != 0 {
+		t.Errorf("registered session's summary should have zero orphans, got %d", summary.OrphanCount)
+	}
+}
+
+func TestProcessEnforceEvent_OrphanEventNotDropped(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+
+	// No session registered for cgroup 7777: this event cannot be attributed.
+	ev := kernelcapture.BpfEnforceEvent{
+		CgroupID:    7777,
+		PID:         555,
+		Op:          kernelcapture.BpfOpNetConnect,
+		ActionTaken: kernelcapture.BpfActionDeny,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		Comm:        "orphan-proc",
+	}
+	d.processEnforceEvent(ev, d.log)
+
+	orphanPath := filepath.Join(d.evidenceDir, sanitizeSessionID(enforceOrphanScope), "enforce_events.jsonl")
+	entries := readEnforceReceiptLines(t, stub, orphanPath)
+	if len(entries) != 1 {
+		t.Fatalf("expected the orphan event to be preserved in the orphan log, got %d entries", len(entries))
+	}
+	if !entries[0].Orphan {
+		t.Error("orphan log entry should have Orphan=true")
+	}
+	if entries[0].SessionID != "" {
+		t.Errorf("orphan entry should carry no session_id, got %q", entries[0].SessionID)
+	}
+
+	summary, ok := d.enforceSummaryForScope(enforceOrphanScope)
+	if !ok {
+		t.Fatal("expected an orphan enforcement summary to exist")
+	}
+	if summary.OrphanCount != 1 || summary.TotalEvents != 1 {
+		t.Errorf("orphan summary = %+v, want 1 orphan/1 total", summary)
+	}
+}
+
+func TestConsumeEnforceEvents_SequencingAndHashChainContinuity(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "chain-session",
+		RootPID:      1,
+		CgroupID:     10,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   300,
+	}, "chain-session")
+
+	base := kernelcapture.BpfEnforceEvent{CgroupID: 10, PID: 1, ActionTaken: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce}
+	reader := &fakeEnforceEventReader{records: []enforceEventRecord{
+		{RawSample: encodeTestEnforceEvent(t, base)},
+		{RawSample: encodeTestEnforceEvent(t, base)},
+		{RawSample: encodeTestEnforceEvent(t, base)},
+	}}
+
+	if err := consumeEnforceEvents(context.Background(), reader, d, d.log); err != nil {
+		t.Fatalf("consumeEnforceEvents: %v", err)
+	}
+
+	path := filepath.Join(d.evidenceDir, sanitizeSessionID("chain-session"), "enforce_events.jsonl")
+	entries := readEnforceReceiptLines(t, stub, path)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 chained entries, got %d", len(entries))
+	}
+	for i, e := range entries {
+		if e.Seq != uint64(i+1) {
+			t.Errorf("entry %d: seq = %d, want %d", i, e.Seq, i+1)
+		}
+	}
+	if entries[1].PrevHash != entries[0].Hash {
+		t.Errorf("entry 1 prev_hash %q does not chain to entry 0 hash %q", entries[1].PrevHash, entries[0].Hash)
+	}
+	if entries[2].PrevHash != entries[1].Hash {
+		t.Errorf("entry 2 prev_hash %q does not chain to entry 1 hash %q", entries[2].PrevHash, entries[1].Hash)
+	}
+
+	ok, brokenAt, err := kernelcapture.VerifyEnforceReceiptChain(entries)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected intact chain, broke at index %d", brokenAt)
+	}
+
+	// Tamper with the middle entry's verdict and confirm verification catches it.
+	tampered := append([]kernelcapture.EnforceReceiptEntry(nil), entries...)
+	tampered[1].Verdict = "compliant"
+	ok, brokenAt, err = kernelcapture.VerifyEnforceReceiptChain(tampered)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain (tampered): %v", err)
+	}
+	if ok || brokenAt != 1 {
+		t.Errorf("expected tamper detection at index 1, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestConsumeEnforceEvents_LostSamplesAccounted(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+
+	reader := &fakeEnforceEventReader{records: []enforceEventRecord{
+		{LostSamples: 5, RawSample: encodeTestEnforceEvent(t, kernelcapture.BpfEnforceEvent{CgroupID: 999, PID: 1})},
+	}}
+	if err := consumeEnforceEvents(context.Background(), reader, d, d.log); err != nil {
+		t.Fatalf("consumeEnforceEvents: %v", err)
+	}
+
+	summary, ok := d.enforceSummaryForScope(enforceOrphanScope)
+	if !ok {
+		t.Fatal("expected orphan summary to exist")
+	}
+	if summary.LostSamples != 5 {
+		t.Errorf("lost samples = %d, want 5", summary.LostSamples)
+	}
+}
+
+func TestConsumeEnforceEvents_StopsOnContextCancellation(t *testing.T) {
+	d := newTestDaemon(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reader := &fakeEnforceEventReader{records: []enforceEventRecord{
+		{RawSample: encodeTestEnforceEvent(t, kernelcapture.BpfEnforceEvent{})},
+	}}
+	err := consumeEnforceEvents(ctx, reader, d, d.log)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestHandleAuthorizedRequest_SessionStatusIncludesEnforcementSummary(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		SessionID:             "status-session",
+		SocketPath:            "/run/ardur/kernelcapture/control.sock",
+		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+		ProcessStartTimeTicks: 1,
+		Authorization: kernelcapture.DaemonPeerAuthorization{
+			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+			Reason:                "test",
+			UID:                   501,
+			PID:                   4242,
+			ProcessStartTimeTicks: 1,
+			Matched:               "uid",
+		},
+	}
+
+	registerResp := d.handleAuthorizedRequest(context.Background(), kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "status-session",
+			RootPID:      100,
+			CgroupID:     55,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   300,
+		},
+	}, handshake)
+	if !registerResp.OK {
+		t.Fatalf("register_session failed: %+v", registerResp)
+	}
+
+	d.processEnforceEvent(kernelcapture.BpfEnforceEvent{
+		CgroupID:    55,
+		PID:         100,
+		ActionTaken: kernelcapture.BpfActionDeny,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+	}, d.log)
+
+	statusResp := d.handleAuthorizedRequest(context.Background(), kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodSessionStatus,
+		SessionStatus:   &kernelcapture.DaemonSessionStatusRequest{SessionID: "status-session"},
+	}, handshake)
+	if !statusResp.OK {
+		t.Fatalf("session_status failed: %+v", statusResp)
+	}
+	if statusResp.Enforcement == nil {
+		t.Fatal("expected session_status response to carry an Enforcement summary")
+	}
+	if statusResp.Enforcement.TotalEvents != 1 || statusResp.Enforcement.VerdictCounts["denied"] != 1 {
+		t.Errorf("enforcement summary = %+v, want 1 total denied event", statusResp.Enforcement)
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -54,13 +54,17 @@ func newTestDaemon(t *testing.T) *daemon {
 	t.Helper()
 	tmpDir := t.TempDir()
 	return &daemon{
-		log:         testLogger(t),
-		registry:    kernelcapture.NewDaemonSessionRegistry(),
-		evidenceDir: filepath.Join(tmpDir, "evidence"),
-		cgroupIndex: make(map[uint64]string),
-		treeScopes:  make(map[string]*kernelcapture.ProcessTreeScope),
-		correlators: make(map[string]*kernelcapture.Correlator),
-		fs:          osEvidenceFS{},
+		log:                  testLogger(t),
+		registry:             kernelcapture.NewDaemonSessionRegistry(),
+		evidenceDir:          filepath.Join(tmpDir, "evidence"),
+		cgroupIndex:          make(map[uint64]string),
+		treeScopes:           make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators:          make(map[string]*kernelcapture.Correlator),
+		enforceChains:        make(map[string]*kernelcapture.EnforceReceiptChain),
+		enforceSummaries:     make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
+		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
+		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
+		fs:                   osEvidenceFS{},
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -81,6 +81,14 @@ type daemon struct {
 	treeScopes  map[string]*kernelcapture.ProcessTreeScope
 	correlators map[string]*kernelcapture.Correlator
 
+	// enforce_events state, maintained under mu (session-scoped) plus two
+	// daemon-lifetime singletons for events that cannot be attributed to any
+	// session (enforceOrphanChain/enforceOrphanSummary; see daemon_enforce.go).
+	enforceChains        map[string]*kernelcapture.EnforceReceiptChain
+	enforceSummaries     map[string]*kernelcapture.EnforceEventSummaryAccumulator
+	enforceOrphanChain   *kernelcapture.EnforceReceiptChain
+	enforceOrphanSummary *kernelcapture.EnforceEventSummaryAccumulator
+
 	// OS filesystem for JSONL append (interface for test injection).
 	fs evidenceFS
 }
@@ -113,15 +121,19 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 	}
 
 	return &daemon{
-		log:         log,
-		registry:    registry,
-		custodyPlan: custodyPlan,
-		peerPolicy:  peerPolicy,
-		evidenceDir: evidenceDir,
-		cgroupIndex: make(map[uint64]string),
-		treeScopes:  make(map[string]*kernelcapture.ProcessTreeScope),
-		correlators: make(map[string]*kernelcapture.Correlator),
-		fs:          osEvidenceFS{},
+		log:                  log,
+		registry:             registry,
+		custodyPlan:          custodyPlan,
+		peerPolicy:           peerPolicy,
+		evidenceDir:          evidenceDir,
+		cgroupIndex:          make(map[uint64]string),
+		treeScopes:           make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators:          make(map[string]*kernelcapture.Correlator),
+		enforceChains:        make(map[string]*kernelcapture.EnforceReceiptChain),
+		enforceSummaries:     make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
+		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
+		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
+		fs:                   osEvidenceFS{},
 	}, nil
 }
 
@@ -141,6 +153,10 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 	case kernelcapture.DaemonProtocolMethodEndSession:
 		if sessionID := req.EndSession; sessionID != nil {
 			d.onSessionEnded(sessionID.SessionID)
+		}
+	case kernelcapture.DaemonProtocolMethodSessionStatus:
+		if summary, ok := d.enforceSummaryForScope(resp.SessionID); ok {
+			resp.Enforcement = &summary
 		}
 	}
 	return resp
@@ -168,6 +184,8 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 		CorrelationGrace: 5 * time.Second,
 		RestartGrace:     3 * time.Second,
 	})
+	d.enforceChains[sessionID] = kernelcapture.NewEnforceReceiptChain()
+	d.enforceSummaries[sessionID] = kernelcapture.NewEnforceEventSummaryAccumulator()
 
 	d.log.Info("session registered",
 		"session_id", sessionID,
@@ -193,6 +211,8 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	}
 	delete(d.treeScopes, sessionID)
 	delete(d.correlators, sessionID)
+	delete(d.enforceChains, sessionID)
+	delete(d.enforceSummaries, sessionID)
 
 	d.log.Info("session ended", "session_id", sessionID)
 }
@@ -295,6 +315,8 @@ func (d *daemon) pruneExpiredSessions() {
 			}
 			delete(d.treeScopes, sid)
 			delete(d.correlators, sid)
+			delete(d.enforceChains, sid)
+			delete(d.enforceSummaries, sid)
 			d.log.Info("pruned expired session", "session_id", sid)
 		}
 	}

--- a/go/pkg/kernelcapture/correlator.go
+++ b/go/pkg/kernelcapture/correlator.go
@@ -294,6 +294,8 @@ func kernelEventType(kind ProcessEventType) string {
 		return "execve"
 	case ProcessEventExit:
 		return "exit"
+	case ProcessEventEnforce:
+		return "kernel_enforce"
 	default:
 		return "process_event"
 	}

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -67,6 +67,12 @@ type DaemonProtocolResponse struct {
 	SessionID       string `json:"session_id,omitempty"`
 	Status          string `json:"status,omitempty"`
 	Error           string `json:"error,omitempty"`
+	// Enforcement carries a session's kernel-enforcement rollup on successful
+	// session_status responses. Populated by the daemon when enforce_events
+	// have been processed for the session; omitted otherwise. Evidence-log
+	// directories are root-0700, so this is the only channel a non-root client
+	// has to learn what kernel-level enforcement happened.
+	Enforcement *EnforceEventSummary `json:"enforcement,omitempty"`
 }
 
 // CgroupFilterSequence describes daemon-side map sequencing. Enabling

--- a/go/pkg/kernelcapture/enforce_event_summary.go
+++ b/go/pkg/kernelcapture/enforce_event_summary.go
@@ -1,0 +1,120 @@
+package kernelcapture
+
+// enforce_event_summary.go — enforcement-event accounting exposed over the
+// daemon status protocol (Epic A #63, plan E3).
+//
+// EnforceEventSummary is the accumulator behind the "enforcement" block on a
+// session_status response. It exists so a client (the run bridge, an
+// operator) can learn what kernel-level enforcement happened for a session
+// without reading the evidence-log JSONL directly — evidence directories are
+// root-0700, so the daemon socket is the only channel a non-root client has.
+import "sync"
+
+// EnforceEventSummary is a point-in-time rollup of enforcement events for one
+// session (or the shared orphan scope). It is safe to copy by value once
+// read; use EnforceEventSummaryAccumulator to build one under concurrent
+// writes.
+type EnforceEventSummary struct {
+	// TotalEvents is every enforce_event processed for this scope, including
+	// ones that could not be matched to a session (only present on the orphan
+	// scope's summary).
+	TotalEvents uint64 `json:"total_events"`
+	// VerdictCounts keys are SyntheticKernelReceipt-style verdict strings
+	// ("denied", "blocked", "compliant", "insufficient_evidence").
+	VerdictCounts map[string]uint64 `json:"verdict_counts,omitempty"`
+	// TierCoverage keys identify the enforcement tier + mode that produced an
+	// event, e.g. "bpf_lsm:enforce" or "bpf_lsm:permissive". Forward-compatible
+	// with future tiers (seccomp unotify, plan E4).
+	TierCoverage map[string]uint64 `json:"tier_coverage,omitempty"`
+	// OrphanCount is enforce_events observed for this session's cgroup before
+	// (or after) it was known to the routing index, or otherwise unattributed.
+	// Zero on the orphan scope's own summary (its events are the orphans).
+	OrphanCount uint64 `json:"orphan_count"`
+	// LostSamples is the cumulative ringbuf LostSamples count observed while
+	// consuming enforce_events, regardless of session attribution.
+	LostSamples uint64 `json:"lost_samples"`
+	// LastSeq is the highest Seq appended to this scope's receipt chain.
+	LastSeq uint64 `json:"last_seq"`
+	// ChainDigest is the hash of the most recently appended receipt: the
+	// chain head. A verifier who trusts this digest (e.g. because it was
+	// attested) can validate the full evidence log against it.
+	ChainDigest string `json:"chain_digest,omitempty"`
+}
+
+// EnforceEventSummaryAccumulator accumulates EnforceEventSummary counters as
+// events are processed. Safe for concurrent use.
+type EnforceEventSummaryAccumulator struct {
+	mu      sync.Mutex
+	summary EnforceEventSummary
+}
+
+// NewEnforceEventSummaryAccumulator returns an empty accumulator.
+func NewEnforceEventSummaryAccumulator() *EnforceEventSummaryAccumulator {
+	return &EnforceEventSummaryAccumulator{
+		summary: EnforceEventSummary{
+			VerdictCounts: make(map[string]uint64),
+			TierCoverage:  make(map[string]uint64),
+		},
+	}
+}
+
+// RecordReceipt folds one finalized EnforceReceiptEntry into the running
+// summary. tier identifies the enforcement backend + mode (e.g.
+// "bpf_lsm:enforce"); pass "" if unknown.
+func (a *EnforceEventSummaryAccumulator) RecordReceipt(entry EnforceReceiptEntry, tier string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.summary.TotalEvents++
+	if entry.Verdict != "" {
+		a.summary.VerdictCounts[entry.Verdict]++
+	}
+	if tier != "" {
+		a.summary.TierCoverage[tier]++
+	}
+	if entry.Orphan {
+		a.summary.OrphanCount++
+	}
+	if entry.Seq > a.summary.LastSeq {
+		a.summary.LastSeq = entry.Seq
+	}
+	a.summary.ChainDigest = entry.Hash
+}
+
+// RecordLostSamples adds n to the cumulative lost-sample counter. It is
+// called regardless of whether the lost samples could have been attributed to
+// any particular session, since the ringbuf reports loss globally.
+func (a *EnforceEventSummaryAccumulator) RecordLostSamples(n uint64) {
+	if n == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.summary.LostSamples += n
+}
+
+// Snapshot returns a detached copy of the current summary.
+func (a *EnforceEventSummaryAccumulator) Snapshot() EnforceEventSummary {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := EnforceEventSummary{
+		TotalEvents: a.summary.TotalEvents,
+		OrphanCount: a.summary.OrphanCount,
+		LostSamples: a.summary.LostSamples,
+		LastSeq:     a.summary.LastSeq,
+		ChainDigest: a.summary.ChainDigest,
+	}
+	if len(a.summary.VerdictCounts) > 0 {
+		out.VerdictCounts = make(map[string]uint64, len(a.summary.VerdictCounts))
+		for k, v := range a.summary.VerdictCounts {
+			out.VerdictCounts[k] = v
+		}
+	}
+	if len(a.summary.TierCoverage) > 0 {
+		out.TierCoverage = make(map[string]uint64, len(a.summary.TierCoverage))
+		for k, v := range a.summary.TierCoverage {
+			out.TierCoverage[k] = v
+		}
+	}
+	return out
+}

--- a/go/pkg/kernelcapture/enforce_receipt_chain.go
+++ b/go/pkg/kernelcapture/enforce_receipt_chain.go
@@ -1,0 +1,139 @@
+package kernelcapture
+
+// enforce_receipt_chain.go — sequencing and hash-chaining for enforce_events
+// evidence (Epic A #63, plan E3).
+//
+// enforce_events.jsonl records were previously unsequenced and unsigned: an
+// entry could be dropped, reordered, or edited after the fact with no way to
+// detect it. EnforceReceiptChain assigns each entry a monotonic Seq and a
+// SHA-256 hash over its own content plus the previous entry's hash, so a
+// verifier can walk the chain from Seq 1 forward and prove nothing was
+// removed, reordered, or altered.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// EnforceReceiptSchema is the schema version tag written into per-session
+// (and orphan) enforce_events JSONL files.
+const EnforceReceiptSchema = "ardur.enforce.receipt.v1"
+
+// EnforceReceiptEntry is one hash-chained, sequenced enforcement-event record.
+// SessionID is empty and Orphan is true for events that could not be
+// attributed to any registered session.
+type EnforceReceiptEntry struct {
+	SchemaVersion         string          `json:"schema_version"`
+	SessionID             string          `json:"session_id,omitempty"`
+	Seq                   uint64          `json:"seq"`
+	PrevHash              string          `json:"prev_hash"`
+	Hash                  string          `json:"hash"`
+	RecordedAt            time.Time       `json:"recorded_at"`
+	Event                 BpfEnforceEvent `json:"event"`
+	Verdict               string          `json:"verdict"`
+	CorrelationMethod     string          `json:"correlation_method,omitempty"`
+	CorrelationConfidence string          `json:"correlation_confidence,omitempty"`
+	Orphan                bool            `json:"orphan"`
+}
+
+// EnforceReceiptChain maintains a monotonic seq + SHA-256 hash chain of
+// enforcement receipts for one routing scope: either a single session, or the
+// shared scope used for events that could not be attributed to any session.
+//
+// EnforceReceiptChain is safe for concurrent use by multiple goroutines.
+type EnforceReceiptChain struct {
+	mu       sync.Mutex
+	nextSeq  uint64
+	lastHash string
+}
+
+// NewEnforceReceiptChain returns a chain starting at Seq 1 with an empty
+// genesis PrevHash.
+func NewEnforceReceiptChain() *EnforceReceiptChain {
+	return &EnforceReceiptChain{nextSeq: 1}
+}
+
+// Append assigns the next Seq and Hash to entry (its Seq/PrevHash/Hash fields
+// are overwritten) and returns the finalized entry. The entry is not
+// considered committed to the chain's running state until Append returns
+// successfully.
+func (c *EnforceReceiptChain) Append(entry EnforceReceiptEntry) (EnforceReceiptEntry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry.Seq = c.nextSeq
+	entry.PrevHash = c.lastHash
+	entry.Hash = ""
+	hash, err := hashEnforceReceiptEntry(entry)
+	if err != nil {
+		return EnforceReceiptEntry{}, fmt.Errorf("kernelcapture: hash enforce receipt entry: %w", err)
+	}
+	entry.Hash = hash
+
+	c.nextSeq++
+	c.lastHash = entry.Hash
+	return entry, nil
+}
+
+// LastHash returns the hash of the most recently appended entry, or "" if the
+// chain is empty.
+func (c *EnforceReceiptChain) LastHash() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastHash
+}
+
+// Len returns the number of entries appended to the chain so far.
+func (c *EnforceReceiptChain) Len() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.nextSeq - 1
+}
+
+// hashEnforceReceiptEntry computes the chain hash for entry: SHA-256 over a
+// canonical JSON encoding of every field except Hash itself (which is what's
+// being computed). PrevHash is included, which is what makes this a chain
+// rather than an independent per-entry digest.
+func hashEnforceReceiptEntry(entry EnforceReceiptEntry) (string, error) {
+	entry.Hash = ""
+	canonical, err := json.Marshal(entry)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// VerifyEnforceReceiptChain re-derives hashes over entries (which must already
+// be ordered by Seq) and reports whether the chain is intact. ok is false and
+// brokenAt is the index of the first entry (0-based, into entries) whose Seq,
+// PrevHash, or Hash does not match what Append would have produced given the
+// preceding entry — this catches gaps in Seq, tampering with any entry's
+// content, reordering, and deletion.
+func VerifyEnforceReceiptChain(entries []EnforceReceiptEntry) (ok bool, brokenAt int, err error) {
+	var expectedSeq uint64 = 1
+	prevHash := ""
+	for i, entry := range entries {
+		if entry.Seq != expectedSeq {
+			return false, i, nil
+		}
+		if entry.PrevHash != prevHash {
+			return false, i, nil
+		}
+		claimedHash := entry.Hash
+		recomputed, hashErr := hashEnforceReceiptEntry(entry)
+		if hashErr != nil {
+			return false, i, fmt.Errorf("kernelcapture: recompute hash for entry %d: %w", i, hashErr)
+		}
+		if claimedHash != recomputed {
+			return false, i, nil
+		}
+		expectedSeq++
+		prevHash = claimedHash
+	}
+	return true, -1, nil
+}

--- a/go/pkg/kernelcapture/enforce_receipt_chain_test.go
+++ b/go/pkg/kernelcapture/enforce_receipt_chain_test.go
@@ -1,0 +1,237 @@
+package kernelcapture
+
+import (
+	"testing"
+	"time"
+)
+
+func testEnforceReceiptEntry(seq int) EnforceReceiptEntry {
+	return EnforceReceiptEntry{
+		SchemaVersion: EnforceReceiptSchema,
+		SessionID:     "session-a",
+		RecordedAt:    time.Unix(1_800_000_000, 0).UTC(),
+		Event: BpfEnforceEvent{
+			CgroupID:    42,
+			PID:         uint32(1000 + seq),
+			Op:          BpfOpFileWrite,
+			ActionTaken: BpfActionDeny,
+			EnforceMode: BpfEnforceModeEnforce,
+		},
+		Verdict: "denied",
+	}
+}
+
+func TestEnforceReceiptChain_AssignsMonotonicSeq(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+
+	for i := 1; i <= 5; i++ {
+		entry, err := c.Append(testEnforceReceiptEntry(i))
+		if err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+		if entry.Seq != uint64(i) {
+			t.Errorf("entry %d: seq = %d, want %d", i, entry.Seq, i)
+		}
+	}
+	if c.Len() != 5 {
+		t.Errorf("Len() = %d, want 5", c.Len())
+	}
+}
+
+func TestEnforceReceiptChain_HashChainsToPrevious(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+
+	first, err := c.Append(testEnforceReceiptEntry(1))
+	if err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+	if first.PrevHash != "" {
+		t.Errorf("genesis entry PrevHash = %q, want empty", first.PrevHash)
+	}
+	if first.Hash == "" {
+		t.Error("genesis entry Hash is empty")
+	}
+
+	second, err := c.Append(testEnforceReceiptEntry(2))
+	if err != nil {
+		t.Fatalf("Append(2): %v", err)
+	}
+	if second.PrevHash != first.Hash {
+		t.Errorf("second.PrevHash = %q, want %q", second.PrevHash, first.Hash)
+	}
+	if c.LastHash() != second.Hash {
+		t.Errorf("LastHash() = %q, want %q", c.LastHash(), second.Hash)
+	}
+
+	// Same logical content appended again must still produce a different hash
+	// because Seq/PrevHash differ — the chain, not just the payload, is hashed.
+	third, err := c.Append(testEnforceReceiptEntry(1))
+	if err != nil {
+		t.Fatalf("Append(1 again): %v", err)
+	}
+	if third.Hash == first.Hash {
+		t.Error("re-appending identical entry content produced the same hash as the genesis entry")
+	}
+}
+
+func TestEnforceReceiptChain_DifferentContentDifferentHash(t *testing.T) {
+	t.Parallel()
+	c1, c2 := NewEnforceReceiptChain(), NewEnforceReceiptChain()
+
+	e1 := testEnforceReceiptEntry(1)
+	e2 := testEnforceReceiptEntry(1)
+	e2.Verdict = "compliant"
+
+	r1, err := c1.Append(e1)
+	if err != nil {
+		t.Fatalf("Append e1: %v", err)
+	}
+	r2, err := c2.Append(e2)
+	if err != nil {
+		t.Fatalf("Append e2: %v", err)
+	}
+	if r1.Hash == r2.Hash {
+		t.Error("entries with different verdicts produced the same hash")
+	}
+}
+
+func TestVerifyEnforceReceiptChain_IntactChainPasses(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+	var entries []EnforceReceiptEntry
+	for i := 1; i <= 4; i++ {
+		entry, err := c.Append(testEnforceReceiptEntry(i))
+		if err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+		entries = append(entries, entry)
+	}
+
+	ok, brokenAt, err := VerifyEnforceReceiptChain(entries)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain: %v", err)
+	}
+	if !ok || brokenAt != -1 {
+		t.Errorf("expected intact chain, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestVerifyEnforceReceiptChain_DetectsTamperedField(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+	var entries []EnforceReceiptEntry
+	for i := 1; i <= 3; i++ {
+		entry, err := c.Append(testEnforceReceiptEntry(i))
+		if err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+		entries = append(entries, entry)
+	}
+
+	entries[1].Event.Path = "/tampered/path"
+
+	ok, brokenAt, err := VerifyEnforceReceiptChain(entries)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain: %v", err)
+	}
+	if ok || brokenAt != 1 {
+		t.Errorf("expected tamper detected at index 1, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestVerifyEnforceReceiptChain_DetectsDeletedEntry(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+	var entries []EnforceReceiptEntry
+	for i := 1; i <= 3; i++ {
+		entry, err := c.Append(testEnforceReceiptEntry(i))
+		if err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+		entries = append(entries, entry)
+	}
+
+	// Remove the middle entry: the seq sequence now has a gap (1, 3) and the
+	// third entry's PrevHash no longer matches the (now second) entry's hash.
+	spliced := []EnforceReceiptEntry{entries[0], entries[2]}
+
+	ok, brokenAt, err := VerifyEnforceReceiptChain(spliced)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain: %v", err)
+	}
+	if ok || brokenAt != 1 {
+		t.Errorf("expected deletion detected at index 1, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestVerifyEnforceReceiptChain_DetectsReorderedEntries(t *testing.T) {
+	t.Parallel()
+	c := NewEnforceReceiptChain()
+	var entries []EnforceReceiptEntry
+	for i := 1; i <= 3; i++ {
+		entry, err := c.Append(testEnforceReceiptEntry(i))
+		if err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+		entries = append(entries, entry)
+	}
+
+	reordered := []EnforceReceiptEntry{entries[0], entries[2], entries[1]}
+
+	ok, brokenAt, err := VerifyEnforceReceiptChain(reordered)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain: %v", err)
+	}
+	if ok || brokenAt != 1 {
+		t.Errorf("expected reorder detected at index 1, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestVerifyEnforceReceiptChain_EmptyChainIsTriviallyIntact(t *testing.T) {
+	t.Parallel()
+	ok, brokenAt, err := VerifyEnforceReceiptChain(nil)
+	if err != nil {
+		t.Fatalf("VerifyEnforceReceiptChain(nil): %v", err)
+	}
+	if !ok || brokenAt != -1 {
+		t.Errorf("expected empty chain to verify as intact, got ok=%v brokenAt=%d", ok, brokenAt)
+	}
+}
+
+func TestEnforceEventSummaryAccumulator_RecordsCountsAndDigest(t *testing.T) {
+	t.Parallel()
+	chain := NewEnforceReceiptChain()
+	acc := NewEnforceEventSummaryAccumulator()
+
+	e1, _ := chain.Append(testEnforceReceiptEntry(1))
+	acc.RecordReceipt(e1, "bpf_lsm:enforce")
+
+	permissive := testEnforceReceiptEntry(2)
+	permissive.Verdict = "blocked"
+	e2, _ := chain.Append(permissive)
+	acc.RecordReceipt(e2, "bpf_lsm:permissive")
+
+	acc.RecordLostSamples(3)
+
+	snap := acc.Snapshot()
+	if snap.TotalEvents != 2 {
+		t.Errorf("TotalEvents = %d, want 2", snap.TotalEvents)
+	}
+	if snap.VerdictCounts["denied"] != 1 || snap.VerdictCounts["blocked"] != 1 {
+		t.Errorf("VerdictCounts = %+v, want denied=1 blocked=1", snap.VerdictCounts)
+	}
+	if snap.TierCoverage["bpf_lsm:enforce"] != 1 || snap.TierCoverage["bpf_lsm:permissive"] != 1 {
+		t.Errorf("TierCoverage = %+v, want one of each tier", snap.TierCoverage)
+	}
+	if snap.LostSamples != 3 {
+		t.Errorf("LostSamples = %d, want 3", snap.LostSamples)
+	}
+	if snap.LastSeq != 2 {
+		t.Errorf("LastSeq = %d, want 2", snap.LastSeq)
+	}
+	if snap.ChainDigest != e2.Hash {
+		t.Errorf("ChainDigest = %q, want chain head %q", snap.ChainDigest, e2.Hash)
+	}
+}

--- a/go/pkg/kernelcapture/types.go
+++ b/go/pkg/kernelcapture/types.go
@@ -8,6 +8,10 @@ type ProcessEventType string
 const (
 	ProcessEventExec ProcessEventType = "exec"
 	ProcessEventExit ProcessEventType = "exit"
+	// ProcessEventEnforce marks a BPF-LSM enforcement decision (deny/allowlist
+	// miss) projected into the generic ProcessEvent shape so it can be routed
+	// through the same Correlator as exec/exit events.
+	ProcessEventEnforce ProcessEventType = "enforce"
 )
 
 // ProcessEvent captures one kernel-observed process lifecycle observation.

--- a/python/tests/test_kernel_correlation.py
+++ b/python/tests/test_kernel_correlation.py
@@ -200,3 +200,75 @@ def test_register_session_validates_inputs(tmp_path: Path) -> None:
         client.register_session(session_id="s", root_pid=0, cgroup_id=1, ttl_seconds=60)
     with pytest.raises(ValueError):
         client.register_session(session_id="s", root_pid=1, cgroup_id=0, ttl_seconds=60)
+
+
+def test_session_status_roundtrip_returns_enforcement_summary(sockdir: Path) -> None:
+    """The daemon's session_status response carries a kernel-enforcement
+    rollup (Epic A #63 / plan E3 phase a). Evidence-log directories are
+    root-0700, so this socket round-trip is the only channel a non-root
+    caller has to learn what kernel enforcement happened for a session.
+    """
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": True,
+            "method": "session_status",
+            "session_id": "sess-1",
+            "status": "active",
+            "enforcement": {
+                "total_events": 4,
+                "verdict_counts": {"denied": 3, "compliant": 1},
+                "tier_coverage": {"bpf_lsm:enforce": 4},
+                "orphan_count": 0,
+                "lost_samples": 0,
+                "last_seq": 4,
+                "chain_digest": "abc123",
+            },
+        },
+    )
+    daemon.start()
+    try:
+        client = kc.KernelCaptureClient(sock)
+        resp = client.session_status(session_id="sess-1")
+    finally:
+        daemon.close()
+
+    assert resp["status"] == "active"
+    assert resp["enforcement"]["total_events"] == 4
+    assert resp["enforcement"]["verdict_counts"]["denied"] == 3
+    assert daemon.received is not None
+    assert daemon.received["method"] == "session_status"
+    assert daemon.received["session_status"]["session_id"] == "sess-1"
+
+
+def test_session_status_validates_session_id(tmp_path: Path) -> None:
+    client = kc.KernelCaptureClient(tmp_path / "x.sock")
+    with pytest.raises(ValueError):
+        client.session_status(session_id="")
+
+
+def test_session_status_response_without_enforcement_key(sockdir: Path) -> None:
+    """A session with no processed enforce_events omits the key entirely;
+    callers must treat a missing key the same as an empty summary.
+    """
+    sock = sockdir / "c.sock"
+    daemon = _FakeDaemon(
+        sock,
+        {
+            "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+            "ok": True,
+            "method": "session_status",
+            "session_id": "sess-2",
+            "status": "active",
+        },
+    )
+    daemon.start()
+    try:
+        client = kc.KernelCaptureClient(sock)
+        resp = client.session_status(session_id="sess-2")
+    finally:
+        daemon.close()
+
+    assert "enforcement" not in resp

--- a/python/tests/test_proxy.py
+++ b/python/tests/test_proxy.py
@@ -79,6 +79,42 @@ class TestSessionLifecycle:
         assert isinstance(result, dict)
 
 
+class TestIssueAttestationForSessionKernelEnforcement:
+    """Epic A #63 / plan E3 phase b: the finalized attestation must be able to
+    see kernel-level enforcement denials, not just proxy-evaluated decisions.
+    """
+
+    def test_folds_kernel_enforcement_block_into_attestation_claims(
+        self, proxy, example_mission, private_key
+    ):
+        token = issue_passport(example_mission, private_key, ttl_s=60)
+        session = proxy.start_session(token)
+        enforcement = {
+            "total_events": 3,
+            "verdict_counts": {"denied": 2, "compliant": 1},
+            "tier_coverage": {"bpf_lsm:enforce": 3},
+            "chain_digest": "deadbeef",
+        }
+
+        _jwt_token, claims = proxy.issue_attestation_for_session(
+            session.jti, proxy.receipt_private_key, kernel_enforcement=enforcement
+        )
+
+        assert claims["kernel_enforcement"] == enforcement
+
+    def test_omits_kernel_enforcement_when_none_provided(
+        self, proxy, example_mission, private_key
+    ):
+        token = issue_passport(example_mission, private_key, ttl_s=60)
+        session = proxy.start_session(token)
+
+        _jwt_token, claims = proxy.issue_attestation_for_session(
+            session.jti, proxy.receipt_private_key
+        )
+
+        assert "kernel_enforcement" not in claims
+
+
 class TestPassportVerification:
     def test_verify_valid_passport(self, proxy, example_mission, private_key):
         token = issue_passport(example_mission, private_key, ttl_s=60)

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from argparse import Namespace
 import json
+import shutil
+import socket
 import sys
+import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -26,6 +30,7 @@ from vibap.run_bridge import (
     EnvProxyAdapter,
     RunContext,
     TransparentInterceptAdapter,
+    _kernel_enforcement_claim,
     run_governed,
     run_governed_cli,
     select_adapter,
@@ -133,6 +138,9 @@ def test_ardur_run_governs_launched_agent_zero_setup(
     assert att["passport_jti"] == result.session_id
     assert int(att["permits"]) == 2
     assert int(att["denials"]) == 1
+    # No kernel daemon was reachable (hermetic test host), so the attestation
+    # must not claim kernel-enforcement data it never actually observed.
+    assert "kernel_enforcement" not in att
 
     # — ZERO manual ardur protect: governance ran from an isolated ephemeral
     #   home with its own passport; nothing was written to ~/.claude/settings.json —
@@ -178,6 +186,119 @@ def test_run_governed_rejects_unknown_via(tmp_path: Path, monkeypatch: pytest.Mo
     _hermetic_kernel_env(monkeypatch, tmp_path)
     with pytest.raises(ValueError, match="unknown --via"):
         run_governed(command=["true"], via="bogus", home=tmp_path / "h")
+
+
+class _FakeSessionStatusDaemon:
+    """A one-shot AF_UNIX server that replays a canned session_status response."""
+
+    def __init__(self, socket_path: Path, response: dict) -> None:
+        self.socket_path = socket_path
+        self.response = response
+        self.received: dict | None = None
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(socket_path))
+        self._server.listen(1)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._server.accept()
+        except OSError:
+            return
+        with conn:
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            line = buf.split(b"\n", 1)[0]
+            try:
+                self.received = json.loads(line.decode("utf-8"))
+            except ValueError:
+                self.received = None
+            conn.sendall(json.dumps(self.response).encode("utf-8") + b"\n")
+
+    def close(self) -> None:
+        self._server.close()
+
+
+class TestKernelEnforcementClaim:
+    """Epic A #63 / plan E3 phase b: the run bridge must be able to fetch a
+    session's kernel-enforcement rollup before folding it into the
+    attestation — and must never let that fetch block finalization.
+    """
+
+    def test_returns_none_when_correlation_was_never_established(self) -> None:
+        correlation = kc.CorrelationResult(available=False, reason="cgroup v2 unavailable")
+        assert _kernel_enforcement_claim("sess-x", correlation) is None
+
+    def test_fetches_enforcement_summary_when_daemon_reachable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sock_dir = Path(tempfile.mkdtemp(dir="/tmp"))
+        try:
+            sock = sock_dir / "c.sock"
+            monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(sock))
+            daemon = _FakeSessionStatusDaemon(
+                sock,
+                {
+                    "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                    "ok": True,
+                    "method": "session_status",
+                    "session_id": "sess-x",
+                    "status": "active",
+                    "enforcement": {"total_events": 2, "verdict_counts": {"denied": 2}},
+                },
+            )
+            try:
+                correlation = kc.CorrelationResult(
+                    available=True, reason="registered", method="cgroup_daemon_register"
+                )
+                result = _kernel_enforcement_claim("sess-x", correlation)
+            finally:
+                daemon.close()
+        finally:
+            shutil.rmtree(sock_dir, ignore_errors=True)
+
+        assert result == {"total_events": 2, "verdict_counts": {"denied": 2}}
+        assert daemon.received is not None
+        assert daemon.received["method"] == "session_status"
+        assert daemon.received["session_status"]["session_id"] == "sess-x"
+
+    def test_degrades_to_none_when_daemon_unreachable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(tmp_path / "no-such-daemon.sock"))
+        correlation = kc.CorrelationResult(available=True, reason="registered")
+        assert _kernel_enforcement_claim("sess-x", correlation) is None
+
+    def test_degrades_to_none_when_daemon_returns_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sock_dir = Path(tempfile.mkdtemp(dir="/tmp"))
+        try:
+            sock = sock_dir / "c.sock"
+            monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(sock))
+            daemon = _FakeSessionStatusDaemon(
+                sock,
+                {
+                    "protocol_version": kc.DAEMON_PROTOCOL_VERSION,
+                    "ok": False,
+                    "method": "session_status",
+                    "error": "session not found",
+                },
+            )
+            try:
+                correlation = kc.CorrelationResult(available=True, reason="registered")
+                result = _kernel_enforcement_claim("sess-x", correlation)
+            finally:
+                daemon.close()
+        finally:
+            shutil.rmtree(sock_dir, ignore_errors=True)
+
+        assert result is None
 
 
 @pytest.mark.parametrize("command", ([], ["--"]))

--- a/python/vibap/kernel_correlation.py
+++ b/python/vibap/kernel_correlation.py
@@ -187,6 +187,26 @@ class KernelCaptureClient:
             }
         )
 
+    def session_status(self, *, session_id: str) -> dict[str, Any]:
+        """Fetch the daemon's status snapshot for a session, including its
+        kernel-enforcement rollup (``"enforcement"``) when the daemon has
+        processed enforce_events for it.
+
+        Evidence-log directories are root-0700, so this socket round-trip is
+        the only way a non-root caller can learn what kernel enforcement
+        happened for a session — see go/pkg/kernelcapture/daemon_protocol.go's
+        ``DaemonProtocolResponse.Enforcement``.
+        """
+        if not session_id:
+            raise ValueError("session_id is required")
+        return self._roundtrip(
+            {
+                "protocol_version": DAEMON_PROTOCOL_VERSION,
+                "method": "session_status",
+                "session_status": {"session_id": session_id},
+            }
+        )
+
 
 # ── cgroup v2 helpers ──────────────────────────────────────────────────────────
 

--- a/python/vibap/proxy.py
+++ b/python/vibap/proxy.py
@@ -3321,6 +3321,8 @@ class GovernanceProxy:
         self,
         session_id: str,
         private_key: ec.EllipticCurvePrivateKey,
+        *,
+        kernel_enforcement: dict[str, Any] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         created_summary = False
         token = ""
@@ -3329,11 +3331,11 @@ class GovernanceProxy:
                 summary, created_summary = self._finalize_session_locked(target)
                 if target.attestation_token is None:
                     lifecycle_claims = self._lifecycle_rollup_for_session_unlocked(target)
-                    extra_claims = (
-                        lifecycle_claims
-                        if int(lifecycle_claims["delegation_count"]) > 0
-                        else None
-                    )
+                    extra_claims: dict[str, Any] = {}
+                    if int(lifecycle_claims["delegation_count"]) > 0:
+                        extra_claims.update(lifecycle_claims)
+                    if kernel_enforcement is not None:
+                        extra_claims["kernel_enforcement"] = kernel_enforcement
                     target.attestation_token = issue_attestation(
                         passport_jti=target.jti,
                         agent_id=target.passport_claims["sub"],

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -455,6 +455,31 @@ def _correlate_launch(
     )
 
 
+def _kernel_enforcement_claim(
+    session_id: str,
+    correlation: kc.CorrelationResult,
+) -> dict[str, Any] | None:
+    """Fetch the daemon's kernel-enforcement rollup for a correlated session.
+
+    Returns ``None`` (never raises) when correlation was never established or
+    the daemon cannot be reached — kernel enforcement data is an enhancement
+    to the attestation, never a hard dependency for finalizing a run. This
+    must be called before the kernel daemon's ``end_session``, which retires
+    the session's enforcement summary daemon-side.
+    """
+    if not correlation.available:
+        return None
+    try:
+        client = kc.KernelCaptureClient(kc.daemon_socket_path())
+        response = client.session_status(session_id=session_id)
+    except (kc.DaemonUnavailable, kc.DaemonProtocolError, ValueError):
+        return None
+    enforcement = response.get("enforcement")
+    if not isinstance(enforcement, dict):
+        return None
+    return enforcement
+
+
 # ── main entry ─────────────────────────────────────────────────────────────────
 
 
@@ -540,6 +565,9 @@ def run_governed(
     daemon_registered = False
     proc: subprocess.Popen[bytes] | None = None
     notes: list[str] = []
+    # Pre-initialized so the finally block has a safe value even if an
+    # exception is raised before kernel correlation is attempted below.
+    correlation = kc.CorrelationResult(available=False, reason="run did not reach kernel correlation")
     try:
         _wait_for_health(proxy_url, api_token)
 
@@ -605,9 +633,12 @@ def run_governed(
             notes.append(f"agent exceeded max-duration {max_duration_s}s and was terminated")
     finally:
         # 7. Finalize the governance session: attestation + receipt chain.
+        # Kernel enforcement must be fetched before the kernel daemon's
+        # end_session call below, which retires the session's summary.
+        kernel_enforcement = _kernel_enforcement_claim(session_id, correlation)
         summary = proxy.end_session(session_id)
         attestation_token, _claims = proxy.issue_attestation_for_session(
-            session_id, proxy.receipt_private_key
+            session_id, proxy.receipt_private_key, kernel_enforcement=kernel_enforcement
         )
         if daemon_registered and cgroup_handle is not None:
             try:


### PR DESCRIPTION
## Summary

Epic A (#63), plan E3 (correlation hardening). Addresses the known gaps in `enforce_events` processing:

- entries were unsequenced and unsigned (no way to detect a dropped/reordered/edited record)
- events bypassed the existing per-session `Correlator`, using a bare cgroup lookup instead
- orphaned events (no registered session for the cgroup) were silently dropped
- ringbuf `LostSamples` were logged but never accounted anywhere durable
- the finalized behavioral attestation never saw kernel-level denials

**Phase a (Go — `go/pkg/kernelcapture`, `go/cmd/ardur-kernelcaptured`)**

- `EnforceReceiptChain`: monotonic `Seq` + SHA-256 hash chain per routing scope, plus `VerifyEnforceReceiptChain` to detect gaps, tampering, deletion, and reordering.
- `processEnforceEvent` routes through the *same* per-session `Correlator` used for exec/exit tracepoint events (PID + cgroup + time-window attribution), instead of the previous bare cgroup-index lookup. The kernel's own action (`ActionTaken`/`EnforceMode`) remains the authoritative verdict — correlation only grades attribution confidence.
- Orphaned events (cgroup with no registered session) and ringbuf `LostSamples` are no longer silently dropped: orphans are hash-chained into a dedicated `_orphan/enforce_events.jsonl` log and counted; lost samples are accumulated and surfaced.
- `EnforceEventSummary` (counts by verdict, tier coverage, orphan count, lost samples, last seq, chain digest) is exposed on `session_status` responses via a new `DaemonProtocolResponse.Enforcement` field.

**Phase b (Python — `python/vibap`)**

- `KernelCaptureClient.session_status()` fetches the summary over the daemon's Unix socket — the only channel available to a non-root caller, since evidence-log directories are root-0700.
- `GovernanceProxy.issue_attestation_for_session()` accepts an optional `kernel_enforcement` extra claim.
- `run_bridge.run_governed()` fetches the summary (`_kernel_enforcement_claim`) before the kernel daemon's `end_session` retires it, and folds it into the attestation. Never raises / never blocks finalization if the daemon is unreachable or correlation was never established.

**Scope note:** the BPF-LSM loader that actually produces real `enforce_events` (Slice 4.2, #92) is a separate, still-blocked C-compile effort (documented in the Epic A slice history) and stays out of scope here. This PR lands the event-processing/hardening pipeline as fully-tested, standalone Go + Python code — built and tested against synthetic events on both darwin and linux — so it's ready to wire in (`consumeEnforceEvents` takes an abstract `enforceEventReader` interface satisfied by a thin adapter over `*ringbuf.Reader`) the moment that loader lands.

## Test plan

- [x] `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` both succeed
- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green, including new tests: seq/hash-chain continuity + tamper/deletion/reorder detection (`enforce_receipt_chain_test.go`), Correlator routing + orphan routing + lost-sample accounting + session_status exposure (`daemon_enforce_test.go`)
- [x] `python -m pytest tests/` — full suite green (1156 passed; the only 2 failures — `test_provider_adapter_fixtures.py` SDK-dependency checks — are pre-existing and unrelated to this change, confirmed by inspection)
- [x] `ruff check` clean on all new/touched files
- [x] New tests: `session_status()` client roundtrip (`test_kernel_correlation.py`), `_kernel_enforcement_claim` fetch/degrade behavior + attestation fold (`test_run_bridge.py`, `test_proxy.py`)

Refs: Epic A #63, plan E3.