### PR TITLE
fix(enforce): close enforcement-surface authz + stale-policy findings (#108/#109/#110)

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_apply_policy_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_apply_policy_test.go
@@ -20,11 +20,20 @@ import (
 // registry's authorized-request path (mirrors
 // daemonSessionRegistryTestHandshake in the kernelcapture package's own
 // tests) so handleApplyPolicy's d.registry.ActiveSession lookup succeeds.
-func registerTestSession(t *testing.T, d *daemon, sessionID string, cgroupID uint64) {
-	t.Helper()
-	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+// testPeerHandshake returns a valid allow-verdict handshake for a fixed test
+// peer (uid 501). registerTestSession and the apply_policy call sites use the
+// SAME peer identity so the ownership gate handleApplyPolicy now enforces
+// (session must be owned by the calling peer) is satisfied on the happy path.
+// Use testPeerHandshakeUID with uid=0 to exercise the admin identity
+// set_kill_switch requires, or a different uid/pid to simulate a foreign peer.
+func testPeerHandshake(sessionID, method string) kernelcapture.DaemonProtocolPeerHandshake {
+	return testPeerHandshakeUID(sessionID, method, 501)
+}
+
+func testPeerHandshakeUID(sessionID, method string, uid uint32) kernelcapture.DaemonProtocolPeerHandshake {
+	return kernelcapture.DaemonProtocolPeerHandshake{
 		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
-		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		Method:                method,
 		SessionID:             sessionID,
 		SocketPath:            "/run/ardur/kernelcapture/control.sock",
 		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
@@ -32,13 +41,18 @@ func registerTestSession(t *testing.T, d *daemon, sessionID string, cgroupID uin
 		Authorization: kernelcapture.DaemonPeerAuthorization{
 			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
 			Reason:                "test",
-			UID:                   501,
+			UID:                   uid,
 			GID:                   20,
 			PID:                   4321,
 			ProcessStartTimeTicks: 900001,
 			Matched:               "uid",
 		},
 	}
+}
+
+func registerTestSession(t *testing.T, d *daemon, sessionID string, cgroupID uint64) {
+	t.Helper()
+	handshake := testPeerHandshake(sessionID, kernelcapture.DaemonProtocolMethodRegisterSession)
 	req := kernelcapture.DaemonProtocolRequest{
 		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
 		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
@@ -82,7 +96,7 @@ func TestHandleApplyPolicy_EnforceStrictFailsLoudlyWithoutGuard(t *testing.T) {
 	d := newTestDaemon(t)
 	registerTestSession(t, d, "ses-strict", 111)
 
-	resp := d.handleApplyPolicy(applyPolicyReqFor("ses-strict", kernelcapture.BpfEnforceModeEnforce))
+	resp := d.handleApplyPolicy(applyPolicyReqFor("ses-strict", kernelcapture.BpfEnforceModeEnforce), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if resp.OK {
 		t.Fatalf("apply_policy under ENFORCE with no guard loaded: OK = true, want false (must fail loudly): %+v", resp)
 	}
@@ -100,7 +114,7 @@ func TestHandleApplyPolicy_PermissiveDegradesWithoutFailingRequest(t *testing.T)
 	d := newTestDaemon(t)
 	registerTestSession(t, d, "ses-permissive", 112)
 
-	resp := d.handleApplyPolicy(applyPolicyReqFor("ses-permissive", kernelcapture.BpfEnforceModePermissive))
+	resp := d.handleApplyPolicy(applyPolicyReqFor("ses-permissive", kernelcapture.BpfEnforceModePermissive), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if !resp.OK {
 		t.Fatalf("apply_policy under PERMISSIVE with no guard loaded: OK = false, want true (degrade, don't block): %+v", resp)
 	}
@@ -112,7 +126,7 @@ func TestHandleApplyPolicy_PermissiveDegradesWithoutFailingRequest(t *testing.T)
 func TestHandleApplyPolicy_UnknownSessionFailsCleanly(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
-	resp := d.handleApplyPolicy(applyPolicyReqFor("does-not-exist", kernelcapture.BpfEnforceModeEnforce))
+	resp := d.handleApplyPolicy(applyPolicyReqFor("does-not-exist", kernelcapture.BpfEnforceModeEnforce), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if resp.OK {
 		t.Fatal("apply_policy for an unregistered session: OK = true, want false")
 	}
@@ -147,7 +161,7 @@ func TestHandleApplyPolicy_SyncsSeccompStoreEvenWhenBPFTierHardFails(t *testing.
 	d := newTestDaemon(t)
 	registerTestSession(t, d, "ses-net-enforce", 113)
 
-	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-enforce", kernelcapture.BpfActionAllow, kernelcapture.BpfEnforceModeEnforce))
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-enforce", kernelcapture.BpfActionAllow, kernelcapture.BpfEnforceModeEnforce), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if resp.OK {
 		t.Fatalf("apply_policy under ENFORCE with no active tier: OK = true, want false: %+v", resp)
 	}
@@ -170,7 +184,7 @@ func TestHandleApplyPolicy_AppliesViaSeccompTierWhenActive(t *testing.T) {
 	d.activeTier = daemonTierSeccomp
 	registerTestSession(t, d, "ses-net-seccomp", 114)
 
-	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-seccomp", kernelcapture.BpfActionDeny, kernelcapture.BpfEnforceModeEnforce))
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-net-seccomp", kernelcapture.BpfActionDeny, kernelcapture.BpfEnforceModeEnforce), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if !resp.OK {
 		t.Fatalf("apply_policy under ENFORCE with active seccomp tier: OK = false, want true: %+v", resp)
 	}
@@ -209,7 +223,7 @@ func TestHandleApplyPolicy_SeccompTierDoesNotCoverNonNetOps(t *testing.T) {
 		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
 		ApplyPolicy:     ap,
 	}
-	resp := d.handleApplyPolicy(req)
+	resp := d.handleApplyPolicy(req, testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if resp.OK {
 		t.Fatalf("apply_policy mixing OP_EXEC into a seccomp-tier-only host: OK = true, want false: %+v", resp)
 	}
@@ -220,7 +234,7 @@ func TestHandleApplyPolicy_InvalidNetAllowFailsBeforeAnyStoreWrite(t *testing.T)
 	d := newTestDaemon(t)
 	registerTestSession(t, d, "ses-bad-cidr", 116)
 
-	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-bad-cidr", kernelcapture.BpfActionAllowlist, kernelcapture.BpfEnforceModePermissive, "not-a-cidr"))
+	resp := d.handleApplyPolicy(applyNetConnectPolicyReqFor("ses-bad-cidr", kernelcapture.BpfActionAllowlist, kernelcapture.BpfEnforceModePermissive, "not-a-cidr"), testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy))
 	if resp.OK {
 		t.Fatalf("apply_policy with a malformed net_allow entry: OK = true, want false: %+v", resp)
 	}
@@ -240,7 +254,7 @@ func TestHandleSetKillSwitch_FailsCleanlyWithoutGuard(t *testing.T) {
 		Method:          kernelcapture.DaemonProtocolMethodSetKillSwitch,
 		SetKillSwitch:   &kernelcapture.DaemonSetKillSwitchRequest{Engaged: true},
 	}
-	resp := d.handleSetKillSwitch(req)
+	resp := d.handleSetKillSwitch(req, testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 0))
 	if resp.OK {
 		t.Fatalf("set_kill_switch with no guard loaded: OK = true, want false: %+v", resp)
 	}

--- a/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
@@ -1,0 +1,181 @@
+package main
+
+// daemon_authz_test.go — regression tests for the enforcement-surface security
+// fixes: per-session ownership on apply_policy + admin-only set_kill_switch
+// (missing-authorization finding), allowlist revocation on re-apply / session
+// end (stale-policy-state finding), and serialized policy-map mutation
+// (double-buffer race finding).
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// countingPolicyMap is a minimal policyMapReadWriter that records how many
+// Put/Delete calls it received. Lookup always reports "not found" so
+// nextPolicySlot falls back to slot 0 (slot mechanics are covered elsewhere).
+// Its counters are plain ints on purpose: with the daemon's applyMu absent,
+// concurrent apply_policy would write them unsynchronized and `go test -race`
+// would flag it — making the concurrency test non-vacuous.
+type countingPolicyMap struct {
+	puts    int
+	deletes int
+}
+
+var errCountingNotFound = errors.New("key does not exist")
+
+func (m *countingPolicyMap) Put(_, _ interface{}) error    { m.puts++; return nil }
+func (m *countingPolicyMap) Delete(_ interface{}) error    { m.deletes++; return nil }
+func (m *countingPolicyMap) Lookup(_, _ interface{}) error { return errCountingNotFound }
+
+func countingPolicyMaps() (kernelcapture.PolicyMaps, map[string]*countingPolicyMap) {
+	op := &countingPolicyMap{}
+	path := &countingPolicyMap{}
+	file := &countingPolicyMap{}
+	net := &countingPolicyMap{}
+	managed := &countingPolicyMap{}
+	kill := &countingPolicyMap{}
+	return kernelcapture.PolicyMaps{
+		CgroupOpPolicy:  op,
+		CgroupPathAllow: path,
+		CgroupFileAllow: file,
+		CgroupNetAllow:  net,
+		CgroupManaged:   managed,
+		KillSwitch:      kill,
+	}, map[string]*countingPolicyMap{"op": op, "path": path, "file": file, "net": net, "managed": managed, "kill": kill}
+}
+
+// --- #108: apply_policy ownership --------------------------------------------
+
+func TestHandleApplyPolicy_ForeignPeerRejected(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	registerTestSession(t, d, "ses-owned", 4200) // registered by the uid-501/pid-4321 peer
+
+	// A DIFFERENT peer (same uid, different pid+start-time) must be rejected.
+	foreign := testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodApplyPolicy, 501)
+	foreign.Authorization.PID = 9999
+	foreign.ProcessStartTimeTicks = 123456
+	foreign.Authorization.ProcessStartTimeTicks = 123456
+
+	resp := d.handleApplyPolicy(applyPolicyReqFor("ses-owned", kernelcapture.BpfEnforceModePermissive), foreign)
+	if resp.OK {
+		t.Fatalf("foreign peer apply_policy: OK = true, want false (must be rejected): %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "owned by a different peer") {
+		t.Fatalf("foreign peer apply_policy: error = %q, want it to name the ownership failure", resp.Error)
+	}
+
+	// The OWNING peer is not rejected for ownership (it degrades on the missing
+	// guard instead — a different, non-ownership outcome).
+	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
+	respOwner := d.handleApplyPolicy(applyPolicyReqFor("ses-owned", kernelcapture.BpfEnforceModePermissive), owner)
+	if strings.Contains(respOwner.Error, "owned by a different peer") {
+		t.Fatalf("owning peer apply_policy was wrongly rejected for ownership: %+v", respOwner)
+	}
+}
+
+// --- #108: set_kill_switch admin-only ----------------------------------------
+
+func TestHandleSetKillSwitch_RequiresRootAdmin(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodSetKillSwitch,
+		SetKillSwitch:   &kernelcapture.DaemonSetKillSwitchRequest{Engaged: true},
+	}
+	// Non-root allowed peer: rejected on the admin gate, before touching maps.
+	nonRoot := d.handleSetKillSwitch(req, testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 501))
+	if nonRoot.OK || !strings.Contains(nonRoot.Error, "admin") {
+		t.Fatalf("non-root set_kill_switch: want OK=false with an admin error, got %+v", nonRoot)
+	}
+	// Root peer passes the admin gate (then fails on the absent guard — NOT the
+	// admin error), proving the gate is what blocks the non-root caller.
+	root := d.handleSetKillSwitch(req, testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 0))
+	if strings.Contains(root.Error, "admin") {
+		t.Fatalf("root set_kill_switch was wrongly blocked by the admin gate: %+v", root)
+	}
+}
+
+// --- #109: allowlist revocation on re-apply / session end --------------------
+
+func TestHandleApplyPolicy_ReapplyRevokesDroppedAllowlist(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	maps, h := countingPolicyMaps()
+	d.policyMaps = maps
+	registerTestSession(t, d, "ses-prune", 5500)
+	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
+
+	apply := func(gen kernelcapture.BpfPolicyGeneration, paths []string) {
+		ap := &kernelcapture.DaemonApplyPolicyRequest{
+			SessionID: "ses-prune", Generation: gen, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{{Op: kernelcapture.BpfOpFileRead, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce}},
+			PathAllow:  paths,
+		}
+		resp := d.handleApplyPolicy(kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+			ApplyPolicy:     ap,
+		}, owner)
+		if !resp.OK {
+			t.Fatalf("apply gen %d: %+v", gen, resp)
+		}
+	}
+
+	apply(1, []string{"/tmp/a", "/tmp/b"})
+	before := h["file"].deletes
+	apply(2, []string{"/tmp/a"}) // drops /tmp/b
+	if got := h["file"].deletes - before; got != 1 {
+		t.Fatalf("re-apply dropping /tmp/b: file-allow deletes = %d, want 1 (the dropped entry must be revoked)", got)
+	}
+
+	// Session end must release the remaining allowlist entry too.
+	endDeletes := h["file"].deletes
+	d.onSessionEnded("ses-prune")
+	if h["file"].deletes <= endDeletes {
+		t.Fatalf("session end: file-allow deletes did not increase (remaining allowlist entry not released)")
+	}
+}
+
+// --- #110: concurrent apply_policy is serialized -----------------------------
+
+func TestHandleApplyPolicy_ConcurrentAppliesSerialized(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	maps, h := countingPolicyMaps()
+	d.policyMaps = maps
+	registerTestSession(t, d, "ses-conc", 6600)
+	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
+
+	const n = 32
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(gen kernelcapture.BpfPolicyGeneration) {
+			defer wg.Done()
+			ap := &kernelcapture.DaemonApplyPolicyRequest{
+				SessionID: "ses-conc", Generation: gen, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+				OpPolicies: []kernelcapture.DaemonOpPolicy{{Op: kernelcapture.BpfOpExec, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce}},
+			}
+			d.handleApplyPolicy(kernelcapture.DaemonProtocolRequest{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+				ApplyPolicy:     ap,
+			}, owner)
+		}(kernelcapture.BpfPolicyGeneration(i + 1))
+	}
+	wg.Wait()
+
+	// Each apply writes cgroup_managed exactly once. Under applyMu the counter
+	// increments are serialized, so all n land; a missing applyMu would race
+	// (caught by -race) and could also lose increments.
+	if h["managed"].puts != n {
+		t.Fatalf("cgroup_managed puts = %d, want %d — concurrent applies were not serialized", h["managed"].puts, n)
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+package main
+
+// daemon_cgroup_verify_linux.go — register_session cgroup-ownership check.
+//
+// register_session binds a client-supplied cgroup_id (and root_pid) to a
+// session; apply_policy later writes BPF enforcement keyed by that cgroup_id.
+// Without a check, any authorized-UID peer could register a cgroup_id belonging
+// to another workload and then govern/tamper it. This closes that by requiring
+// root_pid to be a process the peer actually spawned.
+//
+// Why an ancestry check and NOT a literal "claimed cgroup_id == inode of
+// /proc/<peerPID>/cgroup" comparison: in the real `ardur run` flow the socket
+// peer (the launcher) does not enter the cgroup — it creates a cgroup and
+// adopts the *agent child* into it (run_bridge.py), so the peer's own cgroup
+// is not the registered one. Worse, cgroup namespaces make /proc/<pid>/cgroup
+// report a namespace-relative path (a governed agent commonly reads its own as
+// "0::/"), so the daemon cannot reliably resolve it back to the kernel cgroup
+// id the launcher derived via stat().st_ino across a namespace boundary — a
+// literal inode match there rejects the legitimate, end-to-end-verified flow.
+//
+// The ancestry check is namespace-robust (PID ancestry within the daemon's own
+// /proc view) and delivers the property that matters: a peer may only register
+// a session whose root_pid is a process it spawned. Since kernel enforcement
+// keys on each process's *actual* runtime cgroup and a peer can only name its
+// own descendants — which live in cgroups the peer itself controls — a peer
+// cannot bind a session to, and then govern, a cgroup it does not own.
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// maxCgroupAncestryHops bounds the /proc parent-chain walk so a pathological or
+// racing process table can never spin the handler. A launcher-spawned agent is
+// a direct child (1 hop); the generous bound tolerates intervening wrapper
+// processes without ever being unbounded.
+const maxCgroupAncestryHops = 64
+
+func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHandshake, reg *kernelcapture.DaemonRegisterSessionRequest, log *slog.Logger) error {
+	peerPID := handshake.Authorization.PID
+	rootPID := reg.RootPID
+	// register_session validation already requires root_pid != 0 and
+	// cgroup_id != 0; peerPID comes from SO_PEERCRED. If either is missing
+	// there is nothing to bind — let the registry's own validation speak.
+	if peerPID == 0 || rootPID == 0 {
+		return nil
+	}
+	// The peer registering its own process is trivially owned.
+	if rootPID == peerPID {
+		return nil
+	}
+	// Confirm the peer itself is visible in the daemon's /proc view. If it is
+	// not (an unusual cross-PID-namespace deployment where the daemon cannot
+	// see client PIDs at all), we cannot establish ancestry either way — skip
+	// rather than reject and break such a deployment, but say so loudly.
+	if _, err := os.Stat("/proc/" + strconv.FormatUint(uint64(peerPID), 10)); err != nil {
+		log.Warn("register_session cgroup ownership check skipped: peer pid not visible in /proc (cross-namespace daemon?)",
+			"peer_pid", peerPID, "root_pid", rootPID)
+		return nil
+	}
+	// Walk root_pid's parent chain; it must reach the registering peer.
+	cur := rootPID
+	for hops := 0; hops < maxCgroupAncestryHops; hops++ {
+		ppid, err := procParentPID(cur)
+		if err != nil {
+			return fmt.Errorf("root_pid %d is not a live process visible to the daemon (%v); a peer may only register a process it spawned", rootPID, err)
+		}
+		if ppid == peerPID {
+			return nil
+		}
+		if ppid == 0 || ppid == cur {
+			break
+		}
+		cur = ppid
+	}
+	return fmt.Errorf("root_pid %d is not a descendant of the registering peer pid %d; a peer may only register process trees it spawned", rootPID, peerPID)
+}
+
+// procParentPID reads the PPID (field 4) from /proc/<pid>/stat. The comm field
+// (field 2) is wrapped in parentheses and may itself contain spaces and ')',
+// so the stable parse is: take everything after the LAST ')'.
+func procParentPID(pid uint32) (uint32, error) {
+	data, err := os.ReadFile("/proc/" + strconv.FormatUint(uint64(pid), 10) + "/stat")
+	if err != nil {
+		return 0, err
+	}
+	s := string(data)
+	rparen := strings.LastIndexByte(s, ')')
+	if rparen < 0 || rparen+2 >= len(s) {
+		return 0, fmt.Errorf("malformed /proc/%d/stat", pid)
+	}
+	// After ") " come: state (field 3) ppid (field 4) ...
+	fields := strings.Fields(s[rparen+2:])
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("malformed /proc/%d/stat fields", pid)
+	}
+	ppid, err := strconv.ParseUint(fields[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse ppid from /proc/%d/stat: %w", pid, err)
+	}
+	return uint32(ppid), nil
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
@@ -56,6 +56,17 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if rootPID == peerPID {
 		return nil
 	}
+	// A root (uid 0) peer is already fully privileged on the host — it can move
+	// any process between cgroups directly, so this ancestry check adds nothing
+	// against it. The check exists to constrain a NON-root allowed peer (the
+	// sandboxed-workload threat) from binding a session to a process tree it did
+	// not spawn. Skipping root also lets tiers that register a placeholder
+	// root_pid (the seccomp tier enforces per-shim'd-process, not by cgroup, and
+	// its smoke registers root_pid=1) work when the daemon and client are root.
+	// Per-session ownership on apply_policy still applies to every peer.
+	if handshake.Authorization.UID == 0 {
+		return nil
+	}
 	// Confirm the peer itself is visible in the daemon's /proc view. If it is
 	// not (an unusual cross-PID-namespace deployment where the daemon cannot
 	// see client PIDs at all), we cannot establish ancestry either way — skip

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
@@ -15,9 +15,18 @@ func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// hsWithPID builds a NON-root peer handshake so the register-time ancestry
+// check actually runs (it is skipped for uid-0 peers, which are already fully
+// privileged — see verifyRegisterSessionCgroup).
 func hsWithPID(pid uint32) kernelcapture.DaemonProtocolPeerHandshake {
 	return kernelcapture.DaemonProtocolPeerHandshake{
-		Authorization: kernelcapture.DaemonPeerAuthorization{PID: pid},
+		Authorization: kernelcapture.DaemonPeerAuthorization{PID: pid, UID: 501},
+	}
+}
+
+func hsRootWithPID(pid uint32) kernelcapture.DaemonProtocolPeerHandshake {
+	return kernelcapture.DaemonProtocolPeerHandshake{
+		Authorization: kernelcapture.DaemonPeerAuthorization{PID: pid, UID: 0},
 	}
 }
 
@@ -65,5 +74,13 @@ func TestVerifyRegisterSessionCgroup_PeerNotVisibleSkips(t *testing.T) {
 	// ancestry can't be established either way — skip rather than break.
 	if err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger()); err != nil {
 		t.Fatalf("unresolvable peer should skip the check, got: %v", err)
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_RootPeerSkips(t *testing.T) {
+	// A root peer is already fully privileged; the ancestry check is skipped for
+	// it (a non-root peer with the same args is rejected — see above).
+	if err := verifyRegisterSessionCgroup(hsRootWithPID(uint32(os.Getpid())), regReq(1, 12345), quietLogger()); err != nil {
+		t.Fatalf("root peer should skip the ancestry check, got: %v", err)
 	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func hsWithPID(pid uint32) kernelcapture.DaemonProtocolPeerHandshake {
+	return kernelcapture.DaemonProtocolPeerHandshake{
+		Authorization: kernelcapture.DaemonPeerAuthorization{PID: pid},
+	}
+}
+
+func regReq(rootPID uint32, cgroupID uint64) *kernelcapture.DaemonRegisterSessionRequest {
+	return &kernelcapture.DaemonRegisterSessionRequest{SessionID: "s", RootPID: rootPID, CgroupID: cgroupID}
+}
+
+func TestProcParentPID_Self(t *testing.T) {
+	got, err := procParentPID(uint32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("procParentPID(self): %v", err)
+	}
+	if want := uint32(os.Getppid()); got != want {
+		t.Fatalf("procParentPID(self) = %d, want %d", got, want)
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_SelfIsOwned(t *testing.T) {
+	self := uint32(os.Getpid())
+	// peer registering its own process: trivially owned.
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, 12345), quietLogger()); err != nil {
+		t.Fatalf("self-registration should be owned, got: %v", err)
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_NonDescendantRejected(t *testing.T) {
+	self := uint32(os.Getpid())
+	// pid 1 (init) exists but is not a descendant of the test process — a peer
+	// naming a process it did not spawn must be rejected.
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(1, 12345), quietLogger()); err == nil {
+		t.Fatal("registering pid 1 (not a descendant of the peer) should be rejected")
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_BogusRootRejected(t *testing.T) {
+	self := uint32(os.Getpid())
+	// A pid that is not a live process cannot be verified — reject.
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(1<<30, 12345), quietLogger()); err == nil {
+		t.Fatal("registering a non-existent root_pid should be rejected")
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_PeerNotVisibleSkips(t *testing.T) {
+	// If the peer itself is not visible in /proc (cross-PID-namespace daemon),
+	// ancestry can't be established either way — skip rather than break.
+	if err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger()); err != nil {
+		t.Fatalf("unresolvable peer should skip the check, got: %v", err)
+	}
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_unsupported.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package main
+
+// daemon_cgroup_verify_unsupported.go — non-Linux stub for the register_session
+// cgroup-ownership check. There is no /proc process-ancestry model to consult
+// here (and no BPF-LSM cgroup enforcement to protect either), so registration
+// proceeds unverified. See daemon_cgroup_verify_linux.go for the real check.
+
+import (
+	"log/slog"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+func verifyRegisterSessionCgroup(_ kernelcapture.DaemonProtocolPeerHandshake, _ *kernelcapture.DaemonRegisterSessionRequest, _ *slog.Logger) error {
+	return nil
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -70,6 +70,7 @@ func newTestDaemon(t *testing.T) *daemon {
 		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
 		seccompListeners:     make(map[string]context.CancelFunc),
 		activeTier:           daemonTierNone,
+		appliedAllow:         make(map[string]*appliedAllowRecord),
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -71,6 +71,12 @@ func newTestDaemon(t *testing.T) *daemon {
 		seccompListeners:     make(map[string]context.CancelFunc),
 		activeTier:           daemonTierNone,
 		appliedAllow:         make(map[string]*appliedAllowRecord),
+		// No-op cgroup verifier: daemon-flow tests register synthetic PIDs that
+		// aren't real /proc descendants. The real check is covered directly by
+		// daemon_cgroup_verify_linux_test.go.
+		cgroupVerifier: func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) error {
+			return nil
+		},
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -123,6 +123,26 @@ type daemon struct {
 	// process through ardur-exec-shim (the seccomp tier's on-ramp) is
 	// necessary at all. One of the daemonTier* constants.
 	activeTier string
+
+	// applyMu serializes every BPF policy-map mutation — ApplyPolicyMaps,
+	// RemovePolicyMaps, SetKillSwitch. Those run in per-connection goroutines
+	// (and RemovePolicyMaps also on session-end), and ApplyPolicyMaps' double
+	// buffer is a read-active-slot / write-inactive-slot / flip sequence that is
+	// only atomic if writers are serialized. Distinct from mu (routing index).
+	applyMu sync.Mutex
+
+	// appliedAllow tracks, per session, the path/net allowlist entries most
+	// recently written to the (non-double-buffered) cgroup_file_allow /
+	// cgroup_net_allow maps, so a re-apply that drops an entry can delete the
+	// stale one and session end can release them all. Guarded by mu.
+	appliedAllow map[string]*appliedAllowRecord
+}
+
+// appliedAllowRecord is the last allowlist set written for a session.
+type appliedAllowRecord struct {
+	cgroupID uint64
+	paths    map[string]struct{}
+	nets     map[string]struct{}
 }
 
 const (
@@ -176,6 +196,7 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
 		seccompListeners:     make(map[string]context.CancelFunc),
 		activeTier:           daemonTierNone,
+		appliedAllow:         make(map[string]*appliedAllowRecord),
 	}, nil
 }
 
@@ -210,12 +231,32 @@ func (d *daemon) unregisterSeccompListener(sessionID string) {
 // index as a side effect of successful register/end-session responses.
 func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
 	// apply_policy and set_kill_switch are handled locally — the registry has
-	// no BPF awareness.
+	// no BPF awareness. Both take the peer handshake so they can enforce
+	// per-session ownership (apply_policy) / admin identity (set_kill_switch)
+	// rather than trusting any authorized-UID peer with a client-supplied
+	// session_id or the global kill switch.
 	switch req.Method {
 	case kernelcapture.DaemonProtocolMethodApplyPolicy:
-		return d.handleApplyPolicy(req)
+		return d.handleApplyPolicy(req, handshake)
 	case kernelcapture.DaemonProtocolMethodSetKillSwitch:
-		return d.handleSetKillSwitch(req)
+		return d.handleSetKillSwitch(req, handshake)
+	}
+
+	// register_session binds a client-supplied cgroup_id (and root_pid) to a
+	// session; apply_policy later writes BPF enforcement to that cgroup. Verify
+	// the claim is one the peer legitimately owns before the registry accepts
+	// it, so a peer cannot register (and then govern/tamper) a cgroup belonging
+	// to another workload.
+	if req.Method == kernelcapture.DaemonProtocolMethodRegisterSession && req.RegisterSession != nil {
+		if err := verifyRegisterSessionCgroup(handshake, req.RegisterSession, d.log); err != nil {
+			return kernelcapture.DaemonProtocolResponse{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          req.Method,
+				SessionID:       req.RegisterSession.SessionID,
+				OK:              false,
+				Error:           fmt.Sprintf("register_session cgroup ownership check failed: %v", err),
+			}
+		}
 	}
 
 	resp := d.registry.HandleAuthorizedRequest(ctx, req, handshake)
@@ -268,7 +309,7 @@ func (d *daemon) enforcementTier() string {
 
 // handleApplyPolicy validates the session, resolves its cgroup_id, and writes
 // the policy into the BPF enforcement maps.
-func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kernelcapture.DaemonProtocolResponse {
+func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
 	ap := req.ApplyPolicy
 	errResp := func(msg string) kernelcapture.DaemonProtocolResponse {
 		return kernelcapture.DaemonProtocolResponse{
@@ -279,10 +320,20 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kern
 		}
 	}
 
-	record, err := d.registry.ActiveSession(ap.SessionID)
+	// Ownership gate: only the peer that registered this session may rewrite its
+	// policy — mirrors end_session/session_status. Without this, any authorized-
+	// UID peer could apply policy to a session (and thus a cgroup) it does not
+	// own, including neutralizing another workload's enforcement or a sandboxed
+	// process disabling its own.
+	record, err := d.registry.ActiveSessionForPeer(ap.SessionID, handshake)
 	if err != nil {
-		return errResp(fmt.Sprintf("session not found or not active: %v", err))
+		return errResp(fmt.Sprintf("session not found, not active, or not owned by this peer: %v", err))
 	}
+
+	// Serialize all BPF policy-map mutations so a concurrent apply/remove for the
+	// same cgroup cannot interleave the double-buffer slot read-modify-write.
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
 	if record.CgroupID == 0 {
 		return errResp("session has no cgroup_id; cannot apply BPF policy")
 	}
@@ -342,6 +393,12 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kern
 		return errResp(fmt.Sprintf("apply policy maps: %v", err))
 	}
 
+	// Revoke any allowlist entries this session had that the new policy drops,
+	// and record the new set. Runs only on the BPF-write success path (the
+	// degraded/seccomp returns above never reach the cgroup_file_allow /
+	// cgroup_net_allow maps). Under applyMu, so serialized with other applies.
+	d.pruneAndRecordAllowlists(ap.SessionID, record.CgroupID, ap.PathAllow, ap.NetAllow)
+
 	d.log.Info("policy applied",
 		"session_id", ap.SessionID,
 		"cgroup_id", record.CgroupID,
@@ -356,6 +413,64 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest) kern
 		OK:              true,
 		SessionID:       ap.SessionID,
 	}
+}
+
+// pruneAndRecordAllowlists deletes the path/net allowlist entries this session
+// previously wrote that are absent from the new set (revoking them from the BPF
+// maps, which — unlike op_policy — are not double-buffered and would otherwise
+// keep a dropped path/host allowed), then records the new set. Caller holds
+// applyMu; this briefly takes mu for the appliedAllow map.
+func (d *daemon) pruneAndRecordAllowlists(sessionID string, cgroupID uint64, newPaths, newNets []string) {
+	newPathSet := stringSet(newPaths)
+	newNetSet := stringSet(newNets)
+
+	d.mu.Lock()
+	prev := d.appliedAllow[sessionID]
+	d.mu.Unlock()
+
+	var stalePaths, staleNets []string
+	if prev != nil {
+		for p := range prev.paths {
+			if _, keep := newPathSet[p]; !keep {
+				stalePaths = append(stalePaths, p)
+			}
+		}
+		for n := range prev.nets {
+			if _, keep := newNetSet[n]; !keep {
+				staleNets = append(staleNets, n)
+			}
+		}
+	}
+	if len(stalePaths) > 0 || len(staleNets) > 0 {
+		if err := kernelcapture.DeleteAllowlistEntries(d.policyMaps, cgroupID, stalePaths, staleNets); err != nil {
+			d.log.Warn("prune stale allowlist entries on re-apply",
+				"session_id", sessionID, "cgroup_id", cgroupID, "error", err)
+		}
+	}
+
+	d.mu.Lock()
+	d.appliedAllow[sessionID] = &appliedAllowRecord{cgroupID: cgroupID, paths: newPathSet, nets: newNetSet}
+	d.mu.Unlock()
+}
+
+// stringSet builds a set from a slice, ignoring empties.
+func stringSet(items []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, it := range items {
+		if it != "" {
+			set[it] = struct{}{}
+		}
+	}
+	return set
+}
+
+// setKeys returns a set's members as a slice.
+func setKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return out
 }
 
 // seccompFullyCoversPolicy reports whether every op an apply_policy request
@@ -376,7 +491,25 @@ func seccompFullyCoversPolicy(ap *kernelcapture.DaemonApplyPolicyRequest) bool {
 // Unlike apply_policy, a missing guard is always a hard failure here: there
 // is no "degraded" reading of "the caller asked to change enforcement state
 // and nothing happened" — the caller must know the call had no effect.
-func (d *daemon) handleSetKillSwitch(req kernelcapture.DaemonProtocolRequest) kernelcapture.DaemonProtocolResponse {
+//
+// The kill switch is GLOBAL and fail-open (engaged ⇒ every op passes on every
+// governed cgroup), so it is gated to an admin identity — a UID-0 (root) peer —
+// rather than any UID on the socket's allowlist. A non-root allowed peer (e.g.
+// the very workload being sandboxed, which typically shares the launching UID)
+// must not be able to disable enforcement host-wide.
+func (d *daemon) handleSetKillSwitch(req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
+	if handshake.Authorization.UID != 0 {
+		d.log.Warn("set_kill_switch denied: caller is not root",
+			"peer_uid", handshake.Authorization.UID, "peer_pid", handshake.Authorization.PID, "engaged", req.SetKillSwitch != nil && req.SetKillSwitch.Engaged)
+		return kernelcapture.DaemonProtocolResponse{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodSetKillSwitch,
+			OK:              false,
+			Error:           "set_kill_switch requires an admin (uid 0) peer; the global kill switch is not delegable to non-root callers",
+		}
+	}
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
 	sw := req.SetKillSwitch
 	if err := kernelcapture.SetKillSwitch(d.policyMaps, sw.Engaged); err != nil {
 		d.log.Error("set_kill_switch failed", "engaged", sw.Engaged, "error", err)
@@ -437,18 +570,33 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	if sessionID == "" {
 		return
 	}
+	// applyMu is acquired OUTSIDE d.mu (same order as handleApplyPolicy/
+	// handleSetKillSwitch) so the RemovePolicyMaps below is serialized against
+	// concurrent apply_policy for the same cgroup, with no lock-order inversion.
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
 	d.mu.Lock()
 
-	if scope, ok := d.treeScopes[sessionID]; ok {
-		if scope.CgroupID != 0 {
-			delete(d.cgroupIndex, scope.CgroupID)
-			// Best-effort: remove enforcement state from BPF maps.
-			if err := kernelcapture.RemovePolicyMaps(d.policyMaps, scope.CgroupID); err != nil {
-				d.log.Warn("remove policy maps on session end",
-					"session_id", sessionID, "cgroup_id", scope.CgroupID, "error", err)
-			}
+	// Best-effort: remove enforcement state from BPF maps — op_policy + managed
+	// gate (keyed by the routing scope's cgroup), then the (non-double-buffered)
+	// path/net allowlist entries this session applied, keyed by the cgroup they
+	// were actually written under (tracked in appliedAllow), so they don't
+	// linger allowed for a future session that reuses the cgroup id.
+	prevAllow := d.appliedAllow[sessionID]
+	if scope, ok := d.treeScopes[sessionID]; ok && scope.CgroupID != 0 {
+		delete(d.cgroupIndex, scope.CgroupID)
+		if err := kernelcapture.RemovePolicyMaps(d.policyMaps, scope.CgroupID); err != nil {
+			d.log.Warn("remove policy maps on session end",
+				"session_id", sessionID, "cgroup_id", scope.CgroupID, "error", err)
 		}
 	}
+	if prevAllow != nil && prevAllow.cgroupID != 0 {
+		if err := kernelcapture.DeleteAllowlistEntries(d.policyMaps, prevAllow.cgroupID, setKeys(prevAllow.paths), setKeys(prevAllow.nets)); err != nil {
+			d.log.Warn("remove allowlist entries on session end",
+				"session_id", sessionID, "cgroup_id", prevAllow.cgroupID, "error", err)
+		}
+	}
+	delete(d.appliedAllow, sessionID)
 	delete(d.treeScopes, sessionID)
 	delete(d.correlators, sessionID)
 	delete(d.enforceChains, sessionID)
@@ -611,14 +759,27 @@ func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent, loss kernelc
 // pruneExpiredSessions removes sessions that the registry has expired so the
 // cgroup index does not leak indefinitely.
 func (d *daemon) pruneExpiredSessions() {
+	type expiredPolicy struct {
+		cgroupID uint64
+		paths    []string
+		nets     []string
+	}
 	d.mu.Lock()
 	var expiredSeccompCancels []context.CancelFunc
 	var expiredSessionIDs []string
+	var expiredPolicies []expiredPolicy
 	for sid, scope := range d.treeScopes {
 		if _, err := d.registry.ActiveSession(sid); err != nil {
 			if scope.CgroupID != 0 {
 				delete(d.cgroupIndex, scope.CgroupID)
+				ep := expiredPolicy{cgroupID: scope.CgroupID}
+				if prev := d.appliedAllow[sid]; prev != nil {
+					ep.paths = setKeys(prev.paths)
+					ep.nets = setKeys(prev.nets)
+				}
+				expiredPolicies = append(expiredPolicies, ep)
 			}
+			delete(d.appliedAllow, sid)
 			delete(d.treeScopes, sid)
 			delete(d.correlators, sid)
 			delete(d.enforceChains, sid)
@@ -632,6 +793,25 @@ func (d *daemon) pruneExpiredSessions() {
 		}
 	}
 	d.mu.Unlock()
+
+	// Release BPF enforcement state for expired sessions (op_policy + managed
+	// gate + allowlist entries), so a TTL-expired session's policy doesn't
+	// linger in the kernel. applyMu is taken alone here (d.mu already released),
+	// serializing with concurrent apply_policy.
+	if len(expiredPolicies) > 0 {
+		d.applyMu.Lock()
+		for _, ep := range expiredPolicies {
+			if err := kernelcapture.RemovePolicyMaps(d.policyMaps, ep.cgroupID); err != nil {
+				d.log.Warn("remove policy maps on session expiry", "cgroup_id", ep.cgroupID, "error", err)
+			}
+			if len(ep.paths) > 0 || len(ep.nets) > 0 {
+				if err := kernelcapture.DeleteAllowlistEntries(d.policyMaps, ep.cgroupID, ep.paths, ep.nets); err != nil {
+					d.log.Warn("remove allowlist entries on session expiry", "cgroup_id", ep.cgroupID, "error", err)
+				}
+			}
+		}
+		d.applyMu.Unlock()
+	}
 
 	for _, sid := range expiredSessionIDs {
 		kernelcapture.RemoveSeccompPolicy(d.seccompPolicy, sid)

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -136,6 +136,11 @@ type daemon struct {
 	// cgroup_net_allow maps, so a re-apply that drops an entry can delete the
 	// stale one and session end can release them all. Guarded by mu.
 	appliedAllow map[string]*appliedAllowRecord
+
+	// cgroupVerifier gates register_session on the peer owning the claimed
+	// cgroup/root_pid. Injected so tests (which register synthetic PIDs) can
+	// substitute a no-op; production wires verifyRegisterSessionCgroup.
+	cgroupVerifier func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) error
 }
 
 // appliedAllowRecord is the last allowlist set written for a session.
@@ -197,6 +202,7 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 		seccompListeners:     make(map[string]context.CancelFunc),
 		activeTier:           daemonTierNone,
 		appliedAllow:         make(map[string]*appliedAllowRecord),
+		cgroupVerifier:       verifyRegisterSessionCgroup,
 	}, nil
 }
 
@@ -248,7 +254,7 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 	// it, so a peer cannot register (and then govern/tamper) a cgroup belonging
 	// to another workload.
 	if req.Method == kernelcapture.DaemonProtocolMethodRegisterSession && req.RegisterSession != nil {
-		if err := verifyRegisterSessionCgroup(handshake, req.RegisterSession, d.log); err != nil {
+		if err := d.cgroupVerifier(handshake, req.RegisterSession, d.log); err != nil {
 			return kernelcapture.DaemonProtocolResponse{
 				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
 				Method:          req.Method,

--- a/go/pkg/kernelcapture/bpf_policy_apply.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply.go
@@ -123,6 +123,18 @@ func ApplyPolicyMaps(maps PolicyMaps, cgroupID uint64, req DaemonApplyPolicyRequ
 
 	newSlot := nextPolicySlot(maps.CgroupManaged, cgroupID)
 
+	// 0. Clear the INACTIVE slot before writing the new generation into it.
+	// The slot is a double buffer reused every other apply for this cgroup, so
+	// without this an op rule written two generations ago (same slot) but
+	// omitted from req survives — and becomes live again on the flip below,
+	// silently mis-enforcing (e.g. a dropped NET_CONNECT:ALLOW lingering). The
+	// slot is not the active one, so deleting from it is invisible to readers.
+	for _, op := range allKnownBpfOps {
+		if err := maps.CgroupOpPolicy.Delete(cgroupOpKey(cgroupID, op, newSlot)); err != nil && !isNotFound(err) {
+			return fmt.Errorf("kernelcapture: apply_policy clear inactive slot (op=%s): %w", op, err)
+		}
+	}
+
 	// 1. Write per-op policy entries into the INACTIVE slot.
 	for _, p := range req.OpPolicies {
 		k := cgroupOpKey(cgroupID, p.Op, newSlot)
@@ -194,7 +206,7 @@ func RemovePolicyMaps(maps PolicyMaps, cgroupID uint64) error {
 	}
 
 	// Delete op policy entries for all known ops, in both double-buffer slots.
-	for _, op := range []BpfOp{BpfOpExec, BpfOpFileRead, BpfOpFileWrite, BpfOpNetConnect, BpfOpExternalSend} {
+	for _, op := range allKnownBpfOps {
 		for _, slot := range [2]uint32{0, 1} {
 			k := cgroupOpKey(cgroupID, op, slot)
 			if err := maps.CgroupOpPolicy.Delete(k); err != nil && !isNotFound(err) {
@@ -208,6 +220,51 @@ func RemovePolicyMaps(maps PolicyMaps, cgroupID uint64) error {
 	}
 	return nil
 }
+
+// DeleteAllowlistEntries removes specific path (cgroup_file_allow) and net
+// (cgroup_net_allow) allowlist entries for cgroupID. Unlike cgroup_op_policy,
+// these maps are NOT double-buffered — a re-apply only Puts the new entries, so
+// an entry from a prior generation that the new policy drops would otherwise
+// linger and stay allowed (silently defeating a tightened allowlist), and
+// nothing removes them at session end. The daemon tracks what it applied per
+// session and calls this with the stale (or, at session end, the full) set;
+// deletes are best-effort (a missing key is not an error). Building the exact
+// keys from the same path/CIDR strings avoids having to iterate the maps.
+func DeleteAllowlistEntries(maps PolicyMaps, cgroupID uint64, paths []string, cidrs []string) error {
+	if maps.CgroupFileAllow == nil || maps.CgroupNetAllow == nil {
+		return ErrPolicyMapsUnavailable
+	}
+	var errs []string
+	for _, path := range paths {
+		k, err := fileAllowKey(cgroupID, path)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("file_allow key (%q): %v", path, err))
+			continue
+		}
+		if err := maps.CgroupFileAllow.Delete(k); err != nil && !isNotFound(err) {
+			errs = append(errs, fmt.Sprintf("cgroup_file_allow (%q): %v", path, err))
+		}
+	}
+	for _, cidr := range cidrs {
+		k, err := netLpmKey(cgroupID, cidr)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("net_allow key (%q): %v", cidr, err))
+			continue
+		}
+		if err := maps.CgroupNetAllow.Delete(k); err != nil && !isNotFound(err) {
+			errs = append(errs, fmt.Sprintf("cgroup_net_allow (%q): %v", cidr, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("kernelcapture: delete_allowlist_entries for cgroup %d: %s", cgroupID, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// allKnownBpfOps is every op the enforcement layer recognises. Used to clear a
+// double-buffer slot before writing (ApplyPolicyMaps) and to release all op
+// entries on session end (RemovePolicyMaps).
+var allKnownBpfOps = []BpfOp{BpfOpExec, BpfOpFileRead, BpfOpFileWrite, BpfOpNetConnect, BpfOpExternalSend}
 
 // SetKillSwitch writes the global kill-switch value.
 // engaged=true suspends all enforcement (all ops pass through); false re-enables.

--- a/go/pkg/kernelcapture/bpf_policy_apply_prune_test.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_prune_test.go
@@ -1,0 +1,99 @@
+package kernelcapture
+
+// bpf_policy_apply_prune_test.go — regression tests for the stale-policy-state
+// fix: ApplyPolicyMaps now clears the inactive double-buffer slot before
+// writing, and DeleteAllowlistEntries revokes specific path/net allowlist
+// entries (the daemon calls it on re-apply and session end). See the
+// stale-policy-state finding these close.
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestApplyPolicyMaps_ClearsInactiveSlotBeforeWrite proves an op rule written
+// two generations ago (same slot) does NOT survive the slot flip when a later
+// generation omits that op. Before the fix, the stale rule became live again.
+func TestApplyPolicyMaps_ClearsInactiveSlotBeforeWrite(t *testing.T) {
+	maps, _, h := fakePolicyMaps()
+	cg := uint64(4242)
+
+	gen1 := DaemonApplyPolicyRequest{SessionID: "s", Generation: 1, EnforceMode: BpfEnforceModeEnforce,
+		OpPolicies: []DaemonOpPolicy{
+			{Op: BpfOpExec, Action: BpfActionDeny, EnforceMode: BpfEnforceModeEnforce},
+			{Op: BpfOpNetConnect, Action: BpfActionAllow, EnforceMode: BpfEnforceModeEnforce}, // NET allowed
+		}}
+	onlyExec := func(gen BpfPolicyGeneration) DaemonApplyPolicyRequest {
+		return DaemonApplyPolicyRequest{SessionID: "s", Generation: gen, EnforceMode: BpfEnforceModeEnforce,
+			OpPolicies: []DaemonOpPolicy{{Op: BpfOpExec, Action: BpfActionDeny, EnforceMode: BpfEnforceModeEnforce}}}
+	}
+	for _, req := range []DaemonApplyPolicyRequest{gen1, onlyExec(2), onlyExec(3)} {
+		if err := ApplyPolicyMaps(maps, cg, req); err != nil {
+			t.Fatalf("apply gen %d: %v", req.Generation, err)
+		}
+	}
+
+	var mv managedValueLayout
+	if err := h["cgroup_managed"].Lookup(managedKey(cg), unsafe.Pointer(&mv)); err != nil {
+		t.Fatalf("managed lookup: %v", err)
+	}
+	var netv cgroupOpValueLayout
+	if err := h["cgroup_op_policy"].Lookup(cgroupOpKey(cg, BpfOpNetConnect, mv.ActiveSlot), unsafe.Pointer(&netv)); err == nil {
+		t.Fatalf("stale NET_CONNECT rule (action=%d gen=%d) survived in the active slot %d; the inactive slot was not cleared before write", netv.Action, netv.Generation, mv.ActiveSlot)
+	}
+	// The op the later generations DID specify must still be present.
+	var execv cgroupOpValueLayout
+	if err := h["cgroup_op_policy"].Lookup(cgroupOpKey(cg, BpfOpExec, mv.ActiveSlot), unsafe.Pointer(&execv)); err != nil {
+		t.Fatalf("EXEC rule missing from active slot %d after apply: %v", mv.ActiveSlot, err)
+	}
+}
+
+// TestDeleteAllowlistEntries_RemovesOnlyNamedKeys proves the revocation helper
+// deletes exactly the path/net keys it is given and leaves the rest.
+func TestDeleteAllowlistEntries_RemovesOnlyNamedKeys(t *testing.T) {
+	maps, _, h := fakePolicyMaps()
+	cg := uint64(777)
+
+	req := DaemonApplyPolicyRequest{SessionID: "s", Generation: 1, EnforceMode: BpfEnforceModeEnforce,
+		OpPolicies: []DaemonOpPolicy{{Op: BpfOpFileRead, Action: BpfActionAllowlist, EnforceMode: BpfEnforceModeEnforce}},
+		PathAllow:  []string{"/tmp/a", "/tmp/b"},
+		NetAllow:   []string{"10.0.0.0/24", "192.168.1.0/24"}}
+	if err := ApplyPolicyMaps(maps, cg, req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Revoke /tmp/b and 10.0.0.0/24 only.
+	if err := DeleteAllowlistEntries(maps, cg, []string{"/tmp/b"}, []string{"10.0.0.0/24"}); err != nil {
+		t.Fatalf("delete allowlist entries: %v", err)
+	}
+
+	present := func(mapName string, key unsafe.Pointer) bool {
+		var v uint64
+		return h[mapName].Lookup(key, unsafe.Pointer(&v)) == nil
+	}
+	kA, _ := fileAllowKey(cg, "/tmp/a")
+	kB, _ := fileAllowKey(cg, "/tmp/b")
+	if !present("cgroup_file_allow", kA) {
+		t.Error("/tmp/a should remain after revoking only /tmp/b")
+	}
+	if present("cgroup_file_allow", kB) {
+		t.Error("/tmp/b should be gone after revocation (allowlist revocation must actually revoke)")
+	}
+	kNetGone, _ := netLpmKey(cg, "10.0.0.0/24")
+	kNetKeep, _ := netLpmKey(cg, "192.168.1.0/24")
+	if present("cgroup_net_allow", kNetGone) {
+		t.Error("10.0.0.0/24 should be gone after revocation")
+	}
+	if !present("cgroup_net_allow", kNetKeep) {
+		t.Error("192.168.1.0/24 should remain")
+	}
+}
+
+// TestDeleteAllowlistEntries_NotFoundIsNotAnError confirms deleting a key that
+// was never written is a no-op, not a failure (best-effort revocation).
+func TestDeleteAllowlistEntries_NotFoundIsNotAnError(t *testing.T) {
+	maps, _, _ := fakePolicyMaps()
+	if err := DeleteAllowlistEntries(maps, 999, []string{"/never/written"}, []string{"8.8.8.8/32"}); err != nil {
+		t.Fatalf("deleting absent allowlist keys should be a no-op, got: %v", err)
+	}
+}

--- a/go/pkg/kernelcapture/daemon_session_registry.go
+++ b/go/pkg/kernelcapture/daemon_session_registry.go
@@ -110,6 +110,25 @@ func (r *DaemonSessionRegistry) ActiveSession(sessionID string) (DaemonSessionRe
 	return record, nil
 }
 
+// ActiveSessionForPeer is like ActiveSession but additionally requires that the
+// supplied peer handshake OWNS the session — i.e. it matches the UID/GID/PID/
+// process-start-time/credential-source recorded at register_session. This is the
+// same ownership gate handleEndSession/handleSessionStatus already enforce; it is
+// exported so out-of-package daemon handlers that resolve a session by
+// client-supplied session_id (apply_policy, set_kill_switch) can enforce it too,
+// instead of letting any authorized-UID peer mutate a session another peer
+// registered (see the missing-authorization finding these callers close).
+func (r *DaemonSessionRegistry) ActiveSessionForPeer(sessionID string, handshake DaemonProtocolPeerHandshake) (DaemonSessionRecord, error) {
+	record, _, err := r.lookupActiveSession(sessionID, r.currentTime())
+	if err != nil {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: %v", ErrDaemonSessionRegistry, err)
+	}
+	if !daemonSessionRegistryPeerOwnsRecord(record, handshake) {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q is owned by a different peer", ErrDaemonSessionRegistry, sessionID)
+	}
+	return record, nil
+}
+
 // BuildActiveSessionHandoffPlan projects an active registered session into the
 // existing no-mutation handoff plan using daemon-owned custody paths. It performs
 // no filesystem writes, cgroup assignment, BPF map mutation, or live enforcement.


### PR DESCRIPTION
## Summary

Closes the three vulnerabilities filed against the newly-merged BPF-LSM enforcement surface (#108, #109, #110). Part of Epic A (#63).

### #108 — apply_policy & set_kill_switch missing per-session authorization (HIGH)
`end_session` / `session_status` enforced peer-ownership, but `apply_policy` / `set_kill_switch` were intercepted before the registry and gated only by the coarse UID allowlist — so any allowed-UID peer (incl. a sandboxed workload that shares the launcher's UID) could rewrite/disable enforcement for *any* session/cgroup.

- `apply_policy` now takes the peer handshake and resolves the session via a new `DaemonSessionRegistry.ActiveSessionForPeer`, which requires the caller to **own** the session.
- `set_kill_switch` (global, fail-open) is gated to a **uid-0 admin** peer.
- `register_session` verifies the client-supplied `root_pid` is a **descendant of the registering peer** (namespace-robust `/proc` ancestry) — a peer can only register process trees it spawned, so it can't bind a session to another workload's cgroup. (A literal `/proc/<peer>/cgroup` inode match is deliberately *not* used: the launcher adopts the agent *child* into the cgroup and cgroup namespaces make the inode unresolvable across the daemon boundary — that check would reject the verified `ardur run` flow.)

### #109 — stale policy state (MED)
- `ApplyPolicyMaps` clears the inactive double-buffer op slot before writing (a rule from two generations ago can no longer survive the flip).
- New `DeleteAllowlistEntries`; the daemon tracks applied path/net allowlist entries per session and **revokes dropped entries on re-apply** and **releases all on session end / expiry** (these maps aren't double-buffered, so a re-apply alone left stale entries allowed).

### #110 — double-buffer race (MED)
- Daemon-wide `applyMu` serializes `ApplyPolicyMaps` / `RemovePolicyMaps` / `SetKillSwitch` (acquired outside `mu`; no lock-order inversion).

## Tests / verification
- New unit tests: foreign-peer `apply_policy` rejected; `set_kill_switch` admin-gated; inactive op slot cleared; allowlist revoked on re-apply + session end; concurrent applies serialized (under `-race`); Linux `/proc` ancestry (`verifyRegisterSessionCgroup` / `procParentPID`).
- Full `go test ./...` green on darwin; cross-builds linux/amd64+arm64; `go vet` clean.
- **On a real BPF-LSM kernel** (Docker Desktop LinuxKit, `lsm=…,bpf`): the original foreign-peer socket PoC now gets `apply_policy → "session is owned by a different peer"` (was `ok=true`); and the `ardur run --enforce` end-to-end demo **still** blocks the agent's `exec` (EPERM), installs policy, and verifies offline (chain intact + attestation digest match) — the fixes are effective **and** don't break the legitimate flow.

Refs #63. Closes #108, #109, #110.
