### PR TITLE
fix(run): default --max-tool-calls so `ardur run` doesn't crash (int(None) TypeError)

### DIFF
--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -26,6 +26,8 @@ from vibap.attestation import verify_attestation
 from vibap.passport import load_public_key
 from vibap.receipt import verify_chain
 from vibap.run_bridge import (
+    DEFAULT_MAX_DURATION_S,
+    DEFAULT_MAX_TOOL_CALLS,
     ClaudeCodeAdapter,
     EnvProxyAdapter,
     KernelPolicyEnforcementError,
@@ -537,6 +539,55 @@ class TestKernelEnforcementClaim:
             shutil.rmtree(sock_dir, ignore_errors=True)
 
         assert result is None
+
+
+@pytest.mark.parametrize("unset_field", ["max_tool_calls", "max_duration_s"])
+def test_run_governed_cli_coerces_unset_numeric_budgets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, unset_field: str
+) -> None:
+    """A plain `ardur run` (no --max-tool-calls / --max-duration-s) must not crash.
+
+    The `run` subparser defaults these to None so an explicit 0 is
+    distinguishable from "unset"; run_governed_cli must coerce None to the
+    documented default rather than calling ``int(None)`` (which raised
+    TypeError before the fix, aborting every default-flag `ardur run`).
+    """
+    captured: dict[str, object] = {}
+
+    class _Stop(Exception):
+        pass
+
+    def fake_run_governed(**kwargs: object) -> None:
+        captured.update(kwargs)
+        raise _Stop
+
+    monkeypatch.setattr("vibap.run_bridge.run_governed", fake_run_governed)
+
+    fields = {"max_tool_calls": 7, "max_duration_s": 123}
+    fields[unset_field] = None  # simulate the argparse default for the run subparser
+
+    with pytest.raises(_Stop):
+        run_governed_cli(
+            Namespace(
+                command=["--", "true"],
+                mission="budget coercion smoke",
+                allowed_tools=["Read"],
+                forbidden_tools=None,
+                home=tmp_path / "h",
+                via="env",
+                no_kernel_correlation=True,
+                enforce=False,
+                **fields,
+            )
+        )
+
+    # The unset field falls back to its module default; the other is passed through.
+    assert captured["max_tool_calls"] == (
+        DEFAULT_MAX_TOOL_CALLS if unset_field == "max_tool_calls" else 7
+    )
+    assert captured["max_duration_s"] == (
+        DEFAULT_MAX_DURATION_S if unset_field == "max_duration_s" else 123
+    )
 
 
 @pytest.mark.parametrize("command", ([], ["--"]))

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -878,14 +878,22 @@ def run_governed_cli(args: Any) -> int:
 
     allowed = _split_csv(getattr(args, "allowed_tools", None))
     forbidden = _split_csv(getattr(args, "forbidden_tools", None))
+    # The `run` subparser defaults --max-tool-calls to None (so an explicit 0 is
+    # distinguishable from "unset"), which means the attribute exists as None and
+    # getattr's fallback never fires. Coerce None to the default here rather than
+    # letting int(None) raise TypeError — otherwise a plain `ardur run` with no
+    # --max-tool-calls crashes before the run even starts. Same guard for
+    # --max-duration-s for symmetry.
+    max_tool_calls_arg = getattr(args, "max_tool_calls", None)
+    max_duration_s_arg = getattr(args, "max_duration_s", None)
     try:
         result = run_governed(
             command=command,
             mission=getattr(args, "mission", None),
             allowed_tools=allowed,
             forbidden_tools=forbidden,
-            max_tool_calls=int(getattr(args, "max_tool_calls", DEFAULT_MAX_TOOL_CALLS)),
-            max_duration_s=int(getattr(args, "max_duration_s", DEFAULT_MAX_DURATION_S)),
+            max_tool_calls=DEFAULT_MAX_TOOL_CALLS if max_tool_calls_arg is None else int(max_tool_calls_arg),
+            max_duration_s=DEFAULT_MAX_DURATION_S if max_duration_s_arg is None else int(max_duration_s_arg),
             home=getattr(args, "home", None),
             via=getattr(args, "via", None) or "auto",
             enable_kernel_correlation=not getattr(args, "no_kernel_correlation", False),


### PR DESCRIPTION
## Summary

`ardur run` crashes with a `TypeError` whenever `--max-tool-calls` is **not** passed — i.e. the documented default usage:

```
$ ardur run --mission "…" --forbidden-tools Bash --enforce -- python3 agent.py
Traceback (most recent call last):
  ...
  File ".../vibap/run_bridge.py", line 887, in run_governed_cli
    max_tool_calls=int(getattr(args, "max_tool_calls", DEFAULT_MAX_TOOL_CALLS)),
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

### Root cause

The `run` subparser sets `--max-tool-calls` `default=None` (so an explicit `0` is distinguishable from "unset"). `run_governed_cli` then did:

```python
max_tool_calls=int(getattr(args, "max_tool_calls", DEFAULT_MAX_TOOL_CALLS)),
```

Because the attribute **exists** (as `None`), `getattr`'s fallback never fires, so this is `int(None)` → `TypeError`. The run aborts before it starts. The help text even promises "(default 250 when governing)".

### Fix

Coerce `None` → module default at the call site (same guard applied to `--max-duration-s` for symmetry; it isn't buggy today only because its argparse default happens to be non-`None`).

### Why the existing tests missed it

The per-PR tests (`#96`) call `run_governed(...)` directly with an explicit `max_tool_calls=…`, never the argparse → `run_governed_cli` path with the flag omitted. This adds a regression test that drives `run_governed_cli` with each numeric budget unset and asserts it falls back to the default instead of raising.

### Verification

- New test **fails** on `origin/dev` (reproduces the `TypeError`) and **passes** with the fix.
- `python -m pytest tests/test_run_bridge.py` → **23 passed**.
- `ruff check` clean.
- Found while standing up a real end-to-end `ardur run --enforce` BPF-LSM smoke (privileged Linux); with this fix the plain command runs and the kernel denies the forbidden exec with `EPERM`.
