### PR TITLE
feat(enforce): seccomp user-notify enforcement tier (E4)

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -1,7 +1,8 @@
 name: kernel-enforce
 
-# Privileged Linux CI for the Slice 4.2 BPF-LSM enforcement bridge
-# (go/pkg/kernelcapture/process_guard.bpf.c). Two jobs:
+# Privileged Linux CI for the two-tier kernel enforcement bridge
+# (go/pkg/kernelcapture/process_guard.bpf.c — BPF-LSM; seccomp_notify_linux.go
+# — seccomp user-notify). Three jobs:
 #
 #   bpf-generate — compiles process_guard.bpf.c with the same toolchain
 #     (Ubuntu 24.04 default clang, currently 18.x) used to produce the
@@ -23,9 +24,25 @@ name: kernel-enforce
 #     one thing bpf-generate cannot prove: that the compiled program actually
 #     enforces on a live kernel, not just that it loads.
 #
+#   seccomp-smoke — the seccomp user-notify tier's equivalent proof (plan
+#     E4, the common-case fallback for hosts where BPF-LSM never loads).
+#     Unlike kernel-smoke this needs no KVM/virtme-ng custom kernel boot:
+#     seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER, ...)
+#     works under an ordinary PR_SET_NO_NEW_PRIVS-only process, confirmed
+#     empirically during E4's development — a plain runner is enough. Runs
+#     ardur-seccomp-smoke, which starts a real ardur-kernelcaptured (with no
+#     BPF-LSM available, so it falls back to seccomp), runs ardur-exec-shim
+#     against a real target process, and asserts a policy-denied connect(2)
+#     gets EPERM while a policy-allowed one reaches the kernel's real connect
+#     handling. This exact harness caught two real bugs no pure-Go test
+#     surfaced (see ardur-seccomp-smoke's package doc comment) — losing it
+#     would mean losing the only thing that can catch a regression in either.
+#
 # kernel-smoke starts as continue-on-error: true — promote it to a required
 # check once a burn-in period confirms the virtme-ng invocation and kernel
-# cmdline handling are stable on GitHub-hosted runners.
+# cmdline handling are stable on GitHub-hosted runners. seccomp-smoke needs
+# no such VM and has been stable since it was added, so it's a required
+# check from the start.
 #
 # This workflow is also the gate for the cilium/ebpf dependency: any future
 # version bump that touches go/go.mod must pass bpf-generate (compiles
@@ -38,6 +55,8 @@ on:
       - "go/pkg/kernelcapture/**"
       - "go/cmd/ardur-kernelcaptured/**"
       - "go/cmd/ardur-guard-smoke/**"
+      - "go/cmd/ardur-exec-shim/**"
+      - "go/cmd/ardur-seccomp-smoke/**"
       - "go/go.mod"
       - "go/go.sum"
       - ".github/workflows/kernel-enforce.yml"
@@ -47,6 +66,8 @@ on:
       - "go/pkg/kernelcapture/**"
       - "go/cmd/ardur-kernelcaptured/**"
       - "go/cmd/ardur-guard-smoke/**"
+      - "go/cmd/ardur-exec-shim/**"
+      - "go/cmd/ardur-seccomp-smoke/**"
       - "go/go.mod"
       - "go/go.sum"
       - ".github/workflows/kernel-enforce.yml"
@@ -196,3 +217,54 @@ jobs:
             --run \
             --append "lsm=bpf" \
             --exec /tmp/ardur-guard-smoke
+
+  seccomp-smoke:
+    name: seccomp-smoke
+    needs: bpf-generate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.4"
+          cache: true
+          cache-dependency-path: go/go.sum
+
+      - name: Install BPF build toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev linux-libc-dev
+          clang --version
+
+      # pkg/kernelcapture also contains the BPF-LSM tier's generated
+      # bindings; regenerate them here the same way bpf-generate and
+      # kernel-smoke do so this job never depends on a build-artifact cache
+      # or job ordering to see a consistent tree — bpf-generate's own drift
+      # check (needs: bpf-generate, above) is what actually guards that
+      # what's committed matches what this regenerates.
+      - name: go generate ./go/pkg/kernelcapture/...
+        working-directory: go/pkg/kernelcapture
+        run: go generate ./...
+
+      - name: Build ardur-kernelcaptured, ardur-exec-shim, ardur-seccomp-smoke
+        working-directory: go
+        run: |
+          go build -o /tmp/ardur-kernelcaptured ./cmd/ardur-kernelcaptured
+          go build -o /tmp/ardur-exec-shim ./cmd/ardur-exec-shim
+          go build -o /tmp/ardur-seccomp-smoke ./cmd/ardur-seccomp-smoke
+
+      # ardur-kernelcaptured's custody plan requires its run/state dirs under
+      # /run/ardur and /var/lib/ardur (daemon_custody.go) — not configurable
+      # to an arbitrary tmp path — so this needs root to create/write them,
+      # the same reason kernel-smoke's boot step above runs under sudo. No
+      # KVM, no custom kernel: seccomp(SECCOMP_SET_MODE_FILTER,
+      # SECCOMP_FILTER_FLAG_NEW_LISTENER, ...) works on the runner's own
+      # kernel with no special privilege beyond PR_SET_NO_NEW_PRIVS, which
+      # ardur-exec-shim sets itself.
+      - name: Run the seccomp tier smoke test
+        run: |
+          sudo /tmp/ardur-seccomp-smoke \
+            --daemon-bin /tmp/ardur-kernelcaptured \
+            --shim-bin /tmp/ardur-exec-shim

--- a/go/cmd/ardur-exec-shim/main.go
+++ b/go/cmd/ardur-exec-shim/main.go
@@ -1,0 +1,249 @@
+//go:build linux
+
+// Command ardur-exec-shim is the on-ramp for the seccomp user-notify
+// enforcement tier (Epic A #63, plan E4) — the common-case fallback for
+// hosts where BPF-LSM never loads (stock distros that ship CONFIG_BPF_LSM=y
+// but don't put "bpf" in the boot lsm= list, so the BPF-LSM tier in
+// daemon_guard_linux.go silently isn't active).
+//
+// It installs a connect(2)-scoped SECCOMP_RET_USER_NOTIF filter in itself
+// (kernelcapture.InstallConnectUserNotifyFilter), hands the resulting
+// notification listener fd to ardur-kernelcaptured over a dedicated Unix
+// socket via SCM_RIGHTS (see go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go),
+// then execve()s into the target command — replacing itself, so the governed
+// process tree keeps the shim's PID and the filter (installed before exec,
+// inherited across it by seccomp's design) carries over unchanged. One
+// filter, installed once here, covers every descendant that process tree
+// forks or execs afterward — no per-child re-registration.
+//
+// Claim boundary: this only covers connect(2). Everything else about this
+// tier's scope and its documented weaker-than-BPF-LSM security claim is in
+// go/pkg/kernelcapture/seccomp_policy.go's header comment.
+//
+// Fail-closed without a supervisor: if the handoff to the daemon fails, or
+// the daemon later dies without a replacement attaching, the kernel's own
+// seccomp-notify semantics take over — a USER_NOTIF-returning filter with no
+// live listener answers every trapped syscall with -ENOSYS
+// (Documentation/userspace-api/seccomp_filter.rst). So a missing or lost
+// supervisor blocks connect(2) outright rather than letting it through
+// unfiltered; there is deliberately no separate "abort, don't exec at all"
+// fallback path here — the filter itself is already the fail-closed
+// mechanism, and refusing to run the target at all would only be a *weaker*
+// guarantee (no filter, but also no program) for a caller who asked to run
+// something.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultSeccompSocketPath = "/run/ardur/kernelcapture/seccomp.sock"
+
+	handoffDialTimeout  = 5 * time.Second
+	handoffWriteTimeout = 5 * time.Second
+	handoffReadTimeout  = 10 * time.Second
+	handoffMaxRespBytes = 4096
+
+	// A brief bounded retry, not a long one: this is here to absorb the
+	// ordinary "daemon is still finishing startup" race, not to paper over a
+	// daemon that is actually down — see the package doc comment for what
+	// happens to connect(2) in the target process when the handoff never
+	// succeeds.
+	handoffAttempts  = 3
+	handoffRetryWait = 500 * time.Millisecond
+)
+
+func main() {
+	// seccomp filters attach to the calling OS thread (propagating to
+	// threads/processes created afterward via clone/exec on *that* thread),
+	// not to the Go process as a whole. Without this, the Go scheduler is
+	// free to migrate main's goroutine to a different OS thread between
+	// InstallConnectUserNotifyFilter and the later unix.Exec — one that
+	// never had the filter installed — silently running the target
+	// completely unfiltered. Caught empirically: the first end-to-end run
+	// of this shim let a policy-denied connect() straight through.
+	runtime.LockOSThread()
+
+	var (
+		sessionID     = flag.String("session-id", "", "ardur session_id this shim's connect(2) decisions are evaluated against (required)")
+		seccompSocket = flag.String("seccomp-socket", defaultSeccompSocketPath, "ardur-kernelcaptured's seccomp handoff socket path")
+	)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if *sessionID == "" || len(args) == 0 {
+		usage()
+		os.Exit(2)
+	}
+
+	if err := run(*sessionID, *seccompSocket, args); err != nil {
+		fmt.Fprintf(os.Stderr, "ardur-exec-shim: %v\n", err)
+		os.Exit(1)
+	}
+	// run only returns on a setup failure before exec; a successful exec
+	// replaces this process image and control never comes back here.
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: %s --session-id ID [--seccomp-socket PATH] -- COMMAND [ARGS...]\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
+func run(sessionID, seccompSocketPath string, args []string) error {
+	target, err := lookupTarget(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Establish (and retry, if needed) the handoff connection to the
+	// daemon BEFORE installing the seccomp filter below. This ordering is
+	// load-bearing, not stylistic: seccomp intercepts connect(2) by
+	// syscall number alone, with no awareness of socket address family —
+	// once the filter is live, this process's own connect() to the
+	// daemon's AF_UNIX handoff socket would be trapped by the very
+	// listener it's trying to hand off, and since nothing services that
+	// listener until the handoff completes, the connect() would block
+	// forever (a self-deadlock, caught empirically: the first end-to-end
+	// run of this shim hung exactly here). Dialing first sidesteps it:
+	// the connection already exists by the time the filter goes live, so
+	// writing the header+fd and reading the response over it afterward
+	// are plain read/write on an already-open fd, not new syscalls the
+	// filter would ever see.
+	handoffConn, dialErr := dialHandoffWithRetry(seccompSocketPath)
+
+	listenerFD, err := kernelcapture.InstallConnectUserNotifyFilter()
+	if err != nil {
+		if handoffConn != nil {
+			handoffConn.Close()
+		}
+		return fmt.Errorf("install seccomp connect-notify filter: %w", err)
+	}
+
+	handoffErr := dialErr
+	if dialErr == nil {
+		handoffErr = sendHandoff(handoffConn, sessionID, listenerFD)
+		handoffConn.Close()
+	}
+	if handoffErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"ardur-exec-shim: warning: seccomp handoff to daemon failed, connect(2) will fail closed (ENOSYS) until a listener attaches: %v\n", handoffErr)
+	}
+	// Whether or not the handoff above succeeded, this process's own
+	// reference to listenerFD must not survive into the target: on success
+	// the daemon holds an independent SCM_RIGHTS-duplicated reference, so
+	// closing ours is just cleanup; on failure closing it removes the *last*
+	// reference, which is what makes the kernel answer -ENOSYS rather than
+	// leaving connect(2) calls blocked forever waiting on a notification
+	// nobody will ever read. It also isn't safe to just let exec's implicit
+	// CLOEXEC handling deal with this: the fd came back from a raw
+	// SYS_SECCOMP syscall, not one of Go's fd-tracking open paths, so
+	// CLOEXEC was never set on it — leaving it open would leak a working
+	// listener fd straight into the governed process's own fd table.
+	_ = unix.Close(listenerFD)
+
+	return unix.Exec(target, args, os.Environ())
+}
+
+// lookupTarget resolves argv[0] to an executable path, matching the PATH
+// search execve(2) itself does not do (unix.Exec, like the raw syscall,
+// requires an already-resolved path).
+func lookupTarget(name string) (string, error) {
+	if strings.Contains(name, "/") {
+		return name, nil
+	}
+	resolved, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q in PATH: %w", name, err)
+	}
+	return resolved, nil
+}
+
+// seccompHandoffRequest/seccompHandoffResponse mirror (by JSON shape only —
+// this is a separate binary, there is no shared Go type) the daemon's
+// seccompHandoffRequest/seccompHandoffResponse in
+// go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go.
+type seccompHandoffRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+type seccompHandoffResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// dialHandoffWithRetry connects to the daemon's seccomp handoff socket,
+// retrying a bounded number of times to absorb the daemon-still-starting
+// race. Must run before the seccomp filter is installed — see run's comment
+// for why redialing after that point would deadlock.
+func dialHandoffWithRetry(socketPath string) (*net.UnixConn, error) {
+	var lastErr error
+	for attempt := 0; attempt < handoffAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(handoffRetryWait)
+		}
+		conn, err := net.DialTimeout("unix", socketPath, handoffDialTimeout)
+		if err != nil {
+			lastErr = fmt.Errorf("dial seccomp handoff socket %s: %w", socketPath, err)
+			continue
+		}
+		unixConn, ok := conn.(*net.UnixConn)
+		if !ok {
+			conn.Close()
+			return nil, fmt.Errorf("dial seccomp handoff socket %s: unexpected connection type %T", socketPath, conn)
+		}
+		return unixConn, nil
+	}
+	return nil, lastErr
+}
+
+// sendHandoff writes the session_id header and listenerFD (via SCM_RIGHTS)
+// on an already-connected conn and reads the daemon's response. No retry
+// here: retrying would require a new connect(), which — once the seccomp
+// filter this fd belongs to is installed — would deadlock the same way a
+// fresh dial would (see run's comment). A single already-open connection
+// gets exactly one request/response, matching the daemon's one-shot handoff
+// handler (it closes the connection after responding either way).
+func sendHandoff(conn *net.UnixConn, sessionID string, listenerFD int) error {
+	header, err := json.Marshal(seccompHandoffRequest{SessionID: sessionID})
+	if err != nil {
+		return fmt.Errorf("encode handoff header: %w", err)
+	}
+
+	if err := conn.SetWriteDeadline(time.Now().Add(handoffWriteTimeout)); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+	if _, _, err := conn.WriteMsgUnix(header, unix.UnixRights(listenerFD), nil); err != nil {
+		return fmt.Errorf("send handoff message: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(handoffReadTimeout)); err != nil {
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+	respBuf := make([]byte, handoffMaxRespBytes)
+	n, err := conn.Read(respBuf)
+	if err != nil {
+		return fmt.Errorf("read handoff response: %w", err)
+	}
+
+	var resp seccompHandoffResponse
+	if err := json.Unmarshal(respBuf[:n], &resp); err != nil {
+		return fmt.Errorf("decode handoff response: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("daemon rejected handoff: %s", resp.Error)
+	}
+	return nil
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_apply_policy_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_apply_policy_test.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
@@ -114,6 +115,118 @@ func TestHandleApplyPolicy_UnknownSessionFailsCleanly(t *testing.T) {
 	resp := d.handleApplyPolicy(applyPolicyReqFor("does-not-exist", kernelcapture.BpfEnforceModeEnforce))
 	if resp.OK {
 		t.Fatal("apply_policy for an unregistered session: OK = true, want false")
+	}
+}
+
+// --- seccomp tier (plan E4) ---------------------------------------------
+
+func applyNetConnectPolicyReqFor(sessionID string, action kernelcapture.BpfAction, mode kernelcapture.BpfEnforceMode, netAllow ...string) kernelcapture.DaemonProtocolRequest {
+	ap := &kernelcapture.DaemonApplyPolicyRequest{
+		SessionID:   sessionID,
+		Generation:  1,
+		EnforceMode: mode,
+		OpPolicies: []kernelcapture.DaemonOpPolicy{
+			{Op: kernelcapture.BpfOpNetConnect, Action: action, EnforceMode: mode},
+		},
+		NetAllow: netAllow,
+	}
+	return kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy:     ap,
+	}
+}
+
+// TestHandleApplyPolicy_SyncsSeccompStoreEvenWhenBPFTierHardFails asserts the
+// seccomp tier's in-memory policy is populated as a side effect of
+// handleApplyPolicy regardless of the overall response: a session's seccomp
+// policy must already be in place by the time — if ever — a listener
+// attaches for it, and apply_policy commonly runs well before that handoff.
+func TestHandleApplyPolicy_SyncsSeccompStoreEvenWhenBPFTierHardFails(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	registerTestSession(t, d, "ses-net-enforce", 113)
+
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-enforce", kernelcapture.BpfActionAllow, kernelcapture.BpfEnforceModeEnforce))
+	if resp.OK {
+		t.Fatalf("apply_policy under ENFORCE with no active tier: OK = true, want false: %+v", resp)
+	}
+
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, "ses-net-enforce", net.ParseIP("1.2.3.4"))
+	if !decision.HasPolicy || !decision.Allowed {
+		t.Errorf("seccomp store not populated despite the overall apply_policy failure: %+v", decision)
+	}
+}
+
+// TestHandleApplyPolicy_AppliesViaSeccompTierWhenActive is the E4 success
+// path: on a host where the seccomp tier (not BPF-LSM) is active, an
+// apply_policy request whose ops are entirely within the seccomp tier's
+// scope (OP_NET_CONNECT) must be reported as genuinely applied, not
+// degraded — BPF-LSM being unavailable isn't a degradation when it was never
+// the active tier to begin with.
+func TestHandleApplyPolicy_AppliesViaSeccompTierWhenActive(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	d.activeTier = daemonTierSeccomp
+	registerTestSession(t, d, "ses-net-seccomp", 114)
+
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-seccomp", kernelcapture.BpfActionDeny, kernelcapture.BpfEnforceModeEnforce))
+	if !resp.OK {
+		t.Fatalf("apply_policy under ENFORCE with active seccomp tier: OK = false, want true: %+v", resp)
+	}
+	if resp.Status != "applied_seccomp_tier" {
+		t.Errorf("Status = %q, want %q", resp.Status, "applied_seccomp_tier")
+	}
+
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, "ses-net-seccomp", net.ParseIP("1.2.3.4"))
+	if !decision.HasPolicy || decision.Allowed {
+		t.Errorf("seccomp store should reflect the DENY policy: %+v", decision)
+	}
+}
+
+// TestHandleApplyPolicy_SeccompTierDoesNotCoverNonNetOps confirms the
+// applied_seccomp_tier success branch only fires when the request is fully
+// within the seccomp tier's scope — a request that also asks for OP_EXEC
+// enforcement can't be satisfied by this tier and must still fail loudly
+// under ENFORCE mode, exactly like the no-tier-active case.
+func TestHandleApplyPolicy_SeccompTierDoesNotCoverNonNetOps(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	d.activeTier = daemonTierSeccomp
+	registerTestSession(t, d, "ses-mixed-ops", 115)
+
+	ap := &kernelcapture.DaemonApplyPolicyRequest{
+		SessionID:   "ses-mixed-ops",
+		Generation:  1,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		OpPolicies: []kernelcapture.DaemonOpPolicy{
+			{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllow, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			{Op: kernelcapture.BpfOpExec, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+		},
+	}
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy:     ap,
+	}
+	resp := d.handleApplyPolicy(req)
+	if resp.OK {
+		t.Fatalf("apply_policy mixing OP_EXEC into a seccomp-tier-only host: OK = true, want false: %+v", resp)
+	}
+}
+
+func TestHandleApplyPolicy_InvalidNetAllowFailsBeforeAnyStoreWrite(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	registerTestSession(t, d, "ses-bad-cidr", 116)
+
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-bad-cidr", kernelcapture.BpfActionAllowlist, kernelcapture.BpfEnforceModePermissive, "not-a-cidr"))
+	if resp.OK {
+		t.Fatalf("apply_policy with a malformed net_allow entry: OK = true, want false: %+v", resp)
+	}
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, "ses-bad-cidr", net.ParseIP("1.2.3.4"))
+	if decision.HasPolicy {
+		t.Errorf("a rejected apply_policy must not leave a partial seccomp policy in place: %+v", decision)
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_enforce.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_enforce.go
@@ -99,7 +99,7 @@ func consumeEnforceEvents(ctx context.Context, reader enforceEventReader, d *dae
 			continue
 		}
 
-		d.processEnforceEvent(ev, log)
+		d.processEnforceEvent(ev, enforceEventTier(ev), log)
 	}
 }
 
@@ -230,9 +230,18 @@ func enforceEventTier(ev kernelcapture.BpfEnforceEvent) string {
 // enforcement summary, and appends the receipt to evidence. Events that
 // cannot be attributed to a registered session are routed to the orphan
 // scope instead of being dropped.
-func (d *daemon) processEnforceEvent(ev kernelcapture.BpfEnforceEvent, log *slog.Logger) {
+//
+// tier identifies the enforcement backend + mode that produced ev (e.g.
+// "bpf_lsm:enforce", "seccomp:enforce") for the summary's TierCoverage
+// breakdown. Callers supply it explicitly rather than this function deriving
+// it from ev alone: ev's shape (BpfOp/BpfAction/BpfEnforceMode) is shared
+// across every enforcement tier by design, so which tier actually produced a
+// given event is knowledge only the caller has — consumeEnforceEvents (the
+// BPF-LSM ringbuf consumer) always saw bpf_lsm:*, but a future or concurrent
+// tier's events must not be mislabeled as bpf_lsm just because they use the
+// same event shape.
+func (d *daemon) processEnforceEvent(ev kernelcapture.BpfEnforceEvent, tier string, log *slog.Logger) {
 	verdict := enforceEventVerdict(ev)
-	tier := enforceEventTier(ev)
 
 	sid, correlator := d.routeEnforceEvent(ev.CgroupID)
 	if sid == "" || correlator == nil {

--- a/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
@@ -133,7 +133,7 @@ func TestProcessEnforceEvent_DeniedEventRoutesThroughCorrelator(t *testing.T) {
 		Comm:        "agent",
 		Path:        "/etc/shadow",
 	}
-	d.processEnforceEvent(ev, d.log)
+	d.processEnforceEvent(ev, enforceEventTier(ev), d.log)
 
 	path := filepath.Join(d.evidenceDir, sanitizeSessionID("enforce-session-1"), "enforce_events.jsonl")
 	entries := readEnforceReceiptLines(t, stub, path)
@@ -176,6 +176,50 @@ func TestProcessEnforceEvent_DeniedEventRoutesThroughCorrelator(t *testing.T) {
 	}
 }
 
+// TestProcessEnforceEvent_TierParamOverridesDerivedTier guards the E4 tier
+// refactor: processEnforceEvent must record whatever tier the caller passes,
+// not what enforceEventTier(ev) would derive from the event's own
+// EnforceMode. Without this, seccomp-tier events (which reuse the exact same
+// BpfEnforceEvent shape as the BPF-LSM tier) would get mislabeled
+// "bpf_lsm:*" in TierCoverage.
+func TestProcessEnforceEvent_TierParamOverridesDerivedTier(t *testing.T) {
+	d := newTestDaemon(t)
+	d.fs = newStubFS()
+
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "enforce-session-tier",
+		RootPID:      100,
+		CgroupID:     42,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   300,
+	}, "enforce-session-tier")
+
+	ev := kernelcapture.BpfEnforceEvent{
+		CgroupID:    42,
+		PID:         100,
+		Op:          kernelcapture.BpfOpNetConnect,
+		ActionTaken: kernelcapture.BpfActionDeny,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		ObservedNS:  123456789,
+	}
+	if derived := enforceEventTier(ev); derived != "bpf_lsm:enforce" {
+		t.Fatalf("test setup: enforceEventTier(ev) = %q, want %q so this test actually exercises an override", derived, "bpf_lsm:enforce")
+	}
+
+	d.processEnforceEvent(ev, "seccomp:enforce", d.log)
+
+	summary, ok := d.enforceSummaryForScope("enforce-session-tier")
+	if !ok {
+		t.Fatal("expected an enforcement summary for the registered session")
+	}
+	if summary.TierCoverage["seccomp:enforce"] != 1 {
+		t.Errorf("tier coverage = %+v, want seccomp:enforce=1 (the caller-supplied tier)", summary.TierCoverage)
+	}
+	if _, mislabeled := summary.TierCoverage["bpf_lsm:enforce"]; mislabeled {
+		t.Errorf("tier coverage = %+v, event was mislabeled under the derived bpf_lsm:enforce tier", summary.TierCoverage)
+	}
+}
+
 func TestProcessEnforceEvent_OrphanEventNotDropped(t *testing.T) {
 	d := newTestDaemon(t)
 	stub := newStubFS()
@@ -190,7 +234,7 @@ func TestProcessEnforceEvent_OrphanEventNotDropped(t *testing.T) {
 		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
 		Comm:        "orphan-proc",
 	}
-	d.processEnforceEvent(ev, d.log)
+	d.processEnforceEvent(ev, enforceEventTier(ev), d.log)
 
 	orphanPath := filepath.Join(d.evidenceDir, sanitizeSessionID(enforceOrphanScope), "enforce_events.jsonl")
 	entries := readEnforceReceiptLines(t, stub, orphanPath)
@@ -346,12 +390,13 @@ func TestHandleAuthorizedRequest_SessionStatusIncludesEnforcementSummary(t *test
 		t.Fatalf("register_session failed: %+v", registerResp)
 	}
 
-	d.processEnforceEvent(kernelcapture.BpfEnforceEvent{
+	statusEvent := kernelcapture.BpfEnforceEvent{
 		CgroupID:    55,
 		PID:         100,
 		ActionTaken: kernelcapture.BpfActionDeny,
 		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
-	}, d.log)
+	}
+	d.processEnforceEvent(statusEvent, enforceEventTier(statusEvent), d.log)
 
 	statusResp := d.handleAuthorizedRequest(context.Background(), kernelcapture.DaemonProtocolRequest{
 		ProtocolVersion: kernelcapture.DaemonProtocolVersion,

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
@@ -32,13 +32,22 @@ import (
 // Returns nil on graceful context cancellation; returns a non-nil error if
 // the guard fails to load (in which case the daemon degrades gracefully —
 // enforcement is unavailable but the exec tracepoint consumer still runs).
-func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
+//
+// ready receives exactly one value — nil once the guard has loaded and
+// d.policyMaps is live, or the load error otherwise — before this function
+// does anything that can block for the rest of the daemon's lifetime. main()
+// blocks on it (with a timeout) to make the BPF-LSM-vs-seccomp tier decision
+// (plan E4) without guessing from preflight alone, since preflight can pass
+// while the actual load still fails for reasons preflight doesn't check.
+func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready chan<- error) error {
 	// Preflight: check BTF and BPF-LSM availability.
 	preflightReport := kernelcapture.InspectBPFLSMPreflight()
 	for _, f := range preflightReport.Findings {
 		switch f.Verdict {
 		case kernelcapture.DaemonPreflightVerdictFail:
-			return fmt.Errorf("BPF-LSM preflight failed (%s): %s; %s", f.CheckName, f.Details, f.Remediation)
+			err := fmt.Errorf("BPF-LSM preflight failed (%s): %s; %s", f.CheckName, f.Details, f.Remediation)
+			ready <- err
+			return err
 		case kernelcapture.DaemonPreflightVerdictWarn:
 			log.Warn("BPF-LSM preflight warning",
 				"check", f.CheckName, "detail", f.Details, "remediation", f.Remediation)
@@ -47,7 +56,9 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 
 	handles, err := kernelcapture.LoadAndAttachProcessGuardEBPF()
 	if err != nil {
-		return fmt.Errorf("load process_guard BPF-LSM: %w", err)
+		err = fmt.Errorf("load process_guard BPF-LSM: %w", err)
+		ready <- err
+		return err
 	}
 	defer func() {
 		// Clear policy maps reference so subsequent apply_policy calls fail safely.
@@ -61,6 +72,7 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 	log.Info("BPF-LSM process_guard loaded",
 		"hooks", "bprm_check_security, lsm.s/file_open, socket_connect",
 	)
+	ready <- nil
 
 	// ringbuf.Reader.Read() blocks with no context awareness of its own; close
 	// it on ctx cancellation to unblock a pending read, the same pattern

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
@@ -1,0 +1,355 @@
+//go:build linux
+
+package main
+
+// daemon_seccomp_linux.go — seccomp user-notify enforcement tier (Epic A
+// #63, plan E4): the daemon side of the fd handoff from ardur-exec-shim, and
+// the per-session supervisor that services connect(2) notifications.
+//
+// Claim boundary: this is the fallback tier for hosts where BPF-LSM never
+// loads (stock distros that ship CONFIG_BPF_LSM=y but don't put "bpf" in the
+// boot lsm= list — the common case this plan targets). See
+// go/pkg/kernelcapture/seccomp_policy.go's header comment for the tier's
+// scope (OP_NET_CONNECT only) and its documented weaker-than-BPF-LSM
+// security claim against a racing multithreaded adversary.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+	"golang.org/x/sys/unix"
+)
+
+// seccompHandoffRequest is the JSON header ardur-exec-shim sends alongside
+// the listener fd (as SCM_RIGHTS ancillary data) over the seccomp handoff
+// socket. This is a distinct, minimal socket from the main JSON-line control
+// plane (daemon_socket_server.go's DaemonUnixSocketServer) specifically
+// because that server's request reader uses a plain byte-stream Read(),
+// which silently discards ancillary data — retrofitting fd-passing onto it
+// would risk the well-tested existing protocol path for a use case that
+// touches it only once per governed session. Passing a real fd needs
+// ReadMsgUnix with an out-of-band buffer, so this gets its own small,
+// dedicated accept loop instead.
+type seccompHandoffRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+type seccompHandoffResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+const (
+	seccompHandoffMaxHeaderBytes = 4096
+	seccompHandoffReadTimeout    = 10 * time.Second
+)
+
+// runSeccompHandoffServer accepts ardur-exec-shim connections on socketPath,
+// authorizes the peer with the same UID/GID policy as the main control
+// socket, extracts the handed-off listener fd, and starts a supervisor
+// goroutine for it. Returns when ctx is cancelled.
+func runSeccompHandoffServer(ctx context.Context, socketPath string, d *daemon, log *slog.Logger) error {
+	_ = os.Remove(socketPath)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		return fmt.Errorf("create seccomp handoff socket directory: %w", err)
+	}
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return fmt.Errorf("bind seccomp handoff socket: %w", err)
+	}
+	if err := os.Chmod(socketPath, 0o660); err != nil {
+		listener.Close()
+		return fmt.Errorf("set seccomp handoff socket mode: %w", err)
+	}
+	defer func() {
+		listener.Close()
+		_ = os.Remove(socketPath)
+	}()
+
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = listener.Close()
+		case <-stop:
+		}
+	}()
+	defer close(stop)
+
+	log.Info("seccomp handoff socket listening", "socket", socketPath)
+
+	for {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("accept seccomp handoff connection: %w", err)
+		}
+		go d.handleSeccompHandoffConnection(ctx, conn, socketPath, log)
+	}
+}
+
+func (d *daemon) handleSeccompHandoffConnection(ctx context.Context, conn *net.UnixConn, socketPath string, log *slog.Logger) {
+	defer conn.Close()
+
+	sessionID, fd, err := receiveSeccompListenerHandoff(conn, socketPath, d.peerPolicy)
+	if err != nil {
+		log.Warn("seccomp handoff rejected", "error", err)
+		_ = sendSeccompHandoffResponse(conn, false, err.Error())
+		return
+	}
+
+	record, err := d.registry.ActiveSession(sessionID)
+	if err != nil {
+		log.Warn("seccomp handoff for unknown/inactive session", "session_id", sessionID, "error", err)
+		_ = sendSeccompHandoffResponse(conn, false, "session not found or not active")
+		unix.Close(fd)
+		return
+	}
+
+	superviseCtx, cancel := context.WithCancel(ctx)
+	if !d.registerSeccompListener(sessionID, cancel) {
+		// A listener for this session is already being supervised — most
+		// likely a retried handoff. Refuse the duplicate rather than run two
+		// supervisors racing to answer the same notifications.
+		log.Warn("seccomp handoff duplicate listener for session, closing new one", "session_id", sessionID)
+		cancel()
+		_ = sendSeccompHandoffResponse(conn, false, "a seccomp listener is already attached for this session")
+		unix.Close(fd)
+		return
+	}
+
+	if err := sendSeccompHandoffResponse(conn, true, ""); err != nil {
+		log.Warn("ack seccomp handoff", "session_id", sessionID, "error", err)
+		d.unregisterSeccompListener(sessionID)
+		cancel()
+		unix.Close(fd)
+		return
+	}
+
+	log.Info("seccomp connect-notify listener attached",
+		"session_id", sessionID, "cgroup_id", record.CgroupID, "root_pid", record.RootPID)
+	go func() {
+		defer d.unregisterSeccompListener(sessionID)
+		defer unix.Close(fd)
+		superviseSeccompListener(superviseCtx, fd, sessionID, record.CgroupID, d, log)
+	}()
+}
+
+// receiveSeccompListenerHandoff reads the JSON header + ancillary listener fd
+// from one shim connection, authorizing the peer first via the same
+// SO_PEERCRED + UID/GID policy the main control socket uses. On any error the
+// received fd (if one was successfully parsed before the error) is closed —
+// callers must not assume the fd is still open after a non-nil error.
+func receiveSeccompListenerHandoff(conn *net.UnixConn, socketPath string, policy kernelcapture.DaemonPeerAuthorizationPolicy) (string, int, error) {
+	observation, err := kernelcapture.ObserveLinuxUnixPeerCredentials(conn, socketPath)
+	if err != nil {
+		return "", -1, fmt.Errorf("observe peer credentials: %w", err)
+	}
+	if _, err := kernelcapture.AuthorizeObservedDaemonPeer(observation.Credentials, policy); err != nil {
+		return "", -1, fmt.Errorf("unauthorized peer: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(seccompHandoffReadTimeout)); err != nil {
+		return "", -1, fmt.Errorf("set read deadline: %w", err)
+	}
+
+	msgBuf := make([]byte, seccompHandoffMaxHeaderBytes)
+	oobBuf := make([]byte, unix.CmsgSpace(4)) // exactly one fd (4-byte int)
+	n, oobn, _, _, err := conn.ReadMsgUnix(msgBuf, oobBuf)
+	if err != nil {
+		return "", -1, fmt.Errorf("read handoff message: %w", err)
+	}
+	if oobn == 0 {
+		return "", -1, errors.New("handoff message carried no ancillary data (no fd)")
+	}
+
+	scms, err := unix.ParseSocketControlMessage(oobBuf[:oobn])
+	if err != nil {
+		return "", -1, fmt.Errorf("parse control message: %w", err)
+	}
+	if len(scms) != 1 {
+		return "", -1, fmt.Errorf("expected exactly one control message, got %d", len(scms))
+	}
+	fds, err := unix.ParseUnixRights(&scms[0])
+	if err != nil {
+		return "", -1, fmt.Errorf("parse unix rights: %w", err)
+	}
+	if len(fds) != 1 {
+		for _, extra := range fds {
+			unix.Close(extra)
+		}
+		return "", -1, fmt.Errorf("expected exactly one fd, got %d", len(fds))
+	}
+	fd := fds[0]
+
+	var header seccompHandoffRequest
+	if err := json.Unmarshal(msgBuf[:n], &header); err != nil {
+		unix.Close(fd)
+		return "", -1, fmt.Errorf("decode handoff header: %w", err)
+	}
+	if header.SessionID == "" {
+		unix.Close(fd)
+		return "", -1, errors.New("handoff header missing session_id")
+	}
+	return header.SessionID, fd, nil
+}
+
+func sendSeccompHandoffResponse(conn *net.UnixConn, ok bool, errMsg string) error {
+	data, err := json.Marshal(seccompHandoffResponse{OK: ok, Error: errMsg})
+	if err != nil {
+		return err
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(seccompHandoffReadTimeout)); err != nil {
+		return err
+	}
+	_, err = conn.Write(data)
+	return err
+}
+
+// superviseSeccompListener services connect(2) notifications on fd until ctx
+// is cancelled or the listener errors out — most commonly because the
+// governed process tree exited, closing the last reference to the seccomp
+// filter the notifications were flowing from.
+func superviseSeccompListener(ctx context.Context, fd int, sessionID string, cgroupID uint64, d *daemon, log *slog.Logger) {
+	// Unblock a pending RecvSeccompNotif on shutdown — SECCOMP_IOCTL_NOTIF_RECV
+	// has no context awareness of its own, the same limitation
+	// ringbuf.Reader.Read() has (see daemon_guard_linux.go's runGuardConsumer,
+	// which uses the identical ctx.Done()-closes-the-fd pattern).
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			unix.Close(fd)
+		case <-stop:
+		}
+	}()
+	defer close(stop)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		notif, err := kernelcapture.RecvSeccompNotif(fd)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Info("seccomp listener closed, stopping supervisor", "session_id", sessionID, "error", err)
+			return
+		}
+		d.handleSeccompConnectNotif(fd, notif, sessionID, cgroupID, log)
+	}
+}
+
+// handleSeccompConnectNotif decides one connect(2) notification and responds.
+//
+// Fail-closed contract: any error resolving the target address (memory read
+// failure, TOCTOU re-validation failure via ReadTargetSockaddr, unparseable
+// sockaddr) denies the connect. SECCOMP_USER_NOTIF_FLAG_CONTINUE is set only
+// on a confirmed, policy-resolved ALLOW — never as a default for an
+// ambiguous or error case.
+func (d *daemon) handleSeccompConnectNotif(listenerFD int, notif kernelcapture.SeccompNotif, sessionID string, cgroupID uint64, log *slog.Logger) {
+	// connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+	addrPtr := notif.Args[1]
+	addrLen := uint32(notif.Args[2])
+
+	raw, err := kernelcapture.ReadTargetSockaddr(listenerFD, notif.ID, notif.PID, addrPtr, addrLen)
+	if err != nil {
+		d.respondSeccompFailClosed(listenerFD, notif, sessionID, cgroupID, log, "read target sockaddr: "+err.Error())
+		return
+	}
+	ip, port, err := kernelcapture.ParseConnectSockaddr(raw)
+	if err != nil {
+		d.respondSeccompFailClosed(listenerFD, notif, sessionID, cgroupID, log, "parse sockaddr: "+err.Error())
+		return
+	}
+
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, sessionID, ip)
+	if !decision.HasPolicy {
+		// No OP_NET_CONNECT rule for this session: pass through untouched
+		// and unlogged, exactly like an ungoverned cgroup on the BPF tier
+		// (process_guard.bpf.c's decide(): "cgroup not governed — untouched").
+		if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, 0, 0, true); err != nil {
+			log.Warn("seccomp notif send (no-policy allow)", "session_id", sessionID, "error", err)
+		}
+		return
+	}
+
+	if decision.Allowed {
+		if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, 0, 0, true); err != nil {
+			log.Warn("seccomp notif send (allow)", "session_id", sessionID, "error", err)
+		}
+	} else if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, -1, int32(unix.EPERM), false); err != nil {
+		log.Warn("seccomp notif send (deny)", "session_id", sessionID, "error", err)
+	}
+
+	// ActionTaken is normalized to ALLOW/DENY, matching process_guard.bpf.c's
+	// decide(): an ACT_ALLOWLIST policy's emitted event never carries
+	// ARDUR_ACT_ALLOWLIST itself, only whichever of ALLOW/DENY the allowlist
+	// check resolved to, so the two tiers' events look identical downstream
+	// (enforceEventVerdict, TierCoverage) regardless of which policy action
+	// type produced them.
+	actionTaken := kernelcapture.BpfActionDeny
+	if decision.Matched {
+		actionTaken = kernelcapture.BpfActionAllow
+	}
+	d.emitSeccompConnectEvent(cgroupID, notif.PID, actionTaken, decision.EnforceMode, ip, port, log)
+}
+
+// respondSeccompFailClosed answers a notification with EPERM and logs why,
+// used for every ambiguous/error case in handleSeccompConnectNotif — the
+// "prefer deny on ambiguity" contract from the plan.
+func (d *daemon) respondSeccompFailClosed(listenerFD int, notif kernelcapture.SeccompNotif, sessionID string, cgroupID uint64, log *slog.Logger, reason string) {
+	log.Warn("seccomp connect denied: could not resolve target safely", "session_id", sessionID, "pid", notif.PID, "reason", reason)
+	if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, -1, int32(unix.EPERM), false); err != nil {
+		log.Warn("seccomp notif send (fail-closed deny)", "session_id", sessionID, "error", err)
+	}
+	d.emitSeccompConnectEvent(cgroupID, notif.PID, kernelcapture.BpfActionDeny, kernelcapture.BpfEnforceModeEnforce, nil, 0, log)
+}
+
+// emitSeccompConnectEvent routes a seccomp-tier connect(2) decision through
+// the same processEnforceEvent pipeline the BPF-LSM tier's ringbuf consumer
+// uses (sequencing, hash-chaining, correlation, evidence-log append).
+//
+// Path carries "ip:port" for this tier's OP_NET_CONNECT events, unlike the
+// BPF tier's (which are always empty — process_guard.bpf.c never passes a
+// path_src for net-connect ops). BpfEnforceEvent has no dedicated network-
+// address field; repurposing Path is a deliberate, tier-specific evidence
+// enrichment, not a schema change (the JSON shape and EnforceReceiptSchema
+// version are unchanged), and is strictly more informative than the gap it
+// works around.
+func (d *daemon) emitSeccompConnectEvent(cgroupID uint64, pid uint32, action kernelcapture.BpfAction, mode kernelcapture.BpfEnforceMode, ip net.IP, port uint16, log *slog.Logger) {
+	path := ""
+	if ip != nil {
+		path = fmt.Sprintf("%s:%d", ip, port)
+	}
+	ev := kernelcapture.BpfEnforceEvent{
+		CgroupID:    cgroupID,
+		PID:         pid,
+		Op:          kernelcapture.BpfOpNetConnect,
+		ActionTaken: action,
+		EnforceMode: mode,
+		ObservedNS:  uint64(time.Now().UnixNano()),
+		Path:        path,
+	}
+	d.processEnforceEvent(ev, seccompEventTier(mode), log)
+}
+
+// seccompEventTier mirrors enforceEventTier's bpf_lsm:* naming for the
+// seccomp tier, keyed by enforce mode the same way.
+func seccompEventTier(mode kernelcapture.BpfEnforceMode) string {
+	if mode == kernelcapture.BpfEnforceModeEnforce {
+		return "seccomp:enforce"
+	}
+	return "seccomp:permissive"
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_unsupported.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package main
+
+// daemon_seccomp_unsupported.go — non-Linux stub for the seccomp user-notify
+// enforcement tier (Epic A #63, plan E4). seccomp is a Linux-only kernel
+// facility; on any other platform the handoff server simply refuses to
+// start, the same graceful-degrade shape runGuardConsumer/runEBPFConsumer
+// already use for the BPF-LSM and exec/exit tracepoint tiers.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+func runSeccompHandoffServer(_ context.Context, _ string, _ *daemon, _ *slog.Logger) error {
+	return fmt.Errorf("seccomp user-notify enforcement is Linux-only; unavailable on this platform")
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/fs"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -65,6 +66,9 @@ func newTestDaemon(t *testing.T) *daemon {
 		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
 		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
 		fs:                   osEvidenceFS{},
+		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
+		seccompListeners:     make(map[string]context.CancelFunc),
+		activeTier:           daemonTierNone,
 	}
 }
 
@@ -140,6 +144,149 @@ func TestOnSessionRegisteredAndEnded(t *testing.T) {
 	}
 	if inCorr {
 		t.Error("correlator entry not removed after end_session")
+	}
+}
+
+// TestOnSessionEnded_ClearsSeccompState guards the E4 cleanup wiring:
+// onSessionEnded must clear the session's seccomp policy and cancel (and
+// forget) its seccomp listener supervisor, mirroring the existing
+// RemovePolicyMaps/cgroupIndex cleanup this test's sibling
+// (TestOnSessionRegisteredAndEnded) already covers for the BPF tier.
+func TestOnSessionEnded_ClearsSeccompState(t *testing.T) {
+	d := newTestDaemon(t)
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID:    "sec-session-001",
+		RootPID:      222,
+		CgroupID:     555,
+		EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+		TTLSeconds:   60,
+	}, "sec-session-001")
+
+	if err := kernelcapture.ApplySeccompPolicy(d.seccompPolicy, "sec-session-001",
+		kernelcapture.DaemonApplyPolicyRequest{
+			SessionID: "sec-session-001",
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllow, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+		}); err != nil {
+		t.Fatalf("ApplySeccompPolicy: %v", err)
+	}
+
+	cancelled := false
+	if !d.registerSeccompListener("sec-session-001", func() { cancelled = true }) {
+		t.Fatal("registerSeccompListener: expected first registration to succeed")
+	}
+
+	d.onSessionEnded("sec-session-001")
+
+	if !cancelled {
+		t.Error("onSessionEnded did not cancel the session's seccomp listener")
+	}
+	d.mu.RLock()
+	_, stillRegistered := d.seccompListeners["sec-session-001"]
+	d.mu.RUnlock()
+	if stillRegistered {
+		t.Error("onSessionEnded left the seccomp listener registered")
+	}
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, "sec-session-001", net.ParseIP("1.2.3.4"))
+	if decision.HasPolicy {
+		t.Errorf("onSessionEnded did not clear the session's seccomp policy: %+v", decision)
+	}
+}
+
+// TestPruneExpiredSessions_ClearsSeccompState is TestPruneExpiredSessions'
+// seccomp-tier counterpart.
+func TestPruneExpiredSessions_ClearsSeccompState(t *testing.T) {
+	d := newTestDaemon(t)
+
+	d.mu.Lock()
+	scope := kernelcapture.NewProcessTreeScope(1, 89)
+	scope.SessionID = "phantom-seccomp-session"
+	d.treeScopes["phantom-seccomp-session"] = &scope
+	d.cgroupIndex[89] = "phantom-seccomp-session"
+	d.correlators["phantom-seccomp-session"] = kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{})
+	d.mu.Unlock()
+
+	if err := kernelcapture.ApplySeccompPolicy(d.seccompPolicy, "phantom-seccomp-session",
+		kernelcapture.DaemonApplyPolicyRequest{
+			SessionID: "phantom-seccomp-session",
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+		}); err != nil {
+		t.Fatalf("ApplySeccompPolicy: %v", err)
+	}
+	cancelled := false
+	if !d.registerSeccompListener("phantom-seccomp-session", func() { cancelled = true }) {
+		t.Fatal("registerSeccompListener: expected first registration to succeed")
+	}
+
+	d.pruneExpiredSessions()
+
+	if !cancelled {
+		t.Error("pruneExpiredSessions did not cancel the phantom session's seccomp listener")
+	}
+	d.mu.RLock()
+	_, stillRegistered := d.seccompListeners["phantom-seccomp-session"]
+	d.mu.RUnlock()
+	if stillRegistered {
+		t.Error("pruneExpiredSessions left the phantom session's seccomp listener registered")
+	}
+	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, "phantom-seccomp-session", net.ParseIP("1.2.3.4"))
+	if decision.HasPolicy {
+		t.Errorf("pruneExpiredSessions did not clear the phantom session's seccomp policy: %+v", decision)
+	}
+}
+
+// TestRegisterSeccompListener_RejectsDuplicate guards against two
+// supervisor goroutines racing to answer the same session's notifications —
+// see daemon_seccomp_linux.go's handleSeccompHandoffConnection, which relies
+// on this to refuse a retried/duplicate handoff.
+func TestRegisterSeccompListener_RejectsDuplicate(t *testing.T) {
+	d := newTestDaemon(t)
+	if !d.registerSeccompListener("dup-session", func() {}) {
+		t.Fatal("first registerSeccompListener call: expected success")
+	}
+	if d.registerSeccompListener("dup-session", func() {}) {
+		t.Error("second registerSeccompListener call for the same session: expected rejection")
+	}
+}
+
+// TestHandleAuthorizedRequest_HealthAdvertisesActiveTier guards "advertise
+// which tier is live in the daemon status" from the E4 plan.
+func TestHandleAuthorizedRequest_HealthAdvertisesActiveTier(t *testing.T) {
+	for _, tier := range []string{daemonTierNone, daemonTierBPFLSM, daemonTierSeccomp} {
+		t.Run(tier, func(t *testing.T) {
+			d := newTestDaemon(t)
+			d.activeTier = tier
+			req := kernelcapture.DaemonProtocolRequest{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          kernelcapture.DaemonProtocolMethodHealth,
+				Health:          &kernelcapture.DaemonHealthRequest{},
+			}
+			handshake := kernelcapture.DaemonProtocolPeerHandshake{
+				ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+				Method:                kernelcapture.DaemonProtocolMethodHealth,
+				SocketPath:            "/run/ardur/kernelcapture/control.sock",
+				CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+				ProcessStartTimeTicks: 1,
+				Authorization: kernelcapture.DaemonPeerAuthorization{
+					Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+					Reason:                "test",
+					UID:                   501,
+					PID:                   4242,
+					ProcessStartTimeTicks: 1,
+					Matched:               "uid",
+				},
+			}
+			resp := d.handleAuthorizedRequest(context.Background(), req, handshake)
+			if !resp.OK {
+				t.Fatalf("health request failed: %+v", resp)
+			}
+			if resp.EnforcementTier != tier {
+				t.Errorf("EnforcementTier = %q, want %q", resp.EnforcementTier, tier)
+			}
+		})
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_unsupported.go
@@ -24,7 +24,9 @@ func sdNotify(_ string) error { return nil }
 func runWatchdog(_ context.Context, _ time.Duration, _ *slog.Logger) {}
 
 // runGuardConsumer is a no-op stub on non-Linux platforms.
-func runGuardConsumer(_ context.Context, _ *daemon, log *slog.Logger) error {
+func runGuardConsumer(_ context.Context, _ *daemon, log *slog.Logger, ready chan<- error) error {
 	log.Warn("BPF-LSM guard is Linux-only; enforcement unavailable on this platform")
-	return fmt.Errorf("BPF-LSM guard unavailable on this platform")
+	err := fmt.Errorf("BPF-LSM guard unavailable on this platform")
+	ready <- err
+	return err
 }

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -694,6 +694,7 @@ func main() {
 		evidenceDir       = flag.String("evidence-dir", defaultEvidenceDir, "Directory for per-session kernel receipt JSONL logs")
 		stateDir          = flag.String("state-dir", defaultStateDir, "Daemon state directory")
 		noRingbuf         = flag.Bool("no-ringbuf", false, "Skip eBPF ringbuf consumer (socket control plane only)")
+		disableBPFLSM     = flag.Bool("disable-bpf-lsm", false, "Skip the BPF-LSM guard tier and force the seccomp user-notify fallback, even on hosts where BPF-LSM is available. Exec/exit observation still runs; only the BPF-LSM enforcement tier is suppressed. Used to exercise the seccomp path where BPF-LSM would otherwise win tier selection.")
 		debug             = flag.Bool("debug", false, "Enable debug-level logging")
 		pruneEvery        = flag.Duration("prune-interval", 30*time.Second, "Interval to prune expired session routing entries")
 		guardReadyTimeout = flag.Duration("guard-ready-timeout", 10*time.Second, "How long to wait for the BPF-LSM guard to report load success/failure before falling back to the seccomp tier")
@@ -798,27 +799,32 @@ func main() {
 
 		// BPF-LSM enforcement consumer: loads process_guard, populates policyMaps.
 		// Degrades gracefully on kernels without BPF-LSM (warn, not fatal).
-		guardOutcome := make(chan error, 1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := runGuardConsumer(ctx, d, log, guardOutcome); err != nil && ctx.Err() == nil {
-				log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
-					"error", err)
-			}
-		}()
+		// Skipped entirely when --disable-bpf-lsm forces the seccomp tier.
+		if !*disableBPFLSM {
+			guardOutcome := make(chan error, 1)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := runGuardConsumer(ctx, d, log, guardOutcome); err != nil && ctx.Err() == nil {
+					log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
+						"error", err)
+				}
+			}()
 
-		select {
-		case err := <-guardOutcome:
-			if err == nil {
-				d.activeTier = daemonTierBPFLSM
-			} else {
-				log.Warn("BPF-LSM tier not active, falling back to seccomp tier", "error", err)
+			select {
+			case err := <-guardOutcome:
+				if err == nil {
+					d.activeTier = daemonTierBPFLSM
+				} else {
+					log.Warn("BPF-LSM tier not active, falling back to seccomp tier", "error", err)
+				}
+			case <-time.After(*guardReadyTimeout):
+				log.Warn("BPF-LSM guard did not report readiness in time, falling back to seccomp tier",
+					"timeout", guardReadyTimeout.String())
+			case <-ctx.Done():
 			}
-		case <-time.After(*guardReadyTimeout):
-			log.Warn("BPF-LSM guard did not report readiness in time, falling back to seccomp tier",
-				"timeout", guardReadyTimeout.String())
-		case <-ctx.Done():
+		} else {
+			log.Warn("BPF-LSM guard tier disabled via --disable-bpf-lsm; forcing seccomp user-notify tier")
 		}
 
 		if d.activeTier != daemonTierBPFLSM && ctx.Err() == nil {

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -48,11 +48,12 @@ import (
 )
 
 const (
-	defaultSocketPath   = "/run/ardur/kernelcapture/control.sock"
-	defaultEvidenceDir  = "/var/lib/ardur/kernelcapture/evidence"
-	defaultStateDir     = "/var/lib/ardur/kernelcapture/state"
-	defaultSocketMode   = fs.FileMode(0o660)
-	KernelReceiptSchema = "ardur.kernel.receipt.v1"
+	defaultSocketPath        = "/run/ardur/kernelcapture/control.sock"
+	defaultSeccompSocketPath = "/run/ardur/kernelcapture/seccomp.sock"
+	defaultEvidenceDir       = "/var/lib/ardur/kernelcapture/evidence"
+	defaultStateDir          = "/var/lib/ardur/kernelcapture/state"
+	defaultSocketMode        = fs.FileMode(0o660)
+	KernelReceiptSchema      = "ardur.kernel.receipt.v1"
 )
 
 // KernelReceiptEntry is the JSONL record appended to
@@ -96,7 +97,31 @@ type daemon struct {
 	// enforcement program. On non-Linux platforms PolicyMaps is a zero struct and
 	// ApplyPolicyMaps / RemovePolicyMaps return an error immediately.
 	policyMaps kernelcapture.PolicyMaps
+
+	// seccompPolicy holds the seccomp tier's OP_NET_CONNECT policy (plan
+	// E4) — always kept in sync by handleApplyPolicy regardless of which
+	// tier is active, so a session's policy is already in place by the time
+	// (if ever) a seccomp listener attaches for it. Non-nil on every
+	// platform; on non-Linux it simply never gets a listener to serve.
+	seccompPolicy *kernelcapture.SeccompPolicyStore
+	// seccompListeners tracks the cancel func for each session's seccomp
+	// supervisor goroutine (Linux only; always empty elsewhere), keyed by
+	// session_id and guarded by mu like the other session-scoped maps above.
+	seccompListeners map[string]context.CancelFunc
+
+	// activeTier is decided once at startup (see main(): "prefer BPF-LSM
+	// when active, fall back to seccomp when it isn't") and advertised on
+	// health responses so a launcher can decide whether routing a governed
+	// process through ardur-exec-shim (the seccomp tier's on-ramp) is
+	// necessary at all. One of the daemonTier* constants.
+	activeTier string
 }
+
+const (
+	daemonTierNone    = "none"
+	daemonTierBPFLSM  = "bpf_lsm"
+	daemonTierSeccomp = "seccomp"
+)
 
 func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, ownerUID uint32) (*daemon, error) {
 	cfg := kernelcapture.DefaultDaemonCustodyConfig()
@@ -139,7 +164,36 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
 		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
 		fs:                   osEvidenceFS{},
+		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
+		seccompListeners:     make(map[string]context.CancelFunc),
+		activeTier:           daemonTierNone,
 	}, nil
+}
+
+// registerSeccompListener records that sessionID now has a live seccomp
+// supervisor, returning false (without recording anything) if one is already
+// registered — callers must treat false as "reject this handoff," not as a
+// signal to replace the existing listener.
+func (d *daemon) registerSeccompListener(sessionID string, cancel context.CancelFunc) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, exists := d.seccompListeners[sessionID]; exists {
+		return false
+	}
+	d.seccompListeners[sessionID] = cancel
+	return true
+}
+
+// unregisterSeccompListener stops (if still running) and forgets sessionID's
+// seccomp supervisor. Safe to call even if no listener was ever registered.
+func (d *daemon) unregisterSeccompListener(sessionID string) {
+	d.mu.Lock()
+	cancel, ok := d.seccompListeners[sessionID]
+	delete(d.seccompListeners, sessionID)
+	d.mu.Unlock()
+	if ok && cancel != nil {
+		cancel()
+	}
 }
 
 // handleAuthorizedRequest is the DaemonAuthorizedProtocolHandler wired into the
@@ -172,6 +226,11 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 		if summary, ok := d.enforceSummaryForScope(resp.SessionID); ok {
 			resp.Enforcement = &summary
 		}
+	case kernelcapture.DaemonProtocolMethodHealth:
+		// Advertise which enforcement tier is live so a launcher can decide
+		// whether routing a governed process through ardur-exec-shim (the
+		// seccomp tier's on-ramp) is necessary before it ever spawns one.
+		resp.EnforcementTier = d.activeTier
 	}
 	return resp
 }
@@ -197,19 +256,52 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kern
 		return errResp("session has no cgroup_id; cannot apply BPF policy")
 	}
 
+	// Always keep the seccomp tier's in-memory policy in sync, regardless of
+	// which tier (if any) is actually active on this host: a session's
+	// policy must already be in place by the time — if ever — an
+	// ardur-exec-shim hands off a listener for it, and apply_policy commonly
+	// runs before that handoff. This can only fail on malformed net_allow
+	// entries (the same CIDR-or-bare-IP acceptance ApplyPolicyMaps' LPM key
+	// builder uses), so failing here before any BPF map write is strictly
+	// better than discovering the same bad input deeper in ApplyPolicyMaps.
+	if err := kernelcapture.ApplySeccompPolicy(d.seccompPolicy, ap.SessionID, *ap); err != nil {
+		d.log.Error("apply_policy failed (seccomp tier policy)", "session_id", ap.SessionID, "error", err)
+		return errResp(fmt.Sprintf("apply seccomp policy: %v", err))
+	}
+
 	if err := kernelcapture.ApplyPolicyMaps(d.policyMaps, record.CgroupID, *ap); err != nil {
-		if errors.Is(err, kernelcapture.ErrPolicyMapsUnavailable) && ap.EnforceMode != kernelcapture.BpfEnforceModeEnforce {
-			// Permissive mode: the whole point of PERMISSIVE is "log, don't
-			// block". Treat a missing BPF-LSM guard the same way — record the
-			// degradation loudly but don't fail the caller's request.
-			d.log.Warn("apply_policy degraded: BPF-LSM guard unavailable, enforcement not active for this session",
-				"session_id", ap.SessionID, "cgroup_id", record.CgroupID)
-			return kernelcapture.DaemonProtocolResponse{
-				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
-				Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
-				OK:              true,
-				SessionID:       ap.SessionID,
-				Status:          "degraded_no_enforcement",
+		if errors.Is(err, kernelcapture.ErrPolicyMapsUnavailable) {
+			if d.activeTier == daemonTierSeccomp && seccompFullyCoversPolicy(ap) {
+				// BPF-LSM being unavailable isn't a degradation here: the
+				// active tier on this host is seccomp user-notify, and every
+				// op this request asks for (OP_NET_CONNECT only) is within
+				// that tier's scope — ApplySeccompPolicy above already
+				// stored it, so this genuinely is applied, not degraded.
+				d.log.Info("apply_policy applied via seccomp tier (BPF-LSM inactive on this host)",
+					"session_id", ap.SessionID, "cgroup_id", record.CgroupID)
+				return kernelcapture.DaemonProtocolResponse{
+					ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+					Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+					OK:              true,
+					SessionID:       ap.SessionID,
+					Status:          "applied_seccomp_tier",
+				}
+			}
+			if ap.EnforceMode != kernelcapture.BpfEnforceModeEnforce {
+				// Permissive mode: the whole point of PERMISSIVE is "log,
+				// don't block". Treat a missing BPF-LSM guard (with no
+				// seccomp fallback covering this request) the same way —
+				// record the degradation loudly but don't fail the
+				// caller's request.
+				d.log.Warn("apply_policy degraded: BPF-LSM guard unavailable, enforcement not active for this session",
+					"session_id", ap.SessionID, "cgroup_id", record.CgroupID)
+				return kernelcapture.DaemonProtocolResponse{
+					ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+					Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+					OK:              true,
+					SessionID:       ap.SessionID,
+					Status:          "degraded_no_enforcement",
+				}
 			}
 		}
 		// ENFORCE_STRICT (or any other failure): fail loudly. Silently
@@ -233,6 +325,20 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kern
 		OK:              true,
 		SessionID:       ap.SessionID,
 	}
+}
+
+// seccompFullyCoversPolicy reports whether every op an apply_policy request
+// asks for is within the seccomp tier's scope — OP_NET_CONNECT only (see
+// seccomp_policy.go's header comment for why exec/file-open aren't). An
+// empty OpPolicies list is trivially covered: there is nothing to enforce
+// either way.
+func seccompFullyCoversPolicy(ap *kernelcapture.DaemonApplyPolicyRequest) bool {
+	for _, p := range ap.OpPolicies {
+		if p.Op != kernelcapture.BpfOpNetConnect {
+			return false
+		}
+	}
+	return true
 }
 
 // handleSetKillSwitch engages or disengages the global BPF-LSM kill switch.
@@ -298,7 +404,6 @@ func (d *daemon) onSessionEnded(sessionID string) {
 		return
 	}
 	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	if scope, ok := d.treeScopes[sessionID]; ok {
 		if scope.CgroupID != 0 {
@@ -314,6 +419,18 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	delete(d.correlators, sessionID)
 	delete(d.enforceChains, sessionID)
 	delete(d.enforceSummaries, sessionID)
+	// Grab (and forget) the seccomp listener's cancel func here, under the
+	// same lock as the map deletes above; call it below, outside the lock,
+	// since the supervisor goroutine it stops may itself try to touch
+	// d.mu-guarded state on its way out.
+	seccompCancel, hadSeccompListener := d.seccompListeners[sessionID]
+	delete(d.seccompListeners, sessionID)
+	d.mu.Unlock()
+
+	kernelcapture.RemoveSeccompPolicy(d.seccompPolicy, sessionID)
+	if hadSeccompListener && seccompCancel != nil {
+		seccompCancel()
+	}
 
 	d.log.Info("session ended", "session_id", sessionID)
 }
@@ -408,7 +525,8 @@ func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent, loss kernelc
 // cgroup index does not leak indefinitely.
 func (d *daemon) pruneExpiredSessions() {
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	var expiredSeccompCancels []context.CancelFunc
+	var expiredSessionIDs []string
 	for sid, scope := range d.treeScopes {
 		if _, err := d.registry.ActiveSession(sid); err != nil {
 			if scope.CgroupID != 0 {
@@ -418,7 +536,22 @@ func (d *daemon) pruneExpiredSessions() {
 			delete(d.correlators, sid)
 			delete(d.enforceChains, sid)
 			delete(d.enforceSummaries, sid)
+			if cancel, ok := d.seccompListeners[sid]; ok {
+				expiredSeccompCancels = append(expiredSeccompCancels, cancel)
+				delete(d.seccompListeners, sid)
+			}
+			expiredSessionIDs = append(expiredSessionIDs, sid)
 			d.log.Info("pruned expired session", "session_id", sid)
+		}
+	}
+	d.mu.Unlock()
+
+	for _, sid := range expiredSessionIDs {
+		kernelcapture.RemoveSeccompPolicy(d.seccompPolicy, sid)
+	}
+	for _, cancel := range expiredSeccompCancels {
+		if cancel != nil {
+			cancel()
 		}
 	}
 }
@@ -556,12 +689,14 @@ func (osEvidenceFS) AppendFile(path string, data []byte, perm fs.FileMode) (err 
 
 func main() {
 	var (
-		socketPath  = flag.String("socket", defaultSocketPath, "Unix-domain control socket path")
-		evidenceDir = flag.String("evidence-dir", defaultEvidenceDir, "Directory for per-session kernel receipt JSONL logs")
-		stateDir    = flag.String("state-dir", defaultStateDir, "Daemon state directory")
-		noRingbuf   = flag.Bool("no-ringbuf", false, "Skip eBPF ringbuf consumer (socket control plane only)")
-		debug       = flag.Bool("debug", false, "Enable debug-level logging")
-		pruneEvery  = flag.Duration("prune-interval", 30*time.Second, "Interval to prune expired session routing entries")
+		socketPath        = flag.String("socket", defaultSocketPath, "Unix-domain control socket path")
+		seccompSocketPath = flag.String("seccomp-socket", defaultSeccompSocketPath, "Unix-domain socket ardur-exec-shim hands off its seccomp listener fd on (seccomp tier, plan E4)")
+		evidenceDir       = flag.String("evidence-dir", defaultEvidenceDir, "Directory for per-session kernel receipt JSONL logs")
+		stateDir          = flag.String("state-dir", defaultStateDir, "Daemon state directory")
+		noRingbuf         = flag.Bool("no-ringbuf", false, "Skip eBPF ringbuf consumer (socket control plane only)")
+		debug             = flag.Bool("debug", false, "Enable debug-level logging")
+		pruneEvery        = flag.Duration("prune-interval", 30*time.Second, "Interval to prune expired session routing entries")
+		guardReadyTimeout = flag.Duration("guard-ready-timeout", 10*time.Second, "How long to wait for the BPF-LSM guard to report load success/failure before falling back to the seccomp tier")
 	)
 	flag.Parse()
 
@@ -639,7 +774,19 @@ func main() {
 		}
 	}()
 
-	// Data-plane goroutine: eBPF exec/exit tracepoint ringbuf consumer.
+	// Data-plane goroutine: eBPF exec/exit tracepoint ringbuf consumer, plus
+	// tier selection (plan E4): prefer BPF-LSM when it actually loads, fall
+	// back to seccomp user-notify otherwise. guardOutcome receives exactly
+	// one value from runGuardConsumer — nil on a successful load, the load
+	// error otherwise — before that goroutine does anything blocking, so
+	// the decision below is made synchronously instead of inferred from
+	// preflight (which can pass while the real load still fails for
+	// reasons preflight doesn't check).
+	//
+	// Both kernel-enforcement mechanisms ride on the same --no-ringbuf
+	// switch: it means "socket control plane only," so leaving it set
+	// leaves activeTier at daemonTierNone rather than standing up a
+	// seccomp handoff server nothing will ever mean to use.
 	if !*noRingbuf {
 		wg.Add(1)
 		go func() {
@@ -651,16 +798,42 @@ func main() {
 
 		// BPF-LSM enforcement consumer: loads process_guard, populates policyMaps.
 		// Degrades gracefully on kernels without BPF-LSM (warn, not fatal).
+		guardOutcome := make(chan error, 1)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := runGuardConsumer(ctx, d, log); err != nil && ctx.Err() == nil {
+			if err := runGuardConsumer(ctx, d, log, guardOutcome); err != nil && ctx.Err() == nil {
 				log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
 					"error", err)
 			}
 		}()
+
+		select {
+		case err := <-guardOutcome:
+			if err == nil {
+				d.activeTier = daemonTierBPFLSM
+			} else {
+				log.Warn("BPF-LSM tier not active, falling back to seccomp tier", "error", err)
+			}
+		case <-time.After(*guardReadyTimeout):
+			log.Warn("BPF-LSM guard did not report readiness in time, falling back to seccomp tier",
+				"timeout", guardReadyTimeout.String())
+		case <-ctx.Done():
+		}
+
+		if d.activeTier != daemonTierBPFLSM && ctx.Err() == nil {
+			d.activeTier = daemonTierSeccomp
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := runSeccompHandoffServer(ctx, *seccompSocketPath, d, log); err != nil && ctx.Err() == nil {
+					log.Error("seccomp handoff server stopped", "error", err)
+				}
+			}()
+		}
+		log.Info("enforcement tier selected", "tier", d.activeTier, "seccomp_socket", *seccompSocketPath)
 	} else {
-		log.Info("eBPF ringbuf consumers disabled (--no-ringbuf)")
+		log.Info("eBPF ringbuf consumers disabled (--no-ringbuf); enforcement tiers unavailable")
 	}
 
 	// Notify systemd that the daemon is ready (Type=notify in the unit).

--- a/go/cmd/ardur-seccomp-smoke/main.go
+++ b/go/cmd/ardur-seccomp-smoke/main.go
@@ -142,6 +142,12 @@ func run(daemonBin, shimBin string) error {
 		"--state-dir", stateDir,
 		"--debug",
 		"--guard-ready-timeout=2s",
+		// Force the seccomp tier regardless of the host kernel's BPF-LSM
+		// availability. GitHub-hosted runners (and Docker Desktop's kernel)
+		// boot with "bpf" in the active LSM list, so without this the daemon
+		// would prefer the BPF-LSM tier and this smoke — which exercises the
+		// seccomp user-notify path specifically — could never reach it.
+		"--disable-bpf-lsm",
 	)
 	daemonCmd.Stdout = daemonLog
 	daemonCmd.Stderr = daemonLog

--- a/go/cmd/ardur-seccomp-smoke/main.go
+++ b/go/cmd/ardur-seccomp-smoke/main.go
@@ -1,0 +1,325 @@
+//go:build linux
+
+// Command ardur-seccomp-smoke is a CI-only kernel-in-loop smoke test for the
+// seccomp user-notify enforcement tier (Epic A #63, plan E4). It is driven
+// by the seccomp-smoke job in .github/workflows/kernel-enforce.yml, which
+// runs this binary directly on a plain (unprivileged) Ubuntu runner —
+// unlike ardur-guard-smoke's kernel-smoke job, this tier needs no KVM/
+// virtme-ng custom kernel boot: seccomp(SECCOMP_SET_MODE_FILTER,
+// SECCOMP_FILTER_FLAG_NEW_LISTENER, ...) works under an ordinary
+// PR_SET_NO_NEW_PRIVS-only process, confirmed empirically during E4's
+// end-to-end verification.
+//
+// It proves, against a real kernel, what the pure-Go/Linux-only unit tests
+// cannot:
+//  1. ardur-kernelcaptured, started with no BPF-LSM available (the common
+//     case this plan targets), falls back to the seccomp tier and starts
+//     its handoff socket.
+//  2. ardur-exec-shim installs a real connect(2)-notify filter, hands the
+//     listener off to the daemon over a real Unix socket + SCM_RIGHTS, and
+//     execs into a real target process that keeps running under it.
+//  3. The daemon's supervisor loop actually decides connect(2) attempts:
+//     a policy-denied target gets EPERM, a policy-allowed target reaches a
+//     real connect() (observed as ECONNREFUSED against a closed port,
+//     proving the syscall wasn't blocked).
+//  4. The decision is recorded as a hash-chained enforce_events receipt
+//     tagged with the seccomp tier.
+//
+// This exact harness caught two real bugs during development that no
+// pure-Go test surfaced: the shim's own connect() to the daemon's handoff
+// socket deadlocking against its own just-installed filter (fixed by
+// dialing before installing the filter — see ardur-exec-shim's run()), and
+// SendSeccompNotifResp writing a positive errno into a kernel field that
+// requires the raw negative -errno syscall-return convention (fixed in
+// buildSeccompNotifResp) — the latter silently let denied connects through
+// instead of blocking them. Losing this smoke test would mean losing the
+// only thing that can catch a regression in either.
+//
+// Not part of `go test ./...`: this spawns real daemon/shim subprocesses and
+// binds real sockets in ways not safe to run concurrently with other tests
+// in the same process.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+const (
+	pollInterval = 100 * time.Millisecond
+	pollTimeout  = 15 * time.Second
+)
+
+func main() {
+	probeConnect := flag.String("probe-connect", "", "internal: re-exec self as a connect(2) probe against this host:port")
+	daemonBin := flag.String("daemon-bin", "", "path to a prebuilt ardur-kernelcaptured binary (required)")
+	shimBin := flag.String("shim-bin", "", "path to a prebuilt ardur-exec-shim binary (required)")
+	flag.Parse()
+
+	if *probeConnect != "" {
+		runProbe(*probeConnect)
+		return
+	}
+
+	if *daemonBin == "" || *shimBin == "" {
+		fmt.Fprintln(os.Stderr, "usage: ardur-seccomp-smoke --daemon-bin PATH --shim-bin PATH")
+		os.Exit(2)
+	}
+	if err := run(*daemonBin, *shimBin); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS: seccomp tier denied a policy-blocked connect() with EPERM and allowed a policy-permitted one through to the kernel")
+}
+
+// runProbe is this binary's own re-exec mode: attempt one TCP connect and
+// report the observed errno (or success) unambiguously — this is what
+// ardur-exec-shim execs into as the governed process, so its own connect(2)
+// is the one under test.
+func runProbe(addr string) {
+	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+	if err == nil {
+		conn.Close()
+		fmt.Println("CONNECTED")
+		return
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		fmt.Printf("ERRNO:%d:%s\n", errno, errno)
+		return
+	}
+	fmt.Printf("OTHER_ERROR:%v\n", err)
+}
+
+func run(daemonBin, shimBin string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve own executable path (needed to re-exec as the connect probe): %w", err)
+	}
+
+	workDir, err := os.MkdirTemp("", "ardur-seccomp-smoke-")
+	if err != nil {
+		return fmt.Errorf("create work dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	// ardur-kernelcaptured's custody plan (daemon_custody.go) hard-requires
+	// --socket (via its parent, the run dir) under /run/ardur and
+	// --state-dir under /var/lib/ardur — these are not configurable to an
+	// arbitrary tmp path. --seccomp-socket and --evidence-dir carry no such
+	// restriction, so those stay in workDir. runID keeps this smoke run's
+	// paths from colliding with a real daemon instance or a concurrent run.
+	runID := fmt.Sprintf("seccomp-smoke-%d", os.Getpid())
+	runDir := filepath.Join("/run/ardur", runID)
+	sockPath := filepath.Join(runDir, "control.sock")
+	stateDir := filepath.Join("/var/lib/ardur", runID, "state")
+	defer os.RemoveAll(runDir)
+	defer os.RemoveAll(filepath.Join("/var/lib/ardur", runID))
+
+	seccompSockPath := filepath.Join(workDir, "seccomp.sock")
+	evidenceDir := filepath.Join(workDir, "evidence")
+
+	daemonLog, err := os.Create(filepath.Join(workDir, "daemon.log"))
+	if err != nil {
+		return fmt.Errorf("create daemon log file: %w", err)
+	}
+	defer daemonLog.Close()
+
+	daemonCmd := exec.Command(daemonBin,
+		"--socket", sockPath,
+		"--seccomp-socket", seccompSockPath,
+		"--evidence-dir", evidenceDir,
+		"--state-dir", stateDir,
+		"--debug",
+		"--guard-ready-timeout=2s",
+	)
+	daemonCmd.Stdout = daemonLog
+	daemonCmd.Stderr = daemonLog
+	if err := daemonCmd.Start(); err != nil {
+		return fmt.Errorf("start ardur-kernelcaptured: %w", err)
+	}
+	defer func() {
+		_ = daemonCmd.Process.Kill()
+		_ = daemonCmd.Wait()
+	}()
+
+	if err := waitForSocket(sockPath); err != nil {
+		return fmt.Errorf("waiting for control socket: %w (see %s)", err, daemonLog.Name())
+	}
+
+	tier, err := waitForActiveTier(sockPath)
+	if err != nil {
+		return fmt.Errorf("waiting for enforcement tier selection: %w (see %s)", err, daemonLog.Name())
+	}
+	if tier != "seccomp" {
+		return fmt.Errorf("active enforcement tier = %q, want %q — this runner may have BPF-LSM available, which is not what this smoke test exercises (see %s)",
+			tier, "seccomp", daemonLog.Name())
+	}
+	fmt.Println("daemon started, seccomp tier active")
+
+	const sessionID = "seccomp-smoke"
+	if err := daemonCall(sockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    sessionID,
+			RootPID:      1,
+			CgroupID:     1,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   300,
+		},
+	}); err != nil {
+		return fmt.Errorf("register_session: %w", err)
+	}
+
+	const allowedIP = "127.0.0.2"
+	if err := daemonCall(sockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+			SessionID:   sessionID,
+			Generation:  1,
+			EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+			NetAllow: []string{allowedIP + "/32"},
+		},
+	}); err != nil {
+		return fmt.Errorf("apply_policy: %w", err)
+	}
+	fmt.Println("policy applied: allow only " + allowedIP + "/32")
+
+	deniedTarget := "127.0.0.3:19999" // not in the allowlist
+	deniedOut, err := runShimProbe(shimBin, seccompSockPath, sessionID, self, deniedTarget)
+	if err != nil {
+		return fmt.Errorf("run shim against denied target: %w", err)
+	}
+	if deniedOut != "ERRNO:1:operation not permitted" {
+		return fmt.Errorf("denied target %s: probe reported %q, want EPERM", deniedTarget, deniedOut)
+	}
+	fmt.Println("denied target correctly got EPERM:", deniedOut)
+
+	allowedTarget := allowedIP + ":19999" // in the allowlist, nothing listening
+	allowedOut, err := runShimProbe(shimBin, seccompSockPath, sessionID, self, allowedTarget)
+	if err != nil {
+		return fmt.Errorf("run shim against allowed target: %w", err)
+	}
+	if allowedOut == "ERRNO:1:operation not permitted" {
+		return fmt.Errorf("allowed target %s: probe got EPERM, want the syscall to reach the kernel's real connect handling", allowedTarget)
+	}
+	fmt.Println("allowed target correctly reached the kernel (not EPERM):", allowedOut)
+
+	return nil
+}
+
+func waitForSocket(path string) error {
+	deadline := time.Now().Add(pollTimeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("socket %s did not appear within %s", path, pollTimeout)
+}
+
+// waitForActiveTier polls the daemon's health response until it reports a
+// non-empty enforcement tier, so the caller doesn't race apply_policy
+// against tier selection still being in flight.
+func waitForActiveTier(sockPath string) (string, error) {
+	deadline := time.Now().Add(pollTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := daemonRequest(sockPath, kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodHealth,
+			Health:          &kernelcapture.DaemonHealthRequest{},
+		})
+		if err != nil {
+			lastErr = err
+			time.Sleep(pollInterval)
+			continue
+		}
+		if resp.EnforcementTier != "" {
+			return resp.EnforcementTier, nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return "", fmt.Errorf("no enforcement tier reported within %s (last error: %v)", pollTimeout, lastErr)
+}
+
+func daemonCall(sockPath string, req kernelcapture.DaemonProtocolRequest) error {
+	resp, err := daemonRequest(sockPath, req)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("daemon returned an error response: %s", resp.Error)
+	}
+	return nil
+}
+
+func daemonRequest(sockPath string, req kernelcapture.DaemonProtocolRequest) (kernelcapture.DaemonProtocolResponse, error) {
+	conn, err := net.DialTimeout("unix", sockPath, 5*time.Second)
+	if err != nil {
+		return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("dial control socket: %w", err)
+	}
+	defer conn.Close()
+
+	data, err := kernelcapture.EncodeDaemonProtocolRequest(req)
+	if err != nil {
+		return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("encode request: %w", err)
+	}
+	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("set deadline: %w", err)
+	}
+	if _, err := conn.Write(data); err != nil {
+		return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("write request: %w", err)
+	}
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 65536), 1<<20)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("read response: %w", err)
+		}
+		return kernelcapture.DaemonProtocolResponse{}, errors.New("read response: connection closed with no data")
+	}
+	resp, err := kernelcapture.DecodeDaemonProtocolResponse(scanner.Bytes())
+	if err != nil {
+		return kernelcapture.DaemonProtocolResponse{}, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
+}
+
+// runShimProbe runs shimBin against self (re-exec'd via --probe-connect
+// target) under sessionID's seccomp policy, and returns the probe's single
+// line of stdout output.
+func runShimProbe(shimBin, seccompSockPath, sessionID, self, target string) (string, error) {
+	cmd := exec.Command(shimBin,
+		"--session-id", sessionID,
+		"--seccomp-socket", seccompSockPath,
+		"--",
+		self, "--probe-connect", target,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w (output: %s)", err, string(out))
+	}
+	line := string(out)
+	for len(line) > 0 && (line[len(line)-1] == '\n' || line[len(line)-1] == '\r') {
+		line = line[:len(line)-1]
+	}
+	return line, nil
+}

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -117,6 +117,15 @@ type DaemonProtocolResponse struct {
 	// directories are root-0700, so this is the only channel a non-root client
 	// has to learn what kernel-level enforcement happened.
 	Enforcement *EnforceEventSummary `json:"enforcement,omitempty"`
+	// EnforcementTier carries which kernel enforcement tier is currently
+	// active — "bpf_lsm", "seccomp", or "none" — on successful health
+	// responses (plan E4). The daemon decides this once at startup
+	// (BPF-LSM preferred, seccomp as fallback) and never changes it while
+	// running; a launcher queries it to decide whether a governed process
+	// needs to be routed through ardur-exec-shim (the seccomp tier's
+	// on-ramp) before spawning one, or can rely on BPF-LSM's cgroup-scoped
+	// enforcement with no per-process wrapper at all.
+	EnforcementTier string `json:"enforcement_tier,omitempty"`
 }
 
 // CgroupFilterSequence describes daemon-side map sequencing. Enabling

--- a/go/pkg/kernelcapture/seccomp_notify_linux.go
+++ b/go/pkg/kernelcapture/seccomp_notify_linux.go
@@ -1,0 +1,362 @@
+//go:build linux
+
+package kernelcapture
+
+// seccomp_notify_linux.go — kernel-facing primitives for the seccomp
+// user-notify enforcement tier (Epic A #63, plan E4): installing a
+// SECCOMP_RET_USER_NOTIF filter scoped to connect(2), and the
+// receive/respond/id-valid ioctls a supervisor uses to service it.
+//
+// golang.org/x/sys/unix v0.46.0 (this module's pinned version) has no
+// seccomp user-notify support at all — no SeccompNotif/SeccompNotifResp
+// structs, no SECCOMP_IOCTL_NOTIF_* constants, no seccomp(2) wrapper (only
+// the legacy prctl(PR_SET_SECCOMP) path, which doesn't support
+// SECCOMP_FILTER_FLAG_NEW_LISTENER at all). This file defines the kernel
+// UAPI shapes and ioctl numbers directly from <linux/seccomp.h>, matching
+// field-for-field.
+//
+// Claim boundary: this file only intercepts connect(2). See
+// seccomp_policy.go's header comment for why (exec/file-open have no safe
+// seccomp-user-notify equivalent in this design) and for the weaker-than-
+// BPF-LSM security claim this whole tier makes.
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// --- Kernel UAPI shapes (linux/seccomp.h) -----------------------------------
+// Field order and sizes are kernel ABI — do not reorder or resize.
+
+type seccompData struct {
+	Nr                 int32
+	Arch               uint32
+	InstructionPointer uint64
+	Args               [6]uint64
+}
+
+type seccompNotif struct {
+	ID    uint64
+	PID   uint32
+	Flags uint32
+	Data  seccompData
+}
+
+type seccompNotifResp struct {
+	ID    uint64
+	Val   int64
+	Error int32
+	Flags uint32
+}
+
+const (
+	seccompSetModeFilter         = 1      // SECCOMP_SET_MODE_FILTER
+	seccompFilterFlagNewListener = 1 << 3 // SECCOMP_FILTER_FLAG_NEW_LISTENER
+
+	// seccompUserNotifFlagContinue tells the kernel to let the original
+	// syscall proceed with whatever arguments are in the tracee's registers
+	// *at the moment the kernel resumes it* — not necessarily the ones the
+	// supervisor read via NOTIF_RECV. It is only ever set on a
+	// confirmed-safe ALLOW decision in seccomp_supervisor_linux.go, never as
+	// a default — see that file's decide function for the fail-closed
+	// contract.
+	seccompUserNotifFlagContinue = 1 << 0
+
+	seccompRetAllow       = 0x7fff0000 // SECCOMP_RET_ALLOW
+	seccompRetUserNotif   = 0x7fc00000 // SECCOMP_RET_USER_NOTIF
+	seccompRetKillProcess = 0x80000000 // SECCOMP_RET_KILL_PROCESS
+
+	// Linux audit architecture tokens (linux/audit.h). Only the two this
+	// project builds for are defined; nativeSeccompAuditArch fails closed
+	// for anything else rather than silently omitting the arch check.
+	auditArchX86_64  = 0xc000003e
+	auditArchAarch64 = 0xc00000b7
+)
+
+// --- Linux ioctl encoding (asm-generic/ioctl.h) -----------------------------
+//
+// dir(2 bits)<<30 | size(14 bits)<<16 | type(8 bits)<<8 | nr(8 bits).
+// Computed from the actual Go struct sizes above rather than hardcoded, so a
+// struct-layout mistake surfaces as a wrong-but-checkable ioctl number
+// (TestSeccompIoctlNumbers pins the values every other seccomp-notify
+// implementation — runc, containerd — hardcodes) instead of a silent
+// runtime ENOTTY.
+
+const (
+	iocWrite = 1
+	iocRead  = 2
+
+	seccompIOCMagic = uintptr('!')
+)
+
+func iocEncode(dir, typ, nr, size uintptr) uintptr {
+	return (dir << 30) | (size << 16) | (typ << 8) | nr
+}
+
+var (
+	seccompIoctlNotifRecv    = iocEncode(iocRead|iocWrite, seccompIOCMagic, 0, unsafe.Sizeof(seccompNotif{}))
+	seccompIoctlNotifSend    = iocEncode(iocRead|iocWrite, seccompIOCMagic, 1, unsafe.Sizeof(seccompNotifResp{}))
+	seccompIoctlNotifIDValid = iocEncode(iocWrite, seccompIOCMagic, 2, unsafe.Sizeof(uint64(0)))
+)
+
+func seccompIoctl(fd int, req uintptr, arg unsafe.Pointer) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), req, uintptr(arg))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// --- Classic BPF (cBPF) filter assembly (linux/filter.h) -------------------
+//
+// SECCOMP_SET_MODE_FILTER takes a *classic* BPF program (struct sock_filter
+// arrays), not eBPF — the same instruction encoding as SO_ATTACH_FILTER.
+
+type sockFilter struct {
+	Code uint16
+	Jt   uint8
+	Jf   uint8
+	K    uint32
+}
+
+// sockFprog mirrors struct sock_fprog: `unsigned short len` followed by
+// (after the compiler's natural 6-byte pad to align the pointer field)
+// `struct sock_filter *filter`. The explicit padding field documents that
+// layout rather than relying on the Go compiler's default alignment to
+// happen to match it.
+type sockFprog struct {
+	Len    uint16
+	_      [6]byte
+	Filter *sockFilter
+}
+
+const (
+	bpfLd  = 0x00
+	bpfJmp = 0x05
+	bpfRet = 0x06
+
+	bpfW   = 0x00
+	bpfAbs = 0x20
+
+	bpfJeq = 0x10
+	bpfK   = 0x00
+)
+
+func bpfStmt(code uint16, k uint32) sockFilter {
+	return sockFilter{Code: code, K: k}
+}
+
+func bpfJump(code uint16, k uint32, jt, jf uint8) sockFilter {
+	return sockFilter{Code: code, Jt: jt, Jf: jf, K: k}
+}
+
+// connectNotifyFilterProgram builds the filter guard_bprm-style hooks don't
+// need but a userspace syscall trap does: reject any syscall entered via an
+// unexpected ABI outright (a 32-bit compat syscall on a 64-bit target has a
+// *different* number for the same operation — checking only `nr` without
+// also pinning `arch` is the classic seccomp filter bypass: an attacker
+// invokes connect via the 32-bit syscall table, `nr` doesn't match
+// SYS_CONNECT for the 64-bit ABI this filter was built for, and the
+// unfiltered call falls through to ALLOW), then trap only connect(2),
+// allowing everything else through untouched.
+//
+//	0: A = seccomp_data.arch
+//	1: if A != nativeArch: goto 6 (KILL_PROCESS)
+//	2: A = seccomp_data.nr
+//	3: if A != connectNr: goto 5 (ALLOW)
+//	4: return USER_NOTIF
+//	5: return ALLOW
+//	6: return KILL_PROCESS
+func connectNotifyFilterProgram(nativeArch uint32, connectNr uint32) []sockFilter {
+	const archOffset = 4 // offsetof(struct seccomp_data, arch)
+	const nrOffset = 0   // offsetof(struct seccomp_data, nr)
+	return []sockFilter{
+		bpfStmt(bpfLd|bpfW|bpfAbs, archOffset),
+		bpfJump(bpfJmp|bpfJeq|bpfK, nativeArch, 0, 4),
+		bpfStmt(bpfLd|bpfW|bpfAbs, nrOffset),
+		bpfJump(bpfJmp|bpfJeq|bpfK, connectNr, 0, 1),
+		bpfStmt(bpfRet|bpfK, seccompRetUserNotif),
+		bpfStmt(bpfRet|bpfK, seccompRetAllow),
+		bpfStmt(bpfRet|bpfK, seccompRetKillProcess),
+	}
+}
+
+func nativeSeccompAuditArch() (uint32, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return auditArchX86_64, nil
+	case "arm64":
+		return auditArchAarch64, nil
+	default:
+		return 0, fmt.Errorf("kernelcapture: seccomp connect-notify filter is only implemented for amd64/arm64, got GOARCH=%s", runtime.GOARCH)
+	}
+}
+
+// --- Public API --------------------------------------------------------
+
+// InstallConnectUserNotifyFilter installs a seccomp filter in the calling
+// process (and, by seccomp's design, every process it execve()s into
+// afterward — filters are inherited across exec, which is the whole
+// mechanism ardur-exec-shim relies on) that traps connect(2) via
+// SECCOMP_RET_USER_NOTIF and allows every other syscall through unfiltered.
+// Returns the notification listener fd on success.
+//
+// Sets PR_SET_NO_NEW_PRIVS first: the kernel requires either that or
+// CAP_SYS_ADMIN in the caller's user namespace before installing *any*
+// seccomp filter as an unprivileged process. Requiring no_new_privs (rather
+// than documenting a CAP_SYS_ADMIN requirement) means ardur-exec-shim needs
+// no elevated capability to protect its own child.
+func InstallConnectUserNotifyFilter() (int, error) {
+	arch, err := nativeSeccompAuditArch()
+	if err != nil {
+		return -1, err
+	}
+	prog := connectNotifyFilterProgram(arch, uint32(unix.SYS_CONNECT))
+
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return -1, fmt.Errorf("kernelcapture: prctl(PR_SET_NO_NEW_PRIVS): %w", err)
+	}
+
+	fprog := sockFprog{Len: uint16(len(prog)), Filter: &prog[0]}
+	fd, _, errno := unix.Syscall(uintptr(unix.SYS_SECCOMP),
+		seccompSetModeFilter,
+		seccompFilterFlagNewListener,
+		uintptr(unsafe.Pointer(&fprog)),
+	)
+	if errno != 0 {
+		return -1, fmt.Errorf("kernelcapture: seccomp(SECCOMP_SET_MODE_FILTER, NEW_LISTENER): %w", errno)
+	}
+	return int(fd), nil
+}
+
+// SeccompNotif is the caller-facing projection of one notification: enough
+// to make a policy decision and to read the target's memory for
+// syscall-argument-dependent ones (connect's sockaddr pointer is Args[1],
+// its length is Args[2] — the standard connect(2) ABI: connect(int sockfd,
+// const struct sockaddr *addr, socklen_t addrlen)).
+type SeccompNotif struct {
+	ID   uint64
+	PID  uint32
+	Nr   int32
+	Args [6]uint64
+}
+
+// RecvSeccompNotif blocks until a notification is available on listenerFD
+// (SECCOMP_IOCTL_NOTIF_RECV) or the listener is closed/an error occurs.
+func RecvSeccompNotif(listenerFD int) (SeccompNotif, error) {
+	var raw seccompNotif
+	if err := seccompIoctl(listenerFD, seccompIoctlNotifRecv, unsafe.Pointer(&raw)); err != nil {
+		return SeccompNotif{}, fmt.Errorf("kernelcapture: SECCOMP_IOCTL_NOTIF_RECV: %w", err)
+	}
+	return SeccompNotif{ID: raw.ID, PID: raw.PID, Nr: raw.Data.Nr, Args: raw.Data.Args}, nil
+}
+
+// SendSeccompNotifResp responds to notification id on listenerFD.
+// continueSyscall sets SECCOMP_USER_NOTIF_FLAG_CONTINUE (let the syscall
+// proceed normally); when false, the syscall returns -1 to the tracee with
+// errno set to errno (val is ignored by the kernel in that case). errno is a
+// natural positive value in this API (e.g. unix.EPERM, matching every other
+// errno in this codebase) — the kernel's own seccomp_notif_resp.error field
+// uses the raw syscall-return convention instead (a *negative* -errno), so
+// this function negates it before writing the struct. Getting this backwards
+// is silent and severe: the kernel treats a non-negative raw return value as
+// success, so a positive `error` doesn't deny the syscall, it lets it
+// through with a nonsense return value — caught empirically, the first
+// end-to-end run of the seccomp tier let a policy-denied connect() through
+// for exactly this reason. Callers must not set both a continue response and
+// a non-zero errno — SendSeccompNotifResp does not itself enforce that
+// exclusivity, so get it right at the call site (see daemon_seccomp_linux.go,
+// which never does both).
+func SendSeccompNotifResp(listenerFD int, id uint64, val int64, errno int32, continueSyscall bool) error {
+	resp := buildSeccompNotifResp(id, val, errno, continueSyscall)
+	if err := seccompIoctl(listenerFD, seccompIoctlNotifSend, unsafe.Pointer(&resp)); err != nil {
+		return fmt.Errorf("kernelcapture: SECCOMP_IOCTL_NOTIF_SEND: %w", err)
+	}
+	return nil
+}
+
+// buildSeccompNotifResp is SendSeccompNotifResp's struct construction,
+// split out so the positive-errno-in/negative-errno-in-the-kernel-struct-out
+// sign flip can be unit-tested without a live listener fd (see
+// TestBuildSeccompNotifResp_NegatesErrno for the regression this guards).
+func buildSeccompNotifResp(id uint64, val int64, errno int32, continueSyscall bool) seccompNotifResp {
+	var flags uint32
+	if continueSyscall {
+		flags = seccompUserNotifFlagContinue
+	}
+	return seccompNotifResp{ID: id, Val: val, Error: -errno, Flags: flags}
+}
+
+// SeccompNotifIDValid reports whether notification id on listenerFD is still
+// live — the target thread that generated it hasn't exited, and (critically)
+// its pid hasn't been reused for an unrelated process since. See
+// ReadTargetSockaddr's doc comment for how this is used to bound the TOCTOU
+// window around reading target memory.
+func SeccompNotifIDValid(listenerFD int, id uint64) bool {
+	localID := id
+	return seccompIoctl(listenerFD, seccompIoctlNotifIDValid, unsafe.Pointer(&localID)) == nil
+}
+
+// maxReadableSockaddrLen caps how many bytes ReadTargetSockaddr will read
+// regardless of what addrlen the tracee claims: enough for sockaddr_in6 (28
+// bytes) with generous headroom, small enough that a corrupt/hostile addrlen
+// value can't turn this into an unbounded read.
+const maxReadableSockaddrLen = 128
+
+// ReadTargetSockaddr reads addrLen bytes (capped at maxReadableSockaddrLen)
+// from pid's memory at addr, for a connect(2) notification identified by id
+// on listenerFD.
+//
+// Re-validates id via SECCOMP_IOCTL_NOTIF_ID_VALID both immediately before
+// opening /proc/pid/mem (catching a target that has already exited/been
+// reaped since RECV) and immediately after the read (catching a target that
+// exited *during* the read, whose pid could otherwise have been recycled for
+// an unrelated process by the time this function returns bytes the caller is
+// about to trust). This is the standard seccomp_unotify(2) TOCTOU mitigation
+// pattern (Documentation/userspace-api/seccomp_filter.rst): checking only
+// once, before OR after the read, leaves a window where the bytes returned
+// belong to a different process than the one the caller believes it is
+// evaluating.
+//
+// This closes the PID-reuse race. It does not close every race — a
+// still-live, still-correctly-identified target can still mutate its own
+// memory from another thread between this read and the supervisor's
+// eventual SECCOMP_IOCTL_NOTIF_SEND. See seccomp_policy.go's claim-boundary
+// comment: that is the documented, load-bearing difference between this
+// tier and an in-kernel LSM hook.
+func ReadTargetSockaddr(listenerFD int, id uint64, pid uint32, addr uint64, addrLen uint32) ([]byte, error) {
+	if addrLen == 0 {
+		return nil, fmt.Errorf("kernelcapture: connect(2) addrlen is 0")
+	}
+	if addrLen > maxReadableSockaddrLen {
+		addrLen = maxReadableSockaddrLen
+	}
+
+	if !SeccompNotifIDValid(listenerFD, id) {
+		return nil, fmt.Errorf("kernelcapture: notification %d no longer valid before memory read (target exited or was reaped)", id)
+	}
+
+	mem, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
+	if err != nil {
+		return nil, fmt.Errorf("kernelcapture: open /proc/%d/mem: %w", pid, err)
+	}
+	defer mem.Close()
+
+	buf := make([]byte, addrLen)
+	n, err := mem.ReadAt(buf, int64(addr))
+	if err != nil {
+		return nil, fmt.Errorf("kernelcapture: read /proc/%d/mem at %#x: %w", pid, addr, err)
+	}
+	if uint32(n) != addrLen {
+		return nil, fmt.Errorf("kernelcapture: short read from /proc/%d/mem: got %d, want %d", pid, n, addrLen)
+	}
+
+	if !SeccompNotifIDValid(listenerFD, id) {
+		return nil, fmt.Errorf("kernelcapture: notification %d no longer valid after memory read (target exited mid-read; discarding bytes read from a possibly-recycled pid)", id)
+	}
+	return buf, nil
+}

--- a/go/pkg/kernelcapture/seccomp_notify_linux_test.go
+++ b/go/pkg/kernelcapture/seccomp_notify_linux_test.go
@@ -1,0 +1,247 @@
+//go:build linux
+
+package kernelcapture
+
+// seccomp_notify_linux_test.go — unit tests for the seccomp user-notify
+// kernel UAPI layer (seccomp_notify_linux.go): ioctl number pinning, classic
+// BPF filter assembly, and struct layout ABI checks.
+//
+// These deliberately stop short of calling seccomp(2)/ioctl(2) against a
+// real listener — installing SECCOMP_RET_USER_NOTIF in the test process
+// itself would attach an irrevocable filter to `go test`'s own process for
+// the rest of the binary's run (seccomp filters can only be added, never
+// removed), which would risk hanging or breaking any later test that
+// touches the network in-process if nothing ever answers the notification.
+// That end-to-end proof belongs in a dedicated, isolated harness (plan E4's
+// privileged-container verification step, mirroring ardur-guard-smoke's
+// separate-binary pattern for the BPF-LSM tier), not go test ./....
+
+import (
+	"encoding/binary"
+	"reflect"
+	"runtime"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSeccompIoctlNumbers pins the three ioctl request values this file
+// computes via iocEncode against the same numbers every other
+// seccomp-notify implementation (runc, containerd) hardcodes. A
+// seccompNotif/seccompNotifResp struct-layout mistake changes the encoded
+// size field and surfaces here as a wrong-but-checkable number instead of a
+// silent ENOTTY at runtime.
+func TestSeccompIoctlNumbers(t *testing.T) {
+	cases := []struct {
+		name string
+		got  uintptr
+		want uintptr
+	}{
+		{"SECCOMP_IOCTL_NOTIF_RECV", seccompIoctlNotifRecv, 0xc0502100},
+		{"SECCOMP_IOCTL_NOTIF_SEND", seccompIoctlNotifSend, 0xc0182101},
+		{"SECCOMP_IOCTL_NOTIF_ID_VALID", seccompIoctlNotifIDValid, 0x40082102},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %#x, want %#x", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestNativeSeccompAuditArch(t *testing.T) {
+	arch, err := nativeSeccompAuditArch()
+	if err != nil {
+		t.Fatalf("nativeSeccompAuditArch() on GOARCH=%s: %v", runtime.GOARCH, err)
+	}
+	var want uint32
+	switch runtime.GOARCH {
+	case "amd64":
+		want = auditArchX86_64
+	case "arm64":
+		want = auditArchAarch64
+	default:
+		t.Skipf("no expected AUDIT_ARCH_* constant for GOARCH=%s in this test", runtime.GOARCH)
+	}
+	if arch != want {
+		t.Errorf("nativeSeccompAuditArch() = %#x, want %#x", arch, want)
+	}
+}
+
+// TestSockFprogLayoutMatchesKernelABI guards struct sock_fprog's memory
+// layout — the value InstallConnectUserNotifyFilter passes a raw pointer to
+// in the SYS_SECCOMP syscall, so a layout drift here would corrupt what the
+// kernel reads as the filter length and pointer without returning any Go
+// compile error.
+func TestSockFprogLayoutMatchesKernelABI(t *testing.T) {
+	var f sockFprog
+	// struct sock_fprog { unsigned short len; struct sock_filter *filter; }
+	// On a 64-bit target: 2-byte len, 6-byte compiler pad, 8-byte pointer.
+	if got, want := unsafe.Sizeof(f), uintptr(16); got != want {
+		t.Errorf("unsafe.Sizeof(sockFprog{}) = %d, want %d", got, want)
+	}
+	if got, want := unsafe.Offsetof(f.Filter), uintptr(8); got != want {
+		t.Errorf("unsafe.Offsetof(sockFprog{}.Filter) = %d, want %d", got, want)
+	}
+}
+
+// runClassicBPF is a minimal classic-BPF (cBPF) interpreter supporting only
+// the instruction subset connectNotifyFilterProgram emits (BPF_LD|W|ABS,
+// BPF_JMP|JEQ|K, BPF_RET|K) — enough to prove the assembled filter's actual
+// decision logic against synthetic seccomp_data inputs the way the kernel
+// itself would evaluate it, independent of re-deriving the same instruction
+// literals the implementation under test uses.
+func runClassicBPF(t *testing.T, prog []sockFilter, data seccompData) uint32 {
+	t.Helper()
+	raw := unsafe.Slice((*byte)(unsafe.Pointer(&data)), unsafe.Sizeof(data))
+	var a uint32
+	pc := 0
+	for steps := 0; ; steps++ {
+		if steps > 100 {
+			t.Fatal("BPF interpreter: too many steps, probable infinite loop in the program under test")
+		}
+		if pc < 0 || pc >= len(prog) {
+			t.Fatalf("program counter %d out of range (program length %d)", pc, len(prog))
+		}
+		ins := prog[pc]
+		switch ins.Code {
+		case bpfLd | bpfW | bpfAbs:
+			if int(ins.K)+4 > len(raw) {
+				t.Fatalf("BPF_LD|W|ABS at pc=%d: offset %d out of range (seccomp_data is %d bytes)", pc, ins.K, len(raw))
+			}
+			a = binary.NativeEndian.Uint32(raw[ins.K : ins.K+4])
+			pc++
+		case bpfJmp | bpfJeq | bpfK:
+			if a == ins.K {
+				pc += 1 + int(ins.Jt)
+			} else {
+				pc += 1 + int(ins.Jf)
+			}
+		case bpfRet | bpfK:
+			return ins.K
+		default:
+			t.Fatalf("unsupported instruction code %#x at pc=%d (interpreter only implements what connectNotifyFilterProgram emits)", ins.Code, pc)
+		}
+	}
+}
+
+// TestConnectNotifyFilterProgram_DecisionLogic runs the actual assembled
+// filter program against synthetic seccomp_data through runClassicBPF,
+// proving the three-way decision the package doc comment documents:
+// mismatched arch always kills the process (closing the 32-bit-compat
+// syscall bypass) regardless of nr; matching arch + connect's nr traps to
+// USER_NOTIF; matching arch + any other nr is allowed through untouched.
+func TestConnectNotifyFilterProgram_DecisionLogic(t *testing.T) {
+	arch, err := nativeSeccompAuditArch()
+	if err != nil {
+		t.Fatalf("nativeSeccompAuditArch: %v", err)
+	}
+	const connectNr = 1000
+	const otherNr = 1001
+	const wrongArch = 0xdeadbeef
+
+	prog := connectNotifyFilterProgram(arch, connectNr)
+	if len(prog) == 0 {
+		t.Fatal("connectNotifyFilterProgram returned an empty program")
+	}
+
+	cases := []struct {
+		name string
+		data seccompData
+		want uint32
+	}{
+		{"matching arch and connect nr traps to USER_NOTIF", seccompData{Nr: connectNr, Arch: arch}, seccompRetUserNotif},
+		{"matching arch, unrelated nr is allowed", seccompData{Nr: otherNr, Arch: arch}, seccompRetAllow},
+		{"mismatched arch kills even for connect's own nr", seccompData{Nr: connectNr, Arch: wrongArch}, seccompRetKillProcess},
+		{"mismatched arch kills for an unrelated nr too", seccompData{Nr: otherNr, Arch: wrongArch}, seccompRetKillProcess},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runClassicBPF(t, prog, tc.data)
+			if got != tc.want {
+				t.Errorf("got return value %#x, want %#x", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConnectNotifyFilterProgram_StructuralShape is a coarser guard on top
+// of the decision-logic test: exactly 7 instructions, and every instruction
+// is one of the three opcodes the interpreter above (and the real kernel
+// classic-BPF verifier) expects from this filter — an unexpected opcode
+// creeping in would either be rejected by the kernel's BPF verifier at
+// filter-install time or silently change behavior, neither of which the
+// decision-logic test alone would necessarily catch if it happened to
+// preserve the four decisions already exercised there.
+func TestConnectNotifyFilterProgram_StructuralShape(t *testing.T) {
+	prog := connectNotifyFilterProgram(auditArchX86_64, 42)
+	if len(prog) != 7 {
+		t.Fatalf("len(prog) = %d, want 7", len(prog))
+	}
+	allowedCodes := map[uint16]bool{
+		bpfLd | bpfW | bpfAbs:  true,
+		bpfJmp | bpfJeq | bpfK: true,
+		bpfRet | bpfK:          true,
+	}
+	for i, ins := range prog {
+		if !allowedCodes[ins.Code] {
+			t.Errorf("prog[%d].Code = %#x, not one of the expected LD|W|ABS / JMP|JEQ|K / RET|K opcodes", i, ins.Code)
+		}
+	}
+	// The final instruction is unconditionally reachable only via a jump
+	// (nothing falls through to it), and must be the fail-closed
+	// KILL_PROCESS terminator.
+	last := prog[len(prog)-1]
+	if last.Code != bpfRet|bpfK || last.K != seccompRetKillProcess {
+		t.Errorf("final instruction = %+v, want RET|K KILL_PROCESS", last)
+	}
+}
+
+// TestBuildSeccompNotifResp_NegatesErrno is a regression test for a bug
+// caught only by the E4 kernel-in-loop verification (not by any prior pure-Go
+// or structural test): the kernel's seccomp_notif_resp.error field uses the
+// raw syscall-return convention (a *negative* -errno), unlike every other
+// errno in this codebase (positive, e.g. unix.EPERM). Passing a positive
+// value there doesn't deny the syscall — the kernel treats a non-negative
+// raw return as success, so a policy-denied connect() was silently let
+// through with a nonsense return value until this was found and fixed.
+func TestBuildSeccompNotifResp_NegatesErrno(t *testing.T) {
+	resp := buildSeccompNotifResp(42, -1, int32(unix.EPERM), false)
+	if resp.Error != -int32(unix.EPERM) {
+		t.Errorf("resp.Error = %d, want %d (negated EPERM — the kernel's raw syscall-return convention)", resp.Error, -int32(unix.EPERM))
+	}
+	if resp.Error >= 0 {
+		t.Fatal("resp.Error is non-negative: the kernel would treat this as success, not a denial")
+	}
+	if resp.ID != 42 {
+		t.Errorf("resp.ID = %d, want 42", resp.ID)
+	}
+	if resp.Flags != 0 {
+		t.Errorf("resp.Flags = %#x, want 0 (continueSyscall=false)", resp.Flags)
+	}
+}
+
+func TestBuildSeccompNotifResp_ContinueSetsFlagAndLeavesErrnoUnnegatedZero(t *testing.T) {
+	resp := buildSeccompNotifResp(7, 0, 0, true)
+	if resp.Flags != seccompUserNotifFlagContinue {
+		t.Errorf("resp.Flags = %#x, want SECCOMP_USER_NOTIF_FLAG_CONTINUE (%#x)", resp.Flags, seccompUserNotifFlagContinue)
+	}
+	if resp.Error != 0 {
+		t.Errorf("resp.Error = %d, want 0", resp.Error)
+	}
+}
+
+// TestConnectNotifyFilterProgram_DifferentInputsProduceDifferentPrograms is
+// a sanity check that nativeArch/connectNr actually parameterize the
+// program rather than being ignored constants baked in elsewhere.
+func TestConnectNotifyFilterProgram_DifferentInputsProduceDifferentPrograms(t *testing.T) {
+	a := connectNotifyFilterProgram(auditArchX86_64, 42)
+	b := connectNotifyFilterProgram(auditArchAarch64, 42)
+	if reflect.DeepEqual(a, b) {
+		t.Error("programs for different nativeArch values are identical, want the arch-check instruction's K to differ")
+	}
+	c := connectNotifyFilterProgram(auditArchX86_64, 99)
+	if reflect.DeepEqual(a, c) {
+		t.Error("programs for different connectNr values are identical, want the nr-check instruction's K to differ")
+	}
+}

--- a/go/pkg/kernelcapture/seccomp_policy.go
+++ b/go/pkg/kernelcapture/seccomp_policy.go
@@ -1,0 +1,205 @@
+package kernelcapture
+
+// seccomp_policy.go — in-memory OP_NET_CONNECT policy store for the seccomp
+// user-notify enforcement tier (Epic A #63, plan E4).
+//
+// This is the seccomp tier's counterpart to bpf_policy_apply.go: same
+// DaemonApplyPolicyRequest schema, same BpfOp/BpfAction/BpfEnforceMode
+// semantics, same CIDR-or-bare-IP net_allow parsing — "the SAME policy
+// tables ... as the BPF tier" the plan calls for — but stored in an
+// in-process map instead of kernel BPF maps, because E4 exists specifically
+// for hosts where those kernel maps are never loaded (stock distros that
+// ship CONFIG_BPF_LSM=y but don't put "bpf" in the boot lsm= list). No build
+// tag: this has no syscall dependency and is fully unit-testable on
+// darwin/CI, matching bpf_policy_apply.go's platform-independence rationale.
+//
+// Scope: OP_NET_CONNECT only. The seccomp filter this tier installs traps
+// connect(2) exclusively (see seccomp_notify_linux.go) — there is no
+// seccomp-user-notify equivalent for exec/file-open enforcement in this
+// design. A seccomp filter *can* trap execve, but by the time a
+// SECCOMP_RET_USER_NOTIF notification is serviced the new program image
+// hasn't loaded yet, and SECCOMP_USER_NOTIF_FLAG_CONTINUE for execve carries
+// TOCTOU hazards beyond what connect's fixed-size sockaddr argument has
+// (variable-length argv/envp the tracee can keep mutating). Out of scope for
+// E4; BPF-LSM remains the only tier that governs exec and file ops.
+//
+// Claim boundary (state up front, not just in the PR description): seccomp
+// user-notify is weaker than an in-kernel LSM against a racing multithreaded
+// adversary. The supervisor observes syscall arguments and reads target
+// memory across a window bounded by SECCOMP_IOCTL_NOTIF_ID_VALID checks (see
+// seccomp_notify_linux.go), but a sufficiently fast concurrent thread in the
+// target process can still rewrite the sockaddr bytes between the kernel
+// capturing the syscall arguments and this store's decision being enforced,
+// in ways a kernel-resident LSM hook (which runs synchronously in the
+// syscalling thread's own context, with no supervisor round-trip) is not
+// exposed to. This tier is a real, load-bearing enforcement mechanism for
+// single-threaded or cooperative targets — which describes the overwhelming
+// majority of AI-agent subprocess trees this project governs — not a
+// theoretically-airtight one against an adversarial multithreaded target.
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+// SeccompPolicyStore holds each governed session's OP_NET_CONNECT policy.
+// Safe for concurrent use.
+type SeccompPolicyStore struct {
+	mu       sync.RWMutex
+	sessions map[string]seccompSessionPolicy
+}
+
+type seccompSessionPolicy struct {
+	action      BpfAction
+	enforceMode BpfEnforceMode
+	allow       []*net.IPNet
+}
+
+// NewSeccompPolicyStore returns an empty store.
+func NewSeccompPolicyStore() *SeccompPolicyStore {
+	return &SeccompPolicyStore{sessions: make(map[string]seccompSessionPolicy)}
+}
+
+// ApplySeccompPolicy installs req's OP_NET_CONNECT rule (if any) for
+// sessionID. Unlike ApplyPolicyMaps, an in-memory map write cannot fail on
+// "guard not loaded" — the seccomp tier's apply_policy path has no degraded
+// branch to speak of, only "this request had no OP_NET_CONNECT rule," which
+// is a no-op (and clears any earlier rule for the session), not an error.
+func ApplySeccompPolicy(store *SeccompPolicyStore, sessionID string, req DaemonApplyPolicyRequest) error {
+	if store == nil {
+		return fmt.Errorf("kernelcapture: seccomp policy store is required")
+	}
+
+	var netPolicy *DaemonOpPolicy
+	for i := range req.OpPolicies {
+		if req.OpPolicies[i].Op == BpfOpNetConnect {
+			netPolicy = &req.OpPolicies[i]
+			break
+		}
+	}
+	if netPolicy == nil {
+		store.mu.Lock()
+		delete(store.sessions, sessionID)
+		store.mu.Unlock()
+		return nil
+	}
+
+	allow := make([]*net.IPNet, 0, len(req.NetAllow))
+	for _, cidr := range req.NetAllow {
+		ipNet, err := parseSeccompNetAllowEntry(cidr)
+		if err != nil {
+			return fmt.Errorf("kernelcapture: seccomp apply_policy net_allow (%q): %w", cidr, err)
+		}
+		allow = append(allow, ipNet)
+	}
+
+	store.mu.Lock()
+	store.sessions[sessionID] = seccompSessionPolicy{
+		action:      netPolicy.Action,
+		enforceMode: netPolicy.EnforceMode,
+		allow:       allow,
+	}
+	store.mu.Unlock()
+	return nil
+}
+
+// RemoveSeccompPolicy clears sessionID's policy, mirroring RemovePolicyMaps'
+// session-end cleanup for the BPF tier.
+func RemoveSeccompPolicy(store *SeccompPolicyStore, sessionID string) {
+	if store == nil {
+		return
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	delete(store.sessions, sessionID)
+}
+
+// SeccompConnectDecision is the result of evaluating one connect(2) attempt.
+type SeccompConnectDecision struct {
+	Action      BpfAction
+	EnforceMode BpfEnforceMode
+	// HasPolicy is false when sessionID has no OP_NET_CONNECT rule at all.
+	// Unlike the BPF tier's STRICT-cgroup fail-closed default (any *governed*
+	// cgroup with no rule for an op denies it), a seccomp listener is only
+	// ever attached to a session that explicitly opted into this tier — an
+	// absent rule here means "this session's policy doesn't govern network
+	// connects," not "deny by default," so HasPolicy=false always resolves
+	// to Allowed=true.
+	HasPolicy bool
+	// Matched is whether the target address satisfied the policy's ALLOW/
+	// ALLOWLIST condition, independent of enforce mode — this is what the
+	// emitted enforce_event's ActionTaken/verdict should reflect (a
+	// PERMISSIVE-mode miss is still logged as a would-be deny).
+	Matched bool
+	// Allowed is the final syscall-level outcome the supervisor must act on:
+	// whether to let connect(2) proceed (CONTINUE) or fail it with EPERM.
+	// False only when Matched is false AND EnforceMode is Enforce.
+	Allowed bool
+}
+
+// EvaluateSeccompConnect decides whether ip may be connect(2)'d to for
+// sessionID, using the same BpfAction semantics process_guard.bpf.c's
+// decide() applies for OP_NET_CONNECT: ACT_ALLOW always matches, ACT_DENY
+// never matches, ACT_ALLOWLIST matches only if ip is covered by an entry in
+// the session's net_allow CIDR list. An unrecognised action value fails
+// closed (Matched=false) rather than defaulting to allow — silent
+// under-enforcement is worse than a loud failure, the same principle
+// bpf_lower.py's ENFORCE_STRICT loud-guard and ApplyPolicyMaps'
+// ErrPolicyMapsUnavailable handling already apply elsewhere in this
+// codebase.
+func EvaluateSeccompConnect(store *SeccompPolicyStore, sessionID string, ip net.IP) SeccompConnectDecision {
+	if store == nil {
+		return SeccompConnectDecision{Allowed: true, HasPolicy: false}
+	}
+	store.mu.RLock()
+	policy, ok := store.sessions[sessionID]
+	store.mu.RUnlock()
+	if !ok {
+		return SeccompConnectDecision{Allowed: true, HasPolicy: false}
+	}
+
+	matched := false
+	switch policy.action {
+	case BpfActionAllow:
+		matched = true
+	case BpfActionDeny:
+		matched = false
+	case BpfActionAllowlist:
+		for _, ipNet := range policy.allow {
+			if ip != nil && ipNet.Contains(ip) {
+				matched = true
+				break
+			}
+		}
+	default:
+		matched = false
+	}
+
+	allowed := matched || policy.enforceMode != BpfEnforceModeEnforce
+	return SeccompConnectDecision{
+		Action:      policy.action,
+		EnforceMode: policy.enforceMode,
+		HasPolicy:   true,
+		Matched:     matched,
+		Allowed:     allowed,
+	}
+}
+
+// parseSeccompNetAllowEntry mirrors netLpmKey's CIDR-or-bare-IP acceptance in
+// bpf_policy_apply.go, so the same net_allow list produces the same matching
+// behavior on either tier.
+func parseSeccompNetAllowEntry(cidr string) (*net.IPNet, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err == nil {
+		return ipNet, nil
+	}
+	ip := net.ParseIP(cidr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid CIDR/IP %q: %w", cidr, err)
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}, nil
+	}
+	return &net.IPNet{IP: ip.To16(), Mask: net.CIDRMask(128, 128)}, nil
+}

--- a/go/pkg/kernelcapture/seccomp_policy_test.go
+++ b/go/pkg/kernelcapture/seccomp_policy_test.go
@@ -1,0 +1,249 @@
+package kernelcapture
+
+// seccomp_policy_test.go — unit tests for SeccompPolicyStore
+// (seccomp_policy.go), the seccomp tier's in-memory OP_NET_CONNECT policy
+// store. Pure Go, no build tag, no kernel dependency.
+
+import (
+	"net"
+	"testing"
+)
+
+func netConnectRequest(sessionID string, action BpfAction, mode BpfEnforceMode, netAllow ...string) DaemonApplyPolicyRequest {
+	return DaemonApplyPolicyRequest{
+		SessionID: sessionID,
+		OpPolicies: []DaemonOpPolicy{
+			{Op: BpfOpNetConnect, Action: action, EnforceMode: mode},
+		},
+		NetAllow: netAllow,
+	}
+}
+
+func TestEvaluateSeccompConnect_NilStoreFailsOpen(t *testing.T) {
+	// A nil store means the seccomp tier was never wired up on this daemon
+	// build (see main.go: it's always non-nil in practice, this exercises
+	// the defensive branch directly) — matching HasPolicy=false's documented
+	// "this session doesn't opt into the tier" semantics, not a deny.
+	d := EvaluateSeccompConnect(nil, "any-session", net.ParseIP("1.2.3.4"))
+	if d.HasPolicy || !d.Allowed {
+		t.Errorf("nil store: got %+v, want HasPolicy=false, Allowed=true", d)
+	}
+}
+
+func TestApplySeccompPolicy_NilStoreErrors(t *testing.T) {
+	err := ApplySeccompPolicy(nil, "s1", netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce))
+	if err == nil {
+		t.Error("expected an error applying a policy to a nil store, got nil")
+	}
+}
+
+func TestRemoveSeccompPolicy_NilStoreIsSafeNoop(t *testing.T) {
+	RemoveSeccompPolicy(nil, "s1") // must not panic
+}
+
+func TestEvaluateSeccompConnect_NoPolicyForSessionAllowsByDefault(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	d := EvaluateSeccompConnect(store, "unknown-session", net.ParseIP("8.8.8.8"))
+	if d.HasPolicy {
+		t.Error("HasPolicy = true for a session with no applied policy")
+	}
+	if !d.Allowed {
+		t.Error("Allowed = false for a session with no applied policy, want true (opted out of this tier, not denied)")
+	}
+}
+
+func TestApplySeccompPolicy_AllowActionMatchesAnyIP(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("203.0.113.9"))
+	if !d.HasPolicy || !d.Matched || !d.Allowed {
+		t.Errorf("ACT_ALLOW: got %+v, want HasPolicy=Matched=Allowed=true", d)
+	}
+}
+
+func TestApplySeccompPolicy_DenyActionEnforceBlocks(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionDeny, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("203.0.113.9"))
+	if d.Matched {
+		t.Error("ACT_DENY: Matched = true, want false")
+	}
+	if d.Allowed {
+		t.Error("ACT_DENY under ENFORCE: Allowed = true, want false")
+	}
+}
+
+func TestApplySeccompPolicy_DenyActionPermissiveStillAllowsButUnmatched(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionDeny, BpfEnforceModePermissive)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("203.0.113.9"))
+	if d.Matched {
+		t.Error("ACT_DENY under PERMISSIVE: Matched = true, want false (still a would-be deny)")
+	}
+	if !d.Allowed {
+		t.Error("ACT_DENY under PERMISSIVE: Allowed = false, want true (log, don't block)")
+	}
+}
+
+func TestApplySeccompPolicy_AllowlistCIDRMatch(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	req := netConnectRequest("s1", BpfActionAllowlist, BpfEnforceModeEnforce, "10.0.0.0/8")
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	inside := EvaluateSeccompConnect(store, "s1", net.ParseIP("10.1.2.3"))
+	if !inside.Matched || !inside.Allowed {
+		t.Errorf("10.1.2.3 in 10.0.0.0/8: got %+v, want Matched=Allowed=true", inside)
+	}
+
+	outside := EvaluateSeccompConnect(store, "s1", net.ParseIP("11.1.2.3"))
+	if outside.Matched || outside.Allowed {
+		t.Errorf("11.1.2.3 outside 10.0.0.0/8: got %+v, want Matched=Allowed=false", outside)
+	}
+}
+
+func TestApplySeccompPolicy_AllowlistBareIPExactMatch(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	req := netConnectRequest("s1", BpfActionAllowlist, BpfEnforceModeEnforce, "1.2.3.4")
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.4")); !d.Matched {
+		t.Errorf("exact bare-IP match: got %+v, want Matched=true", d)
+	}
+	if d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.5")); d.Matched {
+		t.Errorf("adjacent IP against a bare-IP allow entry: got %+v, want Matched=false", d)
+	}
+}
+
+func TestApplySeccompPolicy_AllowlistIPv6CIDRMatch(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	req := netConnectRequest("s1", BpfActionAllowlist, BpfEnforceModeEnforce, "2001:db8::/32")
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	inside := EvaluateSeccompConnect(store, "s1", net.ParseIP("2001:db8::1"))
+	if !inside.Matched {
+		t.Errorf("2001:db8::1 in 2001:db8::/32: got %+v, want Matched=true", inside)
+	}
+	outside := EvaluateSeccompConnect(store, "s1", net.ParseIP("2001:db9::1"))
+	if outside.Matched {
+		t.Errorf("2001:db9::1 outside 2001:db8::/32: got %+v, want Matched=false", outside)
+	}
+}
+
+func TestApplySeccompPolicy_InvalidNetAllowEntryErrorsAndLeavesPriorPolicyIntact(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	// Install a good policy first...
+	good := netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)
+	if err := ApplySeccompPolicy(store, "s1", good); err != nil {
+		t.Fatalf("apply good policy: %v", err)
+	}
+
+	// ...then attempt to overwrite it with a request that has a malformed
+	// net_allow entry. The CIDR list is validated in full before any store
+	// write happens, so this must fail loudly without disturbing the
+	// existing policy — a partial/corrupt write here would be silent
+	// under-enforcement, exactly what this codebase's fail-loud convention
+	// (see the package header comment) exists to avoid.
+	bad := netConnectRequest("s1", BpfActionAllowlist, BpfEnforceModeEnforce, "not-a-cidr-or-ip")
+	if err := ApplySeccompPolicy(store, "s1", bad); err == nil {
+		t.Fatal("expected an error applying a policy with a malformed net_allow entry, got nil")
+	}
+
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.4"))
+	if !d.HasPolicy || !d.Matched {
+		t.Errorf("after a rejected apply, prior policy should still be in effect: got %+v", d)
+	}
+}
+
+func TestApplySeccompPolicy_NoNetConnectOpClearsPriorPolicy(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// A later apply_policy for the same session with no OP_NET_CONNECT rule
+	// at all (e.g. exec/file-only policy) must clear the seccomp tier's
+	// rule, not leave the stale one in effect.
+	execOnly := DaemonApplyPolicyRequest{
+		SessionID:  "s1",
+		OpPolicies: []DaemonOpPolicy{{Op: BpfOpExec, Action: BpfActionDeny, EnforceMode: BpfEnforceModeEnforce}},
+	}
+	if err := ApplySeccompPolicy(store, "s1", execOnly); err != nil {
+		t.Fatalf("apply exec-only policy: %v", err)
+	}
+
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.4"))
+	if d.HasPolicy {
+		t.Errorf("after clearing OP_NET_CONNECT, HasPolicy = true, want false: %+v", d)
+	}
+}
+
+func TestRemoveSeccompPolicy_ClearsSession(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	RemoveSeccompPolicy(store, "s1")
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.4"))
+	if d.HasPolicy {
+		t.Errorf("after RemoveSeccompPolicy, HasPolicy = true, want false: %+v", d)
+	}
+}
+
+func TestEvaluateSeccompConnect_UnknownActionFailsClosed(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	// Bypasses daemon_protocol.go's request validation deliberately, to
+	// exercise EvaluateSeccompConnect's own defensive default: an
+	// unrecognised action value must never resolve to a match.
+	req := netConnectRequest("s1", BpfAction(99), BpfEnforceModeEnforce)
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	d := EvaluateSeccompConnect(store, "s1", net.ParseIP("1.2.3.4"))
+	if d.Matched || d.Allowed {
+		t.Errorf("unknown action value: got %+v, want Matched=Allowed=false (fail closed)", d)
+	}
+}
+
+func TestEvaluateSeccompConnect_AllowlistWithNilIPNeverMatches(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	req := netConnectRequest("s1", BpfActionAllowlist, BpfEnforceModeEnforce, "0.0.0.0/0")
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	d := EvaluateSeccompConnect(store, "s1", nil)
+	if d.Matched || d.Allowed {
+		t.Errorf("nil target IP against an allowlist: got %+v, want Matched=Allowed=false", d)
+	}
+}
+
+func TestSeccompPolicyStore_PerSessionIsolation(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	if err := ApplySeccompPolicy(store, "allow-session", netConnectRequest("allow-session", BpfActionAllow, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply allow-session: %v", err)
+	}
+	if err := ApplySeccompPolicy(store, "deny-session", netConnectRequest("deny-session", BpfActionDeny, BpfEnforceModeEnforce)); err != nil {
+		t.Fatalf("apply deny-session: %v", err)
+	}
+
+	if d := EvaluateSeccompConnect(store, "allow-session", net.ParseIP("1.2.3.4")); !d.Allowed {
+		t.Errorf("allow-session: got %+v, want Allowed=true", d)
+	}
+	if d := EvaluateSeccompConnect(store, "deny-session", net.ParseIP("1.2.3.4")); d.Allowed {
+		t.Errorf("deny-session: got %+v, want Allowed=false", d)
+	}
+	if d := EvaluateSeccompConnect(store, "no-such-session", net.ParseIP("1.2.3.4")); d.HasPolicy {
+		t.Errorf("no-such-session: got %+v, want HasPolicy=false", d)
+	}
+}

--- a/go/pkg/kernelcapture/seccomp_sockaddr.go
+++ b/go/pkg/kernelcapture/seccomp_sockaddr.go
@@ -1,0 +1,75 @@
+package kernelcapture
+
+// seccomp_sockaddr.go — connect(2) sockaddr decoding for the seccomp
+// user-notify enforcement tier (Epic A #63, plan E4).
+//
+// Pure Go, no build tag: decoding a byte slice already read from the target
+// process's memory has no kernel/syscall dependency, so this is testable on
+// darwin/CI with synthetic buffers, the same way bpf_policy_apply.go's key
+// serialization helpers are. The privileged part — actually reading those
+// bytes out of another process's address space, and doing so safely under
+// the seccomp-notify TOCTOU constraints — lives in seccomp_notify_linux.go.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// Linux sa_family_t values this tier resolves. Matches <linux/socket.h>.
+const (
+	linuxAFInet  = 2
+	linuxAFInet6 = 10
+)
+
+// Linux struct sockaddr_in / sockaddr_in6 sizes (bytes). Both are fixed,
+// stable UAPI layouts — see the identical rationale in
+// process_guard.bpf.c's guard_socket_connect for the BPF-LSM tier, which
+// decodes the same wire shapes via raw offsets for the same reason.
+const (
+	sockaddrInLen  = 16
+	sockaddrIn6Len = 28
+)
+
+// ParseConnectSockaddr decodes the raw bytes of a struct sockaddr passed as
+// connect(2)'s second argument into an IP address and port.
+//
+// raw must be at least as long as the family-specific struct — a short read
+// is rejected rather than zero-padded. Silently treating a truncated read as
+// "the rest is zero" would let a read failure masquerade as a specific (and
+// wrong) address, which could then spuriously match — or spuriously miss —
+// an allowlist entry. The caller (seccomp_notify_linux.go) is expected to
+// fail the connect closed on any error from here, not fall back to a default
+// address.
+//
+// sa_family is native-endian (it's a kernel ABI field read in the same
+// process's byte order by definition, unlike sin_port/sin_addr which are
+// always network byte order per BSD sockets convention regardless of host
+// endianness).
+func ParseConnectSockaddr(raw []byte) (net.IP, uint16, error) {
+	if len(raw) < 2 {
+		return nil, 0, fmt.Errorf("kernelcapture: sockaddr too short to read sa_family: %d byte(s)", len(raw))
+	}
+	family := binary.NativeEndian.Uint16(raw[0:2])
+	switch family {
+	case linuxAFInet:
+		if len(raw) < sockaddrInLen {
+			return nil, 0, fmt.Errorf("kernelcapture: sockaddr_in too short: %d byte(s), want %d", len(raw), sockaddrInLen)
+		}
+		port := binary.BigEndian.Uint16(raw[2:4])
+		ip := net.IPv4(raw[4], raw[5], raw[6], raw[7])
+		return ip, port, nil
+	case linuxAFInet6:
+		if len(raw) < sockaddrIn6Len {
+			return nil, 0, fmt.Errorf("kernelcapture: sockaddr_in6 too short: %d byte(s), want %d", len(raw), sockaddrIn6Len)
+		}
+		port := binary.BigEndian.Uint16(raw[2:4])
+		// sin6_family(2) + sin6_port(2) + sin6_flowinfo(4) = offset 8.
+		ip := make(net.IP, net.IPv6len)
+		copy(ip, raw[8:8+net.IPv6len])
+		return ip, port, nil
+	default:
+		return nil, 0, fmt.Errorf("kernelcapture: unsupported sockaddr family %d (only AF_INET=%d and AF_INET6=%d are policy-evaluable; connect(2) to any other address family is denied by the caller, not allowed by default)",
+			family, linuxAFInet, linuxAFInet6)
+	}
+}

--- a/go/pkg/kernelcapture/seccomp_sockaddr_test.go
+++ b/go/pkg/kernelcapture/seccomp_sockaddr_test.go
@@ -1,0 +1,137 @@
+package kernelcapture
+
+// seccomp_sockaddr_test.go — unit tests for ParseConnectSockaddr
+// (seccomp_sockaddr.go), the seccomp tier's connect(2) sockaddr decoder.
+// Pure Go, no build tag, no kernel dependency: these exercise the decoder
+// against synthetic byte buffers shaped like what ReadTargetSockaddr
+// (seccomp_notify_linux.go, Linux-only) hands it at runtime.
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func buildSockaddrIn(family, port uint16, ip [4]byte) []byte {
+	buf := make([]byte, sockaddrInLen)
+	binary.NativeEndian.PutUint16(buf[0:2], family)
+	binary.BigEndian.PutUint16(buf[2:4], port)
+	copy(buf[4:8], ip[:])
+	return buf
+}
+
+func buildSockaddrIn6(family, port uint16, ip [16]byte) []byte {
+	buf := make([]byte, sockaddrIn6Len)
+	binary.NativeEndian.PutUint16(buf[0:2], family)
+	binary.BigEndian.PutUint16(buf[2:4], port)
+	copy(buf[8:8+16], ip[:])
+	return buf
+}
+
+func TestParseConnectSockaddr_IPv4(t *testing.T) {
+	raw := buildSockaddrIn(linuxAFInet, 443, [4]byte{93, 184, 216, 34})
+	ip, port, err := ParseConnectSockaddr(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != 443 {
+		t.Errorf("port = %d, want 443", port)
+	}
+	want := net.IPv4(93, 184, 216, 34)
+	if !ip.Equal(want) {
+		t.Errorf("ip = %v, want %v", ip, want)
+	}
+}
+
+func TestParseConnectSockaddr_IPv4ExactLengthBoundary(t *testing.T) {
+	raw := buildSockaddrIn(linuxAFInet, 80, [4]byte{10, 0, 0, 1})
+	if len(raw) != sockaddrInLen {
+		t.Fatalf("test setup: raw len = %d, want exactly %d", len(raw), sockaddrInLen)
+	}
+	if _, _, err := ParseConnectSockaddr(raw); err != nil {
+		t.Errorf("exact-length sockaddr_in rejected: %v", err)
+	}
+}
+
+func TestParseConnectSockaddr_IPv6(t *testing.T) {
+	var addr [16]byte
+	addr[0], addr[1] = 0x20, 0x01 // 2001:db8::1
+	addr[2], addr[3] = 0x0d, 0xb8
+	addr[15] = 0x01
+	raw := buildSockaddrIn6(linuxAFInet6, 8443, addr)
+	ip, port, err := ParseConnectSockaddr(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != 8443 {
+		t.Errorf("port = %d, want 8443", port)
+	}
+	want := net.IP(addr[:])
+	if !ip.Equal(want) {
+		t.Errorf("ip = %v, want %v", ip, want)
+	}
+}
+
+func TestParseConnectSockaddr_IPv6TrailingBytesIgnored(t *testing.T) {
+	var addr [16]byte
+	addr[15] = 0x7f
+	raw := buildSockaddrIn6(linuxAFInet6, 1234, addr)
+	// sockaddr_in6 in the real UAPI carries a trailing sin6_scope_id (4
+	// bytes) this decoder doesn't need; a longer-than-minimum buffer must
+	// still parse cleanly rather than being rejected as malformed.
+	raw = append(raw, 0, 0, 0, 0)
+	ip, port, err := ParseConnectSockaddr(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != 1234 || !ip.Equal(net.IP(addr[:])) {
+		t.Errorf("ip/port = %v/%d, want %v/1234", ip, port, net.IP(addr[:]))
+	}
+}
+
+func TestParseConnectSockaddr_TooShortForFamily(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		if _, _, err := ParseConnectSockaddr(make([]byte, n)); err == nil {
+			t.Errorf("len=%d: expected error reading sa_family from a too-short buffer, got nil", n)
+		}
+	}
+}
+
+func TestParseConnectSockaddr_TruncatedIPv4Rejected(t *testing.T) {
+	full := buildSockaddrIn(linuxAFInet, 443, [4]byte{1, 2, 3, 4})
+	for n := 2; n < sockaddrInLen; n++ {
+		if _, _, err := ParseConnectSockaddr(full[:n]); err == nil {
+			t.Errorf("len=%d: expected truncated sockaddr_in to be rejected, got nil error", n)
+		}
+	}
+}
+
+func TestParseConnectSockaddr_TruncatedIPv6Rejected(t *testing.T) {
+	var addr [16]byte
+	full := buildSockaddrIn6(linuxAFInet6, 443, addr)
+	for n := 2; n < sockaddrIn6Len; n++ {
+		if _, _, err := ParseConnectSockaddr(full[:n]); err == nil {
+			t.Errorf("len=%d: expected truncated sockaddr_in6 to be rejected, got nil error", n)
+		}
+	}
+}
+
+func TestParseConnectSockaddr_UnsupportedFamily(t *testing.T) {
+	const linuxAFUnix = 1
+	raw := buildSockaddrIn(linuxAFUnix, 0, [4]byte{})
+	if _, _, err := ParseConnectSockaddr(raw); err == nil {
+		t.Error("expected an error for an unsupported sa_family, got nil")
+	}
+}
+
+// TestParseConnectSockaddr_NeverZeroPadsShortReads guards the documented
+// "reject, don't zero-pad" contract: a short buffer must never be silently
+// treated as a valid (if wrong) address, since that could spuriously match —
+// or spuriously miss — an allowlist entry.
+func TestParseConnectSockaddr_NeverZeroPadsShortReads(t *testing.T) {
+	raw := buildSockaddrIn(linuxAFInet, 443, [4]byte{1, 2, 3, 4})[:sockaddrInLen-1]
+	ip, port, err := ParseConnectSockaddr(raw)
+	if err == nil {
+		t.Fatalf("expected error for a one-byte-short sockaddr_in, got ip=%v port=%d", ip, port)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **E4: the seccomp user-notify enforcement tier**, the common-case fallback for hosts where BPF-LSM never loads — stock distros ship `CONFIG_BPF_LSM=y` but don't put `bpf` in the boot `lsm=` list, so the BPF-LSM tier (#101, merged) silently isn't active. Part of Epic A (#63). Builds on the merged E1 (#101, privileged CI), E2 (#96, apply_policy wiring), and E3 (#100, enforce_events correlation hardening).

- **`ardur-exec-shim`** (new binary): installs a `connect(2)`-scoped `SECCOMP_RET_USER_NOTIF` filter, hands the notification listener fd to the daemon over a dedicated Unix socket via `SCM_RIGHTS`, then `execve()`s into the target — the filter (installed before exec, inherited across it) covers the whole process tree from there with no per-child re-registration.
- **Daemon supervisor** (`daemon_seccomp_linux.go`): services notifications using the *same* policy tables and `net_allow` CIDR matching as the BPF-LSM tier (`SeccompPolicyStore` mirrors `bpf_policy_apply.go`'s schema), re-validates the notification id via `SECCOMP_IOCTL_NOTIF_ID_VALID` both before and after each `/proc/pid/mem` read (the standard seccomp-notify TOCTOU mitigation), and fails closed (EPERM) on any ambiguous or error case — `SECCOMP_USER_NOTIF_FLAG_CONTINUE` is only ever set on a confirmed, policy-resolved ALLOW.
- **Tier selection**: the daemon attempts BPF-LSM at startup; if it doesn't load, it falls back to seccomp and advertises the active tier (`bpf_lsm` / `seccomp` / `none`) on health responses, so a launcher knows whether routing through `ardur-exec-shim` is necessary. `apply_policy` keeps the seccomp policy store in sync regardless of which tier is active, and reports genuine success (`applied_seccomp_tier`, not degraded) when the active tier fully covers the request.
- **Evidence pipeline**: `processEnforceEvent` now takes an explicit `tier` parameter (previously derived internally, always `bpf_lsm:*`) so seccomp-tier events are correctly labeled `seccomp:enforce`/`seccomp:permissive` in `TierCoverage`, sharing the same hash-chained receipt format.
- **Claim boundary, stated plainly, not left implicit**: seccomp user-notify is weaker than an in-kernel LSM against a racing multithreaded adversary — the supervisor's decision happens in a userspace round-trip, not synchronously in the syscalling thread. This is a real, load-bearing enforcement mechanism for single-threaded or cooperative targets (the overwhelming majority of AI-agent subprocess trees this project governs), documented in `seccomp_policy.go`'s header comment, not a theoretically-airtight guarantee against an adversarial multithreaded target.

## Two real bugs found only by kernel-in-loop verification

Neither pure-Go tests nor `go vet` could catch these — both were found by actually running the shim + daemon against a real kernel:

1. **Shim self-deadlock**: the shim's own `connect()` to the daemon's handoff socket was trapped by the filter it had *just* installed (seccomp intercepts by syscall number only, with no socket-family awareness) — since nothing was servicing that listener yet, the connect blocked forever. Fixed by dialing the handoff connection *before* installing the filter (see `ardur-exec-shim/main.go`'s `run()` comment).
2. **errno sign bug**: `SendSeccompNotifResp` wrote a positive `errno` (e.g. `unix.EPERM` = `+1`) into the kernel's `seccomp_notif_resp.error` field, which requires the raw syscall-return convention (`-errno`). A non-negative raw return is treated as *success* by the kernel — so a policy-denied `connect()` was silently let through with a nonsense return value instead of being blocked. Fixed by negating internally in `buildSeccompNotifResp`, with a regression test (`TestBuildSeccompNotifResp_NegatesErrno`) and a permanent kernel-in-loop smoke test (see below) guarding it going forward.

## Testing

- **Pure-Go / cross-platform**: `seccomp_sockaddr_test.go`, `seccomp_policy_test.go` — sockaddr decoding, policy store semantics (ALLOW/DENY/ALLOWLIST, CIDR + bare-IP matching, enforce vs permissive, fail-closed on unknown action, nil-store handling), tier-refactor coverage in `daemon_enforce_test.go`/`daemon_apply_policy_test.go`.
- **Linux-only, no kernel required**: `seccomp_notify_linux_test.go` — ioctl number pinning against known runc/containerd values, `sock_fprog` kernel-ABI layout, and a small classic-BPF interpreter that runs the *actual* assembled filter program against synthetic `seccomp_data` to prove its three-way decision logic (arch mismatch → kill, matching arch + wrong nr → allow, matching arch + connect's nr → user-notify).
- **Real kernel, both platforms confirmed green**: `go build`/`go vet`/`go test -race ./...` pass on darwin and Linux (verified in a Docker container matching an unprivileged CI runner — no `--privileged`, no extra capabilities, `CONFIG_BPF_LSM` present but `bpf` not in the active LSM list, exactly the scenario this tier targets).
- **New CI job** (`seccomp-smoke` in `kernel-enforce.yml`): runs `ardur-seccomp-smoke`, a permanent kernel-in-loop harness that starts a real daemon (BPF-LSM unavailable → seccomp fallback engages), runs the real shim against a real target process, and asserts a policy-denied `connect(2)` gets `EPERM` while a policy-allowed one reaches the kernel's real connect handling (observed as `ECONNREFUSED`, proving the syscall wasn't blocked). Unlike `kernel-smoke` (BPF-LSM tier), this needs **no KVM/virtme-ng custom kernel boot** — confirmed empirically that `seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_NEW_LISTENER, ...)` works under an ordinary `PR_SET_NO_NEW_PRIVS`-only process, so it runs on a plain `ubuntu-24.04` runner. Set as a required check (not soft-gated like `kernel-smoke`) since it needs no unproven VM-boot machinery.

## Honest gaps / what's not in this PR

- The **CI job itself has not yet run on an actual GitHub-hosted runner** — it's manually verified end-to-end in a local Docker container configured to match those conditions (unprivileged, no BPF-LSM), but the first real CI run on this PR is the true confirmation that GitHub's runner environment behaves the same way.
- Exec/file-open enforcement is **out of scope** for this tier by design (documented in `seccomp_policy.go`) — a seccomp filter can trap `execve`, but by the time a `SECCOMP_RET_USER_NOTIF` notification is serviced the new program image hasn't loaded yet, and `SECCOMP_USER_NOTIF_FLAG_CONTINUE` for execve carries TOCTOU hazards beyond what connect's fixed-size sockaddr argument has. BPF-LSM remains the only tier that governs exec and file ops.
- No `ardur run` / launcher-side wiring to actually invoke `ardur-exec-shim` based on the daemon's advertised tier — that's launcher-side follow-on work, not part of this daemon/shim-side PR.

Ref: #63