### PR TITLE
fix(enforce): verify register_session cgroup ownership against reality (#119)

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
@@ -7,32 +7,56 @@ package main
 // register_session binds a client-supplied cgroup_id (and root_pid) to a
 // session; apply_policy later writes BPF enforcement keyed by that cgroup_id.
 // Without a check, any authorized-UID peer could register a cgroup_id belonging
-// to another workload and then govern/tamper it. This closes that by requiring
-// root_pid to be a process the peer actually spawned.
+// to another workload and then govern/tamper it. This closes that with TWO
+// independent checks, both required:
 //
-// Why an ancestry check and NOT a literal "claimed cgroup_id == inode of
-// /proc/<peerPID>/cgroup" comparison: in the real `ardur run` flow the socket
-// peer (the launcher) does not enter the cgroup — it creates a cgroup and
-// adopts the *agent child* into it (run_bridge.py), so the peer's own cgroup
-// is not the registered one. Worse, cgroup namespaces make /proc/<pid>/cgroup
-// report a namespace-relative path (a governed agent commonly reads its own as
-// "0::/"), so the daemon cannot reliably resolve it back to the kernel cgroup
-// id the launcher derived via stat().st_ino across a namespace boundary — a
-// literal inode match there rejects the legitimate, end-to-end-verified flow.
+//  1. Ancestry — root_pid must be a process the peer actually spawned (PID
+//     ancestry within the daemon's own /proc view, namespace-robust).
+//  2. Ownership (issue #119) — root_pid's ACTUAL cgroup, as resolved by the
+//     daemon, must match the client-claimed cgroup_id.
 //
-// The ancestry check is namespace-robust (PID ancestry within the daemon's own
-// /proc view) and delivers the property that matters: a peer may only register
-// a session whose root_pid is a process it spawned. Since kernel enforcement
-// keys on each process's *actual* runtime cgroup and a peer can only name its
-// own descendants — which live in cgroups the peer itself controls — a peer
-// cannot bind a session to, and then govern, a cgroup it does not own.
+// #115 shipped only (1) and reasoned that (2) could not be done reliably: its
+// comment argued that in the real `ardur run` flow the socket peer (the
+// launcher) does not itself enter the cgroup — it creates one and adopts the
+// *agent child* into it (run_bridge.py) — and that cgroup namespaces make
+// /proc/<pid>/cgroup report a namespace-relative path the daemon cannot
+// resolve back to a real inode across a namespace boundary.
+//
+// That reasoning is correct about resolving the PEER's own cgroup, but #119
+// shows it was applied to the wrong process: this package never needs the
+// peer's cgroup. It needs root_pid's cgroup, resolved by the daemon itself —
+// and the daemon runs host-side, in the init cgroup namespace. /proc/<pid>/cgroup
+// read from a process outside a container's cgroup namespace (the daemon)
+// reports the path relative to the READER's namespace, i.e. the real,
+// non-namespace-relative host path — not root_pid's own view. resolveCgroupID
+// below does exactly that: read /proc/<root_pid>/cgroup as the daemon sees
+// it, resolve to the cgroup directory's inode (the same value
+// bpf_get_current_cgroup_id() returns, and what the Python run bridge computes
+// via os.stat().st_ino when it creates the session's cgroup), and require it
+// equal reg.CgroupID.
+//
+// Without check (2), ancestry alone let a non-root allowed peer register
+// {root_pid: <its own child>, cgroup_id: <any other live cgroup>} — ancestry
+// passes trivially (root_pid really is its child), but nothing had ever
+// verified that child was actually IN the claimed cgroup. The peer could then
+// apply_policy against a cgroup — and workload — it does not own. This was
+// demonstrated live against a build with only check (1); see
+// daemon_cgroup_verify_linux_test.go's TestVerifyRegisterSessionCgroup_Issue119Poc*
+// for the reproduction, now asserting rejection.
+//
+// A third, independent guard (checkCgroupCollision, daemon.go — platform-
+// neutral, no /proc dependency) rejects registering a cgroup_id already bound
+// to another live session, so even a race or a legitimate-looking claim can
+// never let two sessions govern the same cgroup concurrently.
 
 import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
@@ -52,31 +76,59 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if peerPID == 0 || rootPID == 0 {
 		return nil
 	}
-	// The peer registering its own process is trivially owned.
-	if rootPID == peerPID {
-		return nil
-	}
 	// A root (uid 0) peer is already fully privileged on the host — it can move
-	// any process between cgroups directly, so this ancestry check adds nothing
-	// against it. The check exists to constrain a NON-root allowed peer (the
-	// sandboxed-workload threat) from binding a session to a process tree it did
-	// not spawn. Skipping root also lets tiers that register a placeholder
+	// any process between cgroups directly, so neither check below adds anything
+	// against it. Both checks exist to constrain a NON-root allowed peer (the
+	// sandboxed-workload threat) from binding a session to a cgroup/process tree
+	// it does not own. Skipping root also lets tiers that register a placeholder
 	// root_pid (the seccomp tier enforces per-shim'd-process, not by cgroup, and
-	// its smoke registers root_pid=1) work when the daemon and client are root.
-	// Per-session ownership on apply_policy still applies to every peer.
+	// its smoke registers root_pid=1, whose real cgroup is the hierarchy root —
+	// never a session's claimed leaf cgroup) work when the daemon and client are
+	// root. Per-session ownership on apply_policy still applies to every peer.
 	if handshake.Authorization.UID == 0 {
 		return nil
 	}
 	// Confirm the peer itself is visible in the daemon's /proc view. If it is
 	// not (an unusual cross-PID-namespace deployment where the daemon cannot
 	// see client PIDs at all), we cannot establish ancestry either way — skip
-	// rather than reject and break such a deployment, but say so loudly.
+	// rather than reject and break such a deployment, but say so loudly. Since
+	// resolving root_pid's cgroup below relies on the same /proc visibility, a
+	// daemon that can't see the peer generally can't see root_pid either, so
+	// both checks are skipped together here.
 	if _, err := os.Stat("/proc/" + strconv.FormatUint(uint64(peerPID), 10)); err != nil {
 		log.Warn("register_session cgroup ownership check skipped: peer pid not visible in /proc (cross-namespace daemon?)",
 			"peer_pid", peerPID, "root_pid", rootPID)
 		return nil
 	}
-	// Walk root_pid's parent chain; it must reach the registering peer.
+
+	// Check 1: ancestry. The peer registering its own process is trivially a
+	// (zero-hop) descendant; anything else must be found by walking parents.
+	if rootPID != peerPID {
+		if err := verifyCgroupAncestry(rootPID, peerPID); err != nil {
+			return err
+		}
+	}
+
+	// Check 2 (#119): ownership. root_pid's actual cgroup, resolved by the
+	// daemon, must match the claimed cgroup_id. Applies even to the
+	// rootPID==peerPID case above — a peer claiming its OWN pid as root_pid
+	// with a mismatched cgroup_id is the same vulnerability class, just
+	// without the extra step of spawning a child first.
+	if reg.CgroupID != 0 {
+		resolved, err := resolveCgroupID(rootPID)
+		if err != nil {
+			return fmt.Errorf("root_pid %d cgroup could not be resolved (%v); a peer may only register a cgroup_id its root_pid actually occupies", rootPID, err)
+		}
+		if resolved != reg.CgroupID {
+			return fmt.Errorf("root_pid %d is in cgroup %d, not the claimed cgroup_id %d; a peer may only register a cgroup_id its root_pid actually occupies", rootPID, resolved, reg.CgroupID)
+		}
+	}
+
+	return nil
+}
+
+// verifyCgroupAncestry walks rootPID's parent chain looking for peerPID.
+func verifyCgroupAncestry(rootPID, peerPID uint32) error {
 	cur := rootPID
 	for hops := 0; hops < maxCgroupAncestryHops; hops++ {
 		ppid, err := procParentPID(cur)
@@ -92,6 +144,51 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 		cur = ppid
 	}
 	return fmt.Errorf("root_pid %d is not a descendant of the registering peer pid %d; a peer may only register process trees it spawned", rootPID, peerPID)
+}
+
+// resolveCgroupID reads pid's cgroup v2 unified-hierarchy membership from
+// /proc/<pid>/cgroup as observed BY THE DAEMON — which runs host-side, in the
+// init cgroup namespace — and resolves it to the cgroup directory's inode:
+// the same value bpf_get_current_cgroup_id() returns for that cgroup, and
+// what the Python run bridge computes via os.stat().st_ino when it creates a
+// session's cgroup (python/vibap/kernel_correlation.py's create_run_cgroup).
+// See this file's header comment for why this is namespace-robust in the
+// direction that matters (resolving root_pid's cgroup from OUTSIDE any
+// container it might run in), unlike resolving the socket peer's own cgroup.
+func resolveCgroupID(pid uint32) (uint64, error) {
+	cgroupPath, err := resolveCgroupPath(pid)
+	if err != nil {
+		return 0, err
+	}
+	var st syscall.Stat_t
+	if err := syscall.Stat(cgroupPath, &st); err != nil {
+		return 0, fmt.Errorf("stat cgroup path %q (pid %d): %w", cgroupPath, pid, err)
+	}
+	if st.Ino == 0 {
+		return 0, fmt.Errorf("stat cgroup path %q returned inode 0", cgroupPath)
+	}
+	return st.Ino, nil
+}
+
+// resolveCgroupPath returns the absolute, daemon-side cgroupfs path for pid's
+// cgroup v2 unified-hierarchy membership (split out of resolveCgroupID so
+// tests can locate a real, writable cgroup subtree to create a child under —
+// see daemon_cgroup_verify_linux_test.go's cgroupV2SelfDir).
+func resolveCgroupPath(pid uint32) (string, error) {
+	path := "/proc/" + strconv.FormatUint(uint64(pid), 10) + "/cgroup"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 || parts[0] != "0" || parts[1] != "" {
+			continue // not the cgroup v2 unified-hierarchy entry (hierarchy-id 0, no controllers)
+		}
+		rel := strings.TrimPrefix(parts[2], "/")
+		return filepath.Join("/sys/fs/cgroup", rel), nil
+	}
+	return "", fmt.Errorf("no cgroup v2 unified-hierarchy entry found for pid %d in %q", pid, strings.TrimSpace(string(data)))
 }
 
 // procParentPID reads the PPID (field 4) from /proc/<pid>/stat. The comm field

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
@@ -16,8 +19,8 @@ func quietLogger() *slog.Logger {
 }
 
 // hsWithPID builds a NON-root peer handshake so the register-time ancestry
-// check actually runs (it is skipped for uid-0 peers, which are already fully
-// privileged — see verifyRegisterSessionCgroup).
+// and cgroup-ownership checks actually run (both are skipped for uid-0 peers,
+// which are already fully privileged — see verifyRegisterSessionCgroup).
 func hsWithPID(pid uint32) kernelcapture.DaemonProtocolPeerHandshake {
 	return kernelcapture.DaemonProtocolPeerHandshake{
 		Authorization: kernelcapture.DaemonPeerAuthorization{PID: pid, UID: 501},
@@ -34,6 +37,34 @@ func regReq(rootPID uint32, cgroupID uint64) *kernelcapture.DaemonRegisterSessio
 	return &kernelcapture.DaemonRegisterSessionRequest{SessionID: "s", RootPID: rootPID, CgroupID: cgroupID}
 }
 
+// spawnTestChild starts a real, short-lived child of the current test process
+// (guaranteeing genuine PID ancestry, the same relationship a launcher has to
+// the agent it Popen()s) and returns its PID. Killed and reaped on cleanup.
+func spawnTestChild(t *testing.T) uint32 {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn test child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return uint32(cmd.Process.Pid)
+}
+
+// selfCgroupID resolves the test process's own real cgroup_id via the same
+// code path verifyRegisterSessionCgroup uses, so tests assert against ground
+// truth rather than a value the test guessed independently.
+func selfCgroupID(t *testing.T) uint64 {
+	t.Helper()
+	id, err := resolveCgroupID(uint32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("resolveCgroupID(self): %v", err)
+	}
+	return id
+}
+
 func TestProcParentPID_Self(t *testing.T) {
 	got, err := procParentPID(uint32(os.Getpid()))
 	if err != nil {
@@ -44,18 +75,59 @@ func TestProcParentPID_Self(t *testing.T) {
 	}
 }
 
+func TestResolveCgroupID_SelfIsNonZeroAndStable(t *testing.T) {
+	self := uint32(os.Getpid())
+	first, err := resolveCgroupID(self)
+	if err != nil {
+		t.Fatalf("resolveCgroupID(self): %v", err)
+	}
+	if first == 0 {
+		t.Fatal("resolveCgroupID(self) = 0, want a real cgroup inode")
+	}
+	second, err := resolveCgroupID(self)
+	if err != nil {
+		t.Fatalf("resolveCgroupID(self) second call: %v", err)
+	}
+	if second != first {
+		t.Fatalf("resolveCgroupID(self) is not stable across calls: %d != %d", first, second)
+	}
+}
+
+func TestResolveCgroupID_UnknownPidErrors(t *testing.T) {
+	if _, err := resolveCgroupID(1 << 30); err == nil {
+		t.Fatal("resolveCgroupID for a non-existent pid should error")
+	}
+}
+
+// TestVerifyRegisterSessionCgroup_SelfIsOwned proves the still-supported
+// happy path: a peer registering its own pid with its OWN real cgroup_id is
+// accepted. Before #119 this test used an arbitrary, unverified cgroup_id
+// (12345) because nothing checked it; it now must supply the real value.
 func TestVerifyRegisterSessionCgroup_SelfIsOwned(t *testing.T) {
 	self := uint32(os.Getpid())
-	// peer registering its own process: trivially owned.
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, 12345), quietLogger()); err != nil {
-		t.Fatalf("self-registration should be owned, got: %v", err)
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, selfCgroupID(t)), quietLogger()); err != nil {
+		t.Fatalf("self-registration with the real cgroup_id should be owned, got: %v", err)
+	}
+}
+
+// TestVerifyRegisterSessionCgroup_SelfWithWrongCgroupRejected is the #119 gap
+// in its simplest form — no child process needed at all: a peer claiming its
+// OWN pid as root_pid (trivially "owned" by the old ancestry-only check) but
+// a cgroup_id that is NOT the pid's real cgroup must be rejected.
+func TestVerifyRegisterSessionCgroup_SelfWithWrongCgroupRejected(t *testing.T) {
+	self := uint32(os.Getpid())
+	wrong := selfCgroupID(t) + 1 // guaranteed != the real value by construction
+	err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, wrong), quietLogger())
+	if err == nil {
+		t.Fatal("self-registration claiming a cgroup_id that is not the pid's real cgroup should be rejected")
 	}
 }
 
 func TestVerifyRegisterSessionCgroup_NonDescendantRejected(t *testing.T) {
 	self := uint32(os.Getpid())
 	// pid 1 (init) exists but is not a descendant of the test process — a peer
-	// naming a process it did not spawn must be rejected.
+	// naming a process it did not spawn must be rejected, before cgroup
+	// ownership is even considered.
 	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(1, 12345), quietLogger()); err == nil {
 		t.Fatal("registering pid 1 (not a descendant of the peer) should be rejected")
 	}
@@ -71,16 +143,125 @@ func TestVerifyRegisterSessionCgroup_BogusRootRejected(t *testing.T) {
 
 func TestVerifyRegisterSessionCgroup_PeerNotVisibleSkips(t *testing.T) {
 	// If the peer itself is not visible in /proc (cross-PID-namespace daemon),
-	// ancestry can't be established either way — skip rather than break.
+	// neither ancestry nor cgroup ownership can be established — skip rather
+	// than break such a deployment.
 	if err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger()); err != nil {
 		t.Fatalf("unresolvable peer should skip the check, got: %v", err)
 	}
 }
 
 func TestVerifyRegisterSessionCgroup_RootPeerSkips(t *testing.T) {
-	// A root peer is already fully privileged; the ancestry check is skipped for
-	// it (a non-root peer with the same args is rejected — see above).
+	// A root peer is already fully privileged; both checks are skipped for it
+	// (a non-root peer with the same args is rejected — see above).
 	if err := verifyRegisterSessionCgroup(hsRootWithPID(uint32(os.Getpid())), regReq(1, 12345), quietLogger()); err != nil {
-		t.Fatalf("root peer should skip the ancestry check, got: %v", err)
+		t.Fatalf("root peer should skip both checks, got: %v", err)
+	}
+}
+
+// ── issue #119: live PoC reproduction ───────────────────────────────────────
+//
+// The reported exploit: a non-root allowed peer calls
+//
+//	register_session{root_pid: <peer's own child>, cgroup_id: <victim's cgroup>}
+//
+// Ancestry passes (root_pid really is the peer's child), so the pre-#119
+// check (which never looked at cgroup_id at all) accepted this and returned
+// OK=true. The peer could then apply_policy against a cgroup — and workload —
+// it does not own. These two tests are that exact reproduction: a genuine
+// spawned child (real ancestry, not simulated) claiming a cgroup_id that is
+// NOT the child's real cgroup.
+
+func TestVerifyRegisterSessionCgroup_Issue119PocRejected(t *testing.T) {
+	self := uint32(os.Getpid())
+	child := spawnTestChild(t)
+
+	realCgroup, err := resolveCgroupID(child)
+	if err != nil {
+		t.Fatalf("resolveCgroupID(child): %v", err)
+	}
+	victimCgroupID := realCgroup + 1 // "another workload's" cgroup: anything != the child's real one
+
+	// This is the exact call shape from the #119 report: ancestry passes
+	// (child really was spawned by self), cgroup_id does not match reality.
+	err = verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, victimCgroupID), quietLogger())
+	if err == nil {
+		t.Fatal("#119 PoC: register_session{root_pid: own child, cgroup_id: victim} " +
+			"was accepted (OK=true) — the cgroup-ownership gap is NOT closed")
+	}
+	t.Logf("#119 PoC correctly rejected: %v", err)
+}
+
+func TestVerifyRegisterSessionCgroup_Issue119PocAcceptedWithCorrectCgroup(t *testing.T) {
+	// Companion to the rejection test above: proves the check is a real
+	// ownership comparison, not a blanket rejection of any child-cgroup
+	// registration. Same ancestry (spawned child), but the TRUE cgroup_id —
+	// this is exactly the shape of a legitimate `ardur run` registration
+	// before the launcher has moved the child anywhere (the common case: no
+	// cgroup adoption happened, the child stayed in the parent's cgroup).
+	self := uint32(os.Getpid())
+	child := spawnTestChild(t)
+
+	realCgroup, err := resolveCgroupID(child)
+	if err != nil {
+		t.Fatalf("resolveCgroupID(child): %v", err)
+	}
+
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, realCgroup), quietLogger()); err != nil {
+		t.Fatalf("registering a spawned child with its REAL cgroup_id should be accepted, got: %v", err)
+	}
+}
+
+// ── legit `ardur run` adoption flow ─────────────────────────────────────────
+
+// cgroupV2SelfDir resolves the test process's own cgroupfs directory, or
+// skips the test if it cannot be resolved (no cgroup v2, or otherwise
+// unavailable in this environment).
+func cgroupV2SelfDir(t *testing.T) string {
+	t.Helper()
+	path, err := resolveCgroupPath(uint32(os.Getpid()))
+	if err != nil {
+		t.Skipf("cannot resolve own cgroup path (%v); skipping real-adoption reproduction", err)
+	}
+	return path
+}
+
+// TestVerifyRegisterSessionCgroup_LegitAdoptFlowAccepted reproduces the real
+// `ardur run` sequence end to end: create a dedicated cgroup (as
+// kernel_correlation.create_run_cgroup does), spawn a child, move it into
+// that cgroup via cgroup.procs (as CgroupHandle.adopt_pid does), then
+// register with the new cgroup's real inode. Must be accepted — the fix must
+// not break the legitimate flow it exists to protect.
+//
+// Skips gracefully (not a failure) if this environment does not grant write
+// access to a cgroup v2 subtree under the test process's own cgroup — that
+// needs either root or a delegated slice (most systemd-managed CI runners,
+// including GitHub Actions' default ubuntu images, delegate one to the login
+// session; environments that don't still exercise the rest of this file's
+// coverage via the two Issue119Poc tests above, which don't need a real
+// cgroup move).
+func TestVerifyRegisterSessionCgroup_LegitAdoptFlowAccepted(t *testing.T) {
+	parent := cgroupV2SelfDir(t)
+	target := filepath.Join(parent, "ardur-test-119-"+strconv.Itoa(os.Getpid()))
+
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Skipf("cannot create cgroup subtree at %s (%v); need cgroup v2 delegation to run this reproduction", target, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(target) })
+
+	child := spawnTestChild(t)
+
+	procs := filepath.Join(target, "cgroup.procs")
+	if err := os.WriteFile(procs, []byte(strconv.Itoa(int(child))), 0o644); err != nil {
+		t.Skipf("cannot move child into new cgroup via %s (%v); need cgroup v2 delegation to run this reproduction", procs, err)
+	}
+
+	resolvedCgroupID, err := resolveCgroupID(child)
+	if err != nil {
+		t.Fatalf("resolveCgroupID(child) after adoption: %v", err)
+	}
+
+	self := uint32(os.Getpid())
+	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, resolvedCgroupID), quietLogger()); err != nil {
+		t.Fatalf("legit adopt-then-register flow should be accepted, got: %v", err)
 	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -155,6 +155,106 @@ func TestOnSessionRegisteredAndEnded(t *testing.T) {
 	}
 }
 
+// ── issue #119: cgroup collision guard ──────────────────────────────────────
+//
+// checkCgroupCollision is the second, platform-neutral half of #119's fix:
+// even a register_session that independently passes cgroupVerifier's
+// ownership check must not be allowed to bind a cgroup_id another live
+// session already holds.
+
+func TestCheckCgroupCollision_RejectsCgroupAlreadyBoundToAnotherSession(t *testing.T) {
+	d := newTestDaemon(t)
+	d.mu.Lock()
+	d.cgroupIndex[42] = "existing-session"
+	d.mu.Unlock()
+
+	err := d.checkCgroupCollision(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "attacker-session",
+		RootPID:   1,
+		CgroupID:  42,
+	})
+	if err == nil {
+		t.Fatal("registering a cgroup_id already bound to a different session should be rejected")
+	}
+}
+
+func TestCheckCgroupCollision_AllowsSameSessionReRegistering(t *testing.T) {
+	d := newTestDaemon(t)
+	d.mu.Lock()
+	d.cgroupIndex[42] = "same-session"
+	d.mu.Unlock()
+
+	// A session re-registering against the cgroup_id it already owns is not a
+	// collision — it's a legitimate retry of its own registration.
+	err := d.checkCgroupCollision(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "same-session",
+		RootPID:   1,
+		CgroupID:  42,
+	})
+	if err != nil {
+		t.Fatalf("a session re-registering its own cgroup_id should be allowed, got: %v", err)
+	}
+}
+
+func TestCheckCgroupCollision_AllowsUnclaimedCgroup(t *testing.T) {
+	d := newTestDaemon(t)
+	err := d.checkCgroupCollision(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "fresh-session",
+		RootPID:   1,
+		CgroupID:  777,
+	})
+	if err != nil {
+		t.Fatalf("registering an unclaimed cgroup_id should be allowed, got: %v", err)
+	}
+}
+
+func TestCheckCgroupCollision_ZeroCgroupIsNoop(t *testing.T) {
+	d := newTestDaemon(t)
+	// cgroup_id=0 is rejected by protocol validation before this check ever
+	// matters in practice, but the guard itself must not panic or misbehave
+	// on it (e.g. by treating "0: unbound" as some kind of universal match).
+	if err := d.checkCgroupCollision(&kernelcapture.DaemonRegisterSessionRequest{SessionID: "s", RootPID: 1, CgroupID: 0}); err != nil {
+		t.Fatalf("cgroup_id=0 should be a no-op, got: %v", err)
+	}
+}
+
+func TestCheckCgroupCollision_NilRequestIsNoop(t *testing.T) {
+	d := newTestDaemon(t)
+	if err := d.checkCgroupCollision(nil); err != nil {
+		t.Fatalf("nil request should be a no-op, got: %v", err)
+	}
+}
+
+// TestHandleAuthorizedRequest_RejectsCgroupCollisionEvenWithNoOpVerifier
+// proves the collision guard is wired into the real request path
+// (handleAuthorizedRequest), not just unit-testable in isolation: even with
+// cgroupVerifier stubbed to always-allow (as newTestDaemon does, and as
+// production's verifyRegisterSessionCgroup would for a root peer or a
+// same-cgroup claim), a second session cannot register the same cgroup_id
+// an existing live session already holds.
+func TestHandleAuthorizedRequest_RejectsCgroupCollisionEvenWithNoOpVerifier(t *testing.T) {
+	d := newTestDaemon(t)
+	d.mu.Lock()
+	d.cgroupIndex[555] = "first-session"
+	d.mu.Unlock()
+
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "second-session",
+			RootPID:      1,
+			CgroupID:     555,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   60,
+		},
+	}
+	resp := d.handleAuthorizedRequest(context.Background(), req, kernelcapture.DaemonProtocolPeerHandshake{})
+	if resp.OK {
+		t.Fatal("register_session for a cgroup_id already bound to another session should not be OK")
+	}
+}
+
 // TestOnSessionEnded_ClearsSeccompState guards the E4 cleanup wiring:
 // onSessionEnded must clear the session's seccomp policy and cancel (and
 // forget) its seccomp listener supervisor, mirroring the existing

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -263,6 +263,20 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 				Error:           fmt.Sprintf("register_session cgroup ownership check failed: %v", err),
 			}
 		}
+		// #119 collision guard: even a claim that passes ownership verification
+		// must not be allowed to bind a cgroup_id that another live session
+		// already holds — two sessions must never be able to govern the same
+		// cgroup concurrently. See checkCgroupCollision's doc comment for the
+		// residual race this does not fully close.
+		if err := d.checkCgroupCollision(req.RegisterSession); err != nil {
+			return kernelcapture.DaemonProtocolResponse{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          req.Method,
+				SessionID:       req.RegisterSession.SessionID,
+				OK:              false,
+				Error:           fmt.Sprintf("register_session cgroup collision check failed: %v", err),
+			}
+		}
 	}
 
 	resp := d.registry.HandleAuthorizedRequest(ctx, req, handshake)
@@ -535,6 +549,42 @@ func (d *daemon) handleSetKillSwitch(req kernelcapture.DaemonProtocolRequest, ha
 		Method:          kernelcapture.DaemonProtocolMethodSetKillSwitch,
 		OK:              true,
 	}
+}
+
+// checkCgroupCollision (issue #119) rejects a register_session whose claimed
+// cgroup_id is already bound to another live session, so two sessions can
+// never claim enforcement authority over the same cgroup at once — even a
+// claim that independently passes cgroupVerifier's ownership check. Platform-
+// neutral: this is a plain index lookup, no /proc dependency, so it applies
+// (and is tested) on every platform, unlike the Linux-only ownership check.
+//
+// Re-registering the SAME session_id against the SAME cgroup_id it already
+// holds is not a collision (a client may legitimately retry register_session
+// for its own session) and is allowed through.
+//
+// Residual race, accepted: there is a narrow window between this check and
+// onSessionRegistered's index write (below) where two concurrent
+// register_session calls for the identical cgroup_id could both pass this
+// check before either commits. Closing that fully would require moving
+// session admission under the same lock as the registry's own accept path —
+// out of scope for this fix. cgroupVerifier's ownership check is the primary
+// defense against the actual #119 threat (a peer cannot fabricate "root_pid
+// is really a member of this cgroup"); this guard is defense-in-depth on top
+// of that, not the last line, so the residual window is a low-severity gap
+// between two requests that would BOTH have to already be making a
+// legitimately-ownership-verified claim to the same cgroup — an unusual
+// double-registration, not an unauthorized one.
+func (d *daemon) checkCgroupCollision(reg *kernelcapture.DaemonRegisterSessionRequest) error {
+	if reg == nil || reg.CgroupID == 0 {
+		return nil
+	}
+	d.mu.RLock()
+	existing, ok := d.cgroupIndex[reg.CgroupID]
+	d.mu.RUnlock()
+	if ok && existing != reg.SessionID {
+		return fmt.Errorf("cgroup_id %d is already bound to session %q", reg.CgroupID, existing)
+	}
+	return nil
 }
 
 // onSessionRegistered adds the session to the cgroup routing index.


### PR DESCRIPTION
## Summary

Closes #119 (HIGH). Part of Epic A (#63). Residual of #108, gap in #115's `verifyRegisterSessionCgroup`.

`verifyRegisterSessionCgroup` checked only that `root_pid` was a process the peer had spawned (PID ancestry) — it **never inspected `reg.CgroupID`**. A non-root allowed peer could `register_session{root_pid: <its own child>, cgroup_id: <victim's cgroup>}`: ancestry passed trivially (the child really was theirs), the mismatched `cgroup_id` was never checked, and the peer could then `apply_policy` on its own session and reach the enforcement write path for a cgroup — and workload — it does not own.

#115's code comment argued this couldn't be reliably checked because cgroup namespaces make `/proc/<pid>/cgroup` namespace-relative. That's correct, but misapplied: the daemon never needs the socket **peer's** own cgroup (which can be namespace-relative if the peer is containerized) — it needs **`root_pid`'s** cgroup, resolved by the daemon itself. The daemon runs host-side, in the init cgroup namespace, so `/proc/<root_pid>/cgroup` read from there reports the real, non-namespace-relative path — exactly what #119's "Recommended fix" section describes.

## Fix

Two independent, both-required checks in `verifyRegisterSessionCgroup` (`daemon_cgroup_verify_linux.go`):

1. **Ancestry** (existing, #115) — `root_pid` must be a process the peer spawned.
2. **Ownership** (new, #119) — `resolveCgroupID(root_pid)` reads `/proc/<root_pid>/cgroup`, resolves the cgroup v2 unified-hierarchy entry to the cgroup directory's inode (the same value `bpf_get_current_cgroup_id()` returns, and what the Python run bridge computes via `os.stat().st_ino` when it creates a session's cgroup), and requires it equal `reg.CgroupID`. Applied even to the `root_pid == peerPID` self-registration case, which the old ancestry check exempted entirely — the same vulnerability in an even simpler form (no child needed at all).

Plus the collision guard #119 calls out as a cheap interim mitigation, kept as permanent defense-in-depth rather than dropped once the real fix landed: `checkCgroupCollision` (`main.go`, platform-neutral) rejects registering a `cgroup_id` already bound to another live session, wired into `handleAuthorizedRequest` alongside the ownership check.

## PoC evidence (before → after)

Ran the exact #119 PoC shape — `register_session{root_pid: <spawned child>, cgroup_id: <mismatched>}` — against both commits, in a `--privileged` Docker container on a real Linux kernel (not cross-compiled type-checking):

**Before (commit `cfddf89`, #115, unmodified):**
```
=== RUN   TestIssue119Baseline_PocWasAcceptedBeforeFix
    #119 CONFIRMED: pre-fix verifyRegisterSessionCgroup ACCEPTED
    register_session{root_pid=3271 (attacker's own child), cgroup_id=999999999 (victim, unrelated)}
    — OK=true, err=nil. Session "attacker-session" would have been bound to a cgroup the peer does not own.
--- PASS: TestIssue119Baseline_PocWasAcceptedBeforeFix (0.00s)
```
(Throwaway harness, not part of this PR — confirms the regression test below isn't vacuous.)

**After (this branch):**
```
=== RUN   TestVerifyRegisterSessionCgroup_Issue119PocRejected
    #119 PoC correctly rejected: root_pid 3348 is in cgroup 624, not the claimed cgroup_id 625;
    a peer may only register a cgroup_id its root_pid actually occupies
--- PASS: TestVerifyRegisterSessionCgroup_Issue119PocRejected (0.00s)
```

## Test plan

All run for real on Linux (`--privileged` Docker container, `golang:1.26-bookworm`, real cgroup v2), not just cross-compiled:

- [x] `TestVerifyRegisterSessionCgroup_Issue119PocRejected` — the exact PoC shape (spawned child, mismatched `cgroup_id`), now rejected.
- [x] `TestVerifyRegisterSessionCgroup_Issue119PocAcceptedWithCorrectCgroup` — same ancestry, TRUE `cgroup_id` → accepted (proves this is a real comparison, not a blanket rejection).
- [x] `TestVerifyRegisterSessionCgroup_SelfWithWrongCgroupRejected` — the simpler self-registration variant of the same gap.
- [x] `TestVerifyRegisterSessionCgroup_LegitAdoptFlowAccepted` — reproduces the real `ardur run` sequence end to end: creates a real cgroup v2 subtree, spawns a child, moves it via `cgroup.procs` (mirrors `CgroupHandle.adopt_pid`), registers with the resulting real inode → accepted. Skips gracefully (not a failure) if the environment doesn't grant cgroup v2 write access; it did in this container and passed for real.
- [x] `TestVerifyRegisterSessionCgroup_SelfIsOwned`, `_NonDescendantRejected`, `_BogusRootRejected`, `_PeerNotVisibleSkips`, `_RootPeerSkips` — existing #115 coverage, updated where the new check changes expected behavior (SelfIsOwned now needs the real cgroup_id, since the old test's arbitrary value only passed because nothing checked it).
- [x] `TestCheckCgroupCollision_*` (5 tests) + `TestHandleAuthorizedRequest_RejectsCgroupCollisionEvenWithNoOpVerifier` — collision guard, both unit-level and wired through the real request-handling path.
- [x] Full repo `go build`/`go vet`/`go test ./...` green: real Linux (Docker, all packages, not just the changed one), cross-compiled `linux/{amd64,arm64}`, and darwin native.
- [x] `gofmt -l`: clean on every changed file.
- [x] Confirmed by code inspection that `kernel-smoke` (`ardur-guard-smoke`) never calls `register_session` at all, and `seccomp-smoke`'s `register_session` call runs entirely under `sudo` (UID 0) — both untouched by this change, since the root-peer skip this fix preserves is exactly what exempts them.