### PR TITLE
fix(enforce): stop advertising bpf_lsm once detached; pin guard for restart survival

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -17,7 +17,7 @@ name: kernel-enforce
 #
 #   kernel-smoke — boots the runner's own kernel inside a disposable
 #     KVM+virtme-ng VM with BPF-LSM explicitly enabled on the command line,
-#     then runs ardur-guard-smoke as root inside it, two scenarios:
+#     then runs ardur-guard-smoke as root inside it, three scenarios:
 #     (a) apply an OP_EXEC:DENY policy to a fresh cgroup, spawn a child
 #     directly into it, assert its execve fails EPERM and a matching DENY
 #     record lands on enforce_events; (b) apply an OP_FILE_WRITE:ALLOWLIST
@@ -26,9 +26,13 @@ name: kernel-enforce
 #     is the Slice 4.1/4.2 reconciliation proof that guard_file_open's
 #     sleepable hook, which cannot use the cgroup_path_allow LPM trie the
 #     other hooks use, actually enforces path_allow via cgroup_file_allow
-#     instead of failing every allowlisted file op closed. This is the one
-#     thing bpf-generate cannot prove: that the compiled program actually
-#     enforces on a live kernel, not just that it loads.
+#     instead of failing every allowlisted file op closed; (c) issue #124 —
+#     apply an OP_EXEC:DENY policy through a *pinned* guard load, simulate a
+#     daemon restart (Close, then load again from the same bpffs pins with no
+#     re-apply), assert execve is still denied. This is the one thing
+#     bpf-generate cannot prove: that the compiled program actually enforces
+#     — and keeps enforcing across a restart — on a live kernel, not just
+#     that it loads.
 #
 #   seccomp-smoke — the seccomp user-notify tier's equivalent proof (plan
 #     E4, the common-case fallback for hosts where BPF-LSM never loads).

--- a/go/cmd/ardur-guard-smoke/main.go
+++ b/go/cmd/ardur-guard-smoke/main.go
@@ -19,6 +19,9 @@
 //     walk that replaces it for file ops (see ardur_file_allow_key's doc
 //     comment in process_guard.bpf.c).
 //  4. Both cases produce a matching record on the enforce_events ringbuf.
+//  5. Issue #124: a pinned guard load's policy survives a simulated daemon
+//     restart (Close, then load again from the same bpffs pins) with no
+//     re-apply — runRestartSurvivalScenario, restart_survival_scenario.go.
 //
 // Not part of `go test ./...`: this mutates real kernel state (loads a
 // BPF-LSM program, creates cgroups) and requires CAP_BPF/CAP_SYS_ADMIN,
@@ -50,7 +53,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("PASS: process_guard enforced both the exec-deny and file-allowlist scenarios with matching enforce_events")
+	fmt.Println("PASS: process_guard enforced the exec-deny, file-allowlist, and restart-survival scenarios with matching enforce_events")
 }
 
 func run() error {
@@ -82,6 +85,13 @@ func run() error {
 		return fmt.Errorf("file-allowlist scenario: %w", err)
 	}
 	fmt.Println("file-allowlist scenario: PASS")
+
+	// Uses its own pinned load(s), independent of the shared `handles` above
+	// (see runRestartSurvivalScenario's doc comment for why).
+	if err := runRestartSurvivalScenario(); err != nil {
+		return fmt.Errorf("restart-survival scenario: %w", err)
+	}
+	fmt.Println("restart-survival scenario: PASS")
 
 	return nil
 }

--- a/go/cmd/ardur-guard-smoke/restart_survival_scenario.go
+++ b/go/cmd/ardur-guard-smoke/restart_survival_scenario.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+	"golang.org/x/sys/unix"
 )
 
 // runRestartSurvivalScenario applies an OP_EXEC:DENY policy against a fresh
@@ -28,15 +29,49 @@ import (
 // cgroup, which process_guard treats as "not managed" — default-allow. A
 // regression here shows up as execve unexpectedly *succeeding* post-restart,
 // not as an ambiguous error, so this scenario can't pass by accident.
+// ensureBpffsMounted makes /sys/fs/bpf a mounted bpf filesystem if it is not
+// already one. Idempotent: an already-mounted bpffs is success (detected via
+// statfs, with EBUSY from the mount call as a fallback). Needed because BPF
+// link/map pins can only be created on a bpf filesystem.
+func ensureBpffsMounted() error {
+	const bpffs = "/sys/fs/bpf"
+	if err := os.MkdirAll(bpffs, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", bpffs, err)
+	}
+	var st unix.Statfs_t
+	if err := unix.Statfs(bpffs, &st); err == nil && uint64(st.Type) == uint64(unix.BPF_FS_MAGIC) {
+		return nil // already a bpffs
+	}
+	if err := unix.Mount("bpf", bpffs, "bpf", 0, ""); err != nil && err != unix.EBUSY {
+		return fmt.Errorf("mount bpf at %s: %w", bpffs, err)
+	}
+	return nil
+}
+
 func runRestartSurvivalScenario() error {
 	const cgroupDir = "/sys/fs/cgroup/ardur-guard-smoke-restart"
+
+	// BPF pins require a mounted bpf filesystem. A minimal guest (the
+	// virtme-ng kernel-smoke VM) may not auto-mount /sys/fs/bpf, so ensure it
+	// before pinning — otherwise every pin silently fails and the restart
+	// survival this scenario proves is defeated.
+	if err := ensureBpffsMounted(); err != nil {
+		return fmt.Errorf("ensure bpffs mounted: %w", err)
+	}
 
 	// A dedicated, disposable pin directory (not DefaultPinnedGuardPaths'
 	// real /sys/fs/bpf/ardur/) so this smoke run never collides with an
 	// actual daemon's pins on the same host and cleans up after itself.
-	pinDir, err := resolvedTempDir("ardur-guard-smoke-pins-*")
-	if err != nil {
-		return fmt.Errorf("create pin directory: %w", err)
+	//
+	// It MUST live on a bpffs mount, not the tmpfs (/dev/shm) the other
+	// scenarios use for their regular file paths: BPF link/map pins can only
+	// be created on a bpf filesystem, and pinning to tmpfs fails with "is not
+	// on a bpf filesystem" — silently (each pin is non-fatal), which then
+	// detaches everything on Close and defeats the very restart survival this
+	// scenario exists to prove. Use a subdir under /sys/fs/bpf.
+	pinDir := fmt.Sprintf("/sys/fs/bpf/ardur-guard-smoke-pins-%d", os.Getpid())
+	if err := os.MkdirAll(pinDir, 0o700); err != nil {
+		return fmt.Errorf("create bpffs pin directory %s (is /sys/fs/bpf a mounted bpf filesystem?): %w", pinDir, err)
 	}
 	defer os.RemoveAll(pinDir)
 	paths := kernelcapture.PinnedGuardPaths{

--- a/go/cmd/ardur-guard-smoke/restart_survival_scenario.go
+++ b/go/cmd/ardur-guard-smoke/restart_survival_scenario.go
@@ -1,0 +1,111 @@
+//go:build linux
+
+package main
+
+// restart_survival_scenario.go — proves issue #124's fix: pinning the
+// process_guard BPF-LSM links and policy-state maps means a daemon restart
+// re-attaches to already-enforcing kernel state instead of dropping the
+// applied policy. A daemon restart is simulated here the same way it happens
+// for real: ProcessGuardHandles.Close() releases this process's FDs but,
+// by design, never removes the bpffs pins — the three LSM programs and
+// every policy map stay exactly as they were in the kernel throughout.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+// runRestartSurvivalScenario applies an OP_EXEC:DENY policy against a fresh
+// cgroup through a pinned guard load, confirms EPERM, simulates a daemon
+// restart (Close, then load again from the same pins), and asserts execve is
+// STILL denied WITHOUT ever calling ApplyPolicyMaps a second time.
+//
+// This is a meaningful (not vacuous) assertion: if the second load silently
+// fell back to a fresh unpinned attach instead of reusing the pinned state,
+// the freshly created cgroup_managed map would have no entry at all for this
+// cgroup, which process_guard treats as "not managed" — default-allow. A
+// regression here shows up as execve unexpectedly *succeeding* post-restart,
+// not as an ambiguous error, so this scenario can't pass by accident.
+func runRestartSurvivalScenario() error {
+	const cgroupDir = "/sys/fs/cgroup/ardur-guard-smoke-restart"
+
+	// A dedicated, disposable pin directory (not DefaultPinnedGuardPaths'
+	// real /sys/fs/bpf/ardur/) so this smoke run never collides with an
+	// actual daemon's pins on the same host and cleans up after itself.
+	pinDir, err := resolvedTempDir("ardur-guard-smoke-pins-*")
+	if err != nil {
+		return fmt.Errorf("create pin directory: %w", err)
+	}
+	defer os.RemoveAll(pinDir)
+	paths := kernelcapture.PinnedGuardPaths{
+		BprmLinkPath:        pinDir + "/bprm_link",
+		FileOpenLinkPath:    pinDir + "/file_open_link",
+		SocketConnLinkPath:  pinDir + "/socket_connect_link",
+		CgroupOpPolicyPath:  pinDir + "/cgroup_op_policy",
+		CgroupPathAllowPath: pinDir + "/cgroup_path_allow",
+		CgroupFileAllowPath: pinDir + "/cgroup_file_allow",
+		CgroupNetAllowPath:  pinDir + "/cgroup_net_allow",
+		CgroupManagedPath:   pinDir + "/cgroup_managed",
+		KillSwitchPath:      pinDir + "/kill_switch",
+		EnforceEventsPath:   pinDir + "/enforce_events",
+	}
+	defer kernelcapture.RemovePinnedGuardState(paths)
+
+	cgroupID, cgFile, err := setupSmokeCgroup(cgroupDir)
+	if err != nil {
+		return fmt.Errorf("set up cgroup: %w", err)
+	}
+	defer cgFile.Close()
+	defer os.Remove(cgroupDir)
+
+	firstHandles, err := kernelcapture.LoadAndAttachProcessGuardEBPFPinned(paths)
+	if err != nil {
+		return fmt.Errorf("first (pre-restart) pinned load: %w", err)
+	}
+
+	maps := kernelcapture.PolicyMapsFromHandles(firstHandles)
+	policy := kernelcapture.DaemonApplyPolicyRequest{
+		SessionID:   "guard-smoke-restart",
+		Generation:  smokeGeneration,
+		EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		OpPolicies: []kernelcapture.DaemonOpPolicy{
+			// Same OP_FILE_READ:ALLOW rationale as runExecDenyScenario: execve
+			// opens the target binary for reading before bprm_check_security
+			// runs, so this must be present or the process never reaches the
+			// exec hook this scenario is actually testing.
+			{Op: kernelcapture.BpfOpFileRead, Action: kernelcapture.BpfActionAllow, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			{Op: kernelcapture.BpfOpExec, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+		},
+	}
+	if err := kernelcapture.ApplyPolicyMaps(maps, cgroupID, policy); err != nil {
+		firstHandles.Close()
+		return fmt.Errorf("apply OP_EXEC:DENY policy before simulated restart: %w", err)
+	}
+	fmt.Printf("applied OP_EXEC:DENY (ENFORCE) policy for cgroup_id=%d via pinned load\n", cgroupID)
+
+	if err := execveInCgroupExpectEPERM(cgFile); err != nil {
+		firstHandles.Close()
+		return fmt.Errorf("pre-restart EPERM check: %w", err)
+	}
+	fmt.Println("pre-restart: execve denied as expected")
+
+	// Simulate the daemon process exiting and restarting.
+	firstHandles.Close()
+
+	secondHandles, err := kernelcapture.LoadAndAttachProcessGuardEBPFPinned(paths)
+	if err != nil {
+		return fmt.Errorf("second (post-restart) pinned load: %w", err)
+	}
+	defer secondHandles.Close()
+
+	// Deliberately no ApplyPolicyMaps call here: the whole point is that the
+	// pre-restart policy is still enforced without re-applying anything.
+	if err := execveInCgroupExpectEPERM(cgFile); err != nil {
+		return fmt.Errorf("post-restart EPERM check (policy must survive without re-apply, issue #124): %w", err)
+	}
+	fmt.Println("post-restart: execve still denied with no re-apply -- pinned policy survived (issue #124)")
+
+	return nil
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_degrade_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_degrade_test.go
@@ -1,0 +1,179 @@
+package main
+
+// daemon_guard_degrade_test.go — tests for issue #121: the daemon must never
+// keep advertising the bpf_lsm enforcement tier once the guard consumer that
+// was actually feeding enforce_events has exited. Exercises degradeGuardTier
+// directly (the pure state-transition logic) and end-to-end through the
+// health protocol response, without needing a real kernel/BPF-LSM.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+func TestDegradeGuardTier_MovesBPFLSMToNone(t *testing.T) {
+	d := newTestDaemon(t)
+	d.setActiveTier(daemonTierBPFLSM)
+
+	d.degradeGuardTier(errors.New("ringbuf read: i/o error"), d.log)
+
+	if got := d.getActiveTier(); got != daemonTierNone {
+		t.Fatalf("activeTier after degrade = %q, want %q", got, daemonTierNone)
+	}
+}
+
+// TestDegradeGuardTier_CleanEOFAlsoDegrades covers the "err == nil" cause: a
+// clean io.EOF from consumeEnforceEvents (e.g. the guard was force-detached
+// externally, closing the ringbuf for a reason other than this daemon's own
+// ctx-cancellation watcher) must degrade the tier exactly like a real error
+// does -- the guard is equally gone either way.
+func TestDegradeGuardTier_CleanEOFAlsoDegrades(t *testing.T) {
+	d := newTestDaemon(t)
+	d.setActiveTier(daemonTierBPFLSM)
+
+	d.degradeGuardTier(nil, d.log)
+
+	if got := d.getActiveTier(); got != daemonTierNone {
+		t.Fatalf("activeTier after clean-EOF degrade = %q, want %q", got, daemonTierNone)
+	}
+}
+
+// TestDegradeGuardTier_NoOpWhenBPFLSMNeverActive covers the startup-load-
+// failure path: runGuardConsumer can return before main()'s ready-channel
+// select has ever set activeTier to bpf_lsm (preflight or load failed
+// immediately). degradeGuardTier must not manufacture a spurious transition
+// or tamper-audit entry in that case.
+func TestDegradeGuardTier_NoOpWhenBPFLSMNeverActive(t *testing.T) {
+	d := newTestDaemon(t)
+	// activeTier is daemonTierNone from newTestDaemon; simulate the seccomp
+	// fallback having already won, too.
+	d.setActiveTier(daemonTierSeccomp)
+
+	d.degradeGuardTier(errors.New("preflight failed"), d.log)
+
+	if got := d.getActiveTier(); got != daemonTierSeccomp {
+		t.Fatalf("activeTier changed to %q, want unchanged %q", got, daemonTierSeccomp)
+	}
+	if n := d.tamperChain.Len(); n != 0 {
+		t.Fatalf("tamperChain.Len() = %d, want 0 (no-op must not record an entry)", n)
+	}
+}
+
+// TestDegradeGuardTier_RecordsAuditableTamperEntry proves the degradation is
+// not just a log line: it is hash-chained and appended to the same evidence
+// trail RunTamperAudit ticks use, so an operator who is already watching
+// tamper_audit.jsonl for drift sees this event too.
+func TestDegradeGuardTier_RecordsAuditableTamperEntry(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = stub
+	d.setActiveTier(daemonTierBPFLSM)
+
+	cause := errors.New("enforce_events ringbuf read: link detached")
+	d.degradeGuardTier(cause, d.log)
+
+	if n := d.tamperChain.Len(); n != 1 {
+		t.Fatalf("tamperChain.Len() = %d, want 1", n)
+	}
+
+	path := filepath.Join(d.evidenceDir, "_tamper", "tamper_audit.jsonl")
+	stub.mu.Lock()
+	data := stub.appends[path]
+	stub.mu.Unlock()
+	if len(data) == 0 {
+		t.Fatalf("no tamper_audit.jsonl entry written to %s", path)
+	}
+
+	var entry kernelcapture.TamperReceiptEntry
+	if err := json.Unmarshal(data[:len(data)-1], &entry); err != nil {
+		t.Fatalf("unmarshal tamper receipt: %v\n%s", err, data)
+	}
+	if !entry.Result.Drift {
+		t.Fatal("recorded tamper entry Drift = false, want true")
+	}
+	found := false
+	for _, c := range entry.Result.Checks {
+		if c.Name == "guard_consumer" {
+			found = true
+			if c.OK {
+				t.Error("guard_consumer check OK = true, want false")
+			}
+			if c.Detail == "" || !strings.Contains(c.Detail, "guard consumer exited") || !strings.Contains(c.Detail, cause.Error()) {
+				t.Errorf("guard_consumer detail = %q, want it to explain the cause and the transition", c.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no guard_consumer check in the recorded tamper entry")
+	}
+}
+
+// TestHealthReflectsTrueTier_AfterGuardConsumerDeath is the end-to-end proof
+// the issue asks for: a client calling health after the guard consumer has
+// died must see EnforcementTierNone, never a stale EnforcementTierBPFLSM --
+// even though nothing here touches a real kernel or BPF-LSM.
+func TestHealthReflectsTrueTier_AfterGuardConsumerDeath(t *testing.T) {
+	d := newTestDaemon(t)
+	d.fs = newStubFS()
+
+	// Simulate a successful guard load: policyMaps populated, tier live.
+	d.policyMaps = kernelcapture.PolicyMaps{
+		CgroupOpPolicy:  &fakeHealthPolicyMap{},
+		CgroupPathAllow: &fakeHealthPolicyMap{},
+		CgroupFileAllow: &fakeHealthPolicyMap{},
+		CgroupNetAllow:  &fakeHealthPolicyMap{},
+		CgroupManaged:   &fakeHealthPolicyMap{},
+		KillSwitch:      &fakeHealthPolicyMap{},
+	}
+	d.setActiveTier(daemonTierBPFLSM)
+
+	before := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
+	if before.EnforcementTier != kernelcapture.EnforcementTierBPFLSM {
+		t.Fatalf("precondition: EnforcementTier = %q, want %q", before.EnforcementTier, kernelcapture.EnforcementTierBPFLSM)
+	}
+
+	// The guard consumer dies mid-run: its defer clears policyMaps (mirrors
+	// runGuardConsumer's defer in daemon_guard_linux.go), and the goroutine
+	// that awaited it calls degradeGuardTier -- exactly what main() now does.
+	d.policyMaps = kernelcapture.PolicyMaps{}
+	d.degradeGuardTier(errors.New("guard died"), d.log)
+
+	after := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
+	if !after.OK {
+		t.Fatalf("health response = %+v, want OK", after)
+	}
+	if after.EnforcementTier != kernelcapture.EnforcementTierNone {
+		t.Fatalf("EnforcementTier after guard death = %q, want %q (must never keep advertising a detached tier)",
+			after.EnforcementTier, kernelcapture.EnforcementTierNone)
+	}
+}
+
+// TestActiveTier_ConcurrentReadWriteIsRaceFree exercises getActiveTier /
+// setActiveTier / enforcementTier concurrently -- activeTier is written from
+// the guard goroutine and read from every socket-handling goroutine in
+// production; this is meaningful under `go test -race` (see kernel-enforce.yml).
+func TestActiveTier_ConcurrentReadWriteIsRaceFree(t *testing.T) {
+	d := newTestDaemon(t)
+	d.fs = newStubFS()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			d.setActiveTier(daemonTierBPFLSM)
+			d.degradeGuardTier(errors.New("flap"), d.log)
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		_ = d.enforcementTier()
+		_ = d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
+	}
+	<-done
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
@@ -22,6 +22,18 @@ package main
 // links and kill-switch state each tick via kernelcapture.RunTamperAudit and
 // records the result through d.recordTamperAudit — see tamper_audit.go for
 // what this can and cannot detect.
+//
+// Restart survival (issue #124): loads via LoadAndAttachProcessGuardEBPFPinned,
+// which pins the three LSM links and every policy-state map under
+// /sys/fs/bpf/ardur/ so a daemon restart re-attaches to the still-enforcing
+// kernel state instead of dropping it — see that function's doc comment.
+//
+// Fail-open on mid-run death (issue #121): if this function returns while the
+// daemon is still running (main()'s ctx not yet cancelled) — whether from a
+// real error or a clean ringbuf close caused by something other than our own
+// shutdown watcher below — the caller in main() calls d.degradeGuardTier so
+// activeTier (and therefore every health response) stops claiming bpf_lsm the
+// moment nothing is actually attached anymore.
 
 import (
 	"context"
@@ -68,7 +80,7 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready ch
 		}
 	}
 
-	handles, err := kernelcapture.LoadAndAttachProcessGuardEBPF()
+	handles, err := kernelcapture.LoadAndAttachProcessGuardEBPFPinned(kernelcapture.DefaultPinnedGuardPaths())
 	if err != nil {
 		err = fmt.Errorf("load process_guard BPF-LSM: %w", err)
 		ready <- err

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -122,6 +122,14 @@ type daemon struct {
 	// health responses so a launcher can decide whether routing a governed
 	// process through ardur-exec-shim (the seccomp tier's on-ramp) is
 	// necessary at all. One of the daemonTier* constants.
+	//
+	// Not just startup-once, though: if the BPF-LSM guard consumer exits
+	// mid-run (issue #121 — e.g. the ringbuf closes because the guard was
+	// force-detached externally, or a real error), degradeGuardTier moves
+	// this back to daemonTierNone so health never keeps advertising bpf_lsm
+	// once nothing is actually attached. Read/write only via getActiveTier /
+	// setActiveTier, which take mu — this field is written from the guard
+	// goroutine and read from every socket-handling goroutine concurrently.
 	activeTier string
 
 	// applyMu serializes every BPF policy-map mutation — ApplyPolicyMaps,
@@ -304,13 +312,83 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 // activeTier is set to bpf_lsm exactly when the maps load, so the two never
 // disagree there; the fallback only matters for that bypass path.
 func (d *daemon) enforcementTier() string {
-	if d.activeTier != "" && d.activeTier != daemonTierNone {
-		return d.activeTier
+	if tier := d.getActiveTier(); tier != "" && tier != daemonTierNone {
+		return tier
 	}
 	if kernelcapture.PolicyMapsReady(d.policyMaps) {
 		return kernelcapture.EnforcementTierBPFLSM
 	}
 	return kernelcapture.EnforcementTierNone
+}
+
+// getActiveTier returns the current activeTier under mu. See activeTier's
+// doc comment: this is read from every socket-handling goroutine and written
+// from both main()'s startup tier selection and degradeGuardTier.
+func (d *daemon) getActiveTier() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.activeTier
+}
+
+// setActiveTier atomically updates activeTier under mu.
+func (d *daemon) setActiveTier(tier string) {
+	d.mu.Lock()
+	d.activeTier = tier
+	d.mu.Unlock()
+}
+
+// degradeGuardTier handles the guard consumer goroutine returning while ctx
+// is still live — i.e. NOT normal shutdown (issue #121).
+//
+// This fires for two distinct causes, both of which mean the same thing to a
+// health caller: process_guard is no longer attached and enforce_events is no
+// longer flowing. (a) cause != nil: a real read/decode failure. (b) cause ==
+// nil: consumeEnforceEvents returned via a clean io.EOF, which
+// ringbufEnforceEventReader also produces when the ringbuf was closed for a
+// reason OTHER than this daemon's own ctx-cancellation watcher — e.g. the
+// guard was force-detached externally (bpftool link detach, or the same
+// external-tamper class RunTamperAudit checks for on its own timer). Either
+// way, d.policyMaps was already cleared to its zero value by runGuardConsumer's
+// defer by the time this runs; activeTier must not keep claiming bpf_lsm past
+// that point.
+//
+// No-op if activeTier was never actually bpf_lsm — covers the startup-load-
+// failure case, where runGuardConsumer returns immediately (before this
+// goroutine's caller's ready-channel select has run) and there is nothing to
+// degrade from.
+//
+// Deliberately does not attempt to stand up the seccomp fallback tier
+// retroactively: that tier's supervisor goroutine and socket lifecycle are
+// wired only at startup (main()'s "if activeTier != bpf_lsm" branch), and
+// retrofitting a second start site here would need its own careful
+// wg/cancellation handling for a case that is already rare and already
+// correctly reported once this function returns. Loudly signalling the true
+// (degraded) tier — never silently keeping a stale bpf_lsm claim alive — is
+// the fix; auto-failover is a larger, separate change.
+func (d *daemon) degradeGuardTier(cause error, log *slog.Logger) {
+	previous := d.getActiveTier()
+	if previous != daemonTierBPFLSM {
+		return
+	}
+	d.setActiveTier(daemonTierNone)
+
+	detail := fmt.Sprintf(
+		"guard consumer exited while the daemon is still running; enforcement tier downgraded from %q to %q",
+		previous, daemonTierNone,
+	)
+	if cause != nil {
+		detail = fmt.Sprintf("%s: %v", detail, cause)
+	}
+	log.Error("BPF-LSM guard consumer exited mid-run: enforcement tier degraded", "cause", cause, "previous_tier", previous)
+	d.recordTamperAudit(kernelcapture.TamperAuditResult{
+		CheckedAt: time.Now().UTC(),
+		Drift:     true,
+		Checks: []kernelcapture.TamperCheckResult{{
+			Name:   "guard_consumer",
+			OK:     false,
+			Detail: detail,
+		}},
+	}, log)
 }
 
 // handleApplyPolicy validates the session, resolves its cgroup_id, and writes
@@ -359,7 +437,7 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, hand
 
 	if err := kernelcapture.ApplyPolicyMaps(d.policyMaps, record.CgroupID, *ap); err != nil {
 		if errors.Is(err, kernelcapture.ErrPolicyMapsUnavailable) {
-			if d.activeTier == daemonTierSeccomp && seccompFullyCoversPolicy(ap) {
+			if d.getActiveTier() == daemonTierSeccomp && seccompFullyCoversPolicy(ap) {
 				// BPF-LSM being unavailable isn't a degradation here: the
 				// active tier on this host is seccomp user-notify, and every
 				// op this request asks for (OP_NET_CONNECT only) is within
@@ -1078,16 +1156,26 @@ func main() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				if err := runGuardConsumer(ctx, d, log, guardOutcome); err != nil && ctx.Err() == nil {
+				err := runGuardConsumer(ctx, d, log, guardOutcome)
+				if ctx.Err() != nil {
+					return // normal shutdown
+				}
+				if err != nil {
 					log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
 						"error", err)
 				}
+				// Reached whether runGuardConsumer failed mid-run (err != nil)
+				// or its ringbuf closed cleanly for a reason other than our
+				// own shutdown watcher (err == nil — e.g. an external force-
+				// detach); either way the guard is no longer attached. Issue
+				// #121: never leave activeTier claiming bpf_lsm past this point.
+				d.degradeGuardTier(err, log)
 			}()
 
 			select {
 			case err := <-guardOutcome:
 				if err == nil {
-					d.activeTier = daemonTierBPFLSM
+					d.setActiveTier(daemonTierBPFLSM)
 				} else {
 					log.Warn("BPF-LSM tier not active, falling back to seccomp tier", "error", err)
 				}
@@ -1100,8 +1188,8 @@ func main() {
 			log.Warn("BPF-LSM guard tier disabled via --disable-bpf-lsm; forcing seccomp user-notify tier")
 		}
 
-		if d.activeTier != daemonTierBPFLSM && ctx.Err() == nil {
-			d.activeTier = daemonTierSeccomp
+		if d.getActiveTier() != daemonTierBPFLSM && ctx.Err() == nil {
+			d.setActiveTier(daemonTierSeccomp)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -1110,7 +1198,7 @@ func main() {
 				}
 			}()
 		}
-		log.Info("enforcement tier selected", "tier", d.activeTier, "seccomp_socket", *seccompSocketPath)
+		log.Info("enforcement tier selected", "tier", d.getActiveTier(), "seccomp_socket", *seccompSocketPath)
 	} else {
 		log.Info("eBPF ringbuf consumers disabled (--no-ringbuf); enforcement tiers unavailable")
 	}

--- a/go/pkg/kernelcapture/bpf_policy_apply_linux.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_linux.go
@@ -13,6 +13,9 @@ package kernelcapture
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -141,6 +144,288 @@ func LoadAndAttachProcessGuardEBPF() (*ProcessGuardHandles, error) {
 	}
 
 	return h, nil
+}
+
+// PinnedGuardPaths holds the bpffs paths used for pinning the process_guard
+// BPF-LSM links and its policy-state maps (issue #124).
+//
+// Unlike the process-exec tracepoint (PinnedEBPFPaths: 2 links + 1 ringbuf
+// map), the guard has three LSM links and seven maps. Only the six maps that
+// hold policy STATE plus the enforce_events ringbuf are listed here — the
+// three per-CPU scratch maps (file_allow_scratch, net_lpm_scratch,
+// path_lpm_scratch) are working memory the BPF program repopulates on every
+// invocation; they carry no state worth preserving across a restart and are
+// safe to recreate empty on every load.
+type PinnedGuardPaths struct {
+	BprmLinkPath       string
+	FileOpenLinkPath   string
+	SocketConnLinkPath string
+
+	CgroupOpPolicyPath  string
+	CgroupPathAllowPath string
+	CgroupFileAllowPath string
+	CgroupNetAllowPath  string
+	CgroupManagedPath   string
+	KillSwitchPath      string
+	EnforceEventsPath   string
+}
+
+// allPaths returns every pin path, for the "ensure directory, then pin"
+// and "load every pin, all-or-nothing" loops below.
+func (p PinnedGuardPaths) allPaths() []string {
+	return []string{
+		p.BprmLinkPath, p.FileOpenLinkPath, p.SocketConnLinkPath,
+		p.CgroupOpPolicyPath, p.CgroupPathAllowPath, p.CgroupFileAllowPath,
+		p.CgroupNetAllowPath, p.CgroupManagedPath, p.KillSwitchPath,
+		p.EnforceEventsPath,
+	}
+}
+
+// DefaultPinnedGuardPaths returns the standard bpffs pin paths under the
+// ardur-owned bpffs namespace (/sys/fs/bpf/ardur/), alongside
+// DefaultPinnedEBPFPaths' tracepoint pins.
+func DefaultPinnedGuardPaths() PinnedGuardPaths {
+	const base = "/sys/fs/bpf/ardur/"
+	return PinnedGuardPaths{
+		BprmLinkPath:        base + "guard_bprm_link",
+		FileOpenLinkPath:    base + "guard_file_open_link",
+		SocketConnLinkPath:  base + "guard_socket_connect_link",
+		CgroupOpPolicyPath:  base + "cgroup_op_policy",
+		CgroupPathAllowPath: base + "cgroup_path_allow",
+		CgroupFileAllowPath: base + "cgroup_file_allow",
+		CgroupNetAllowPath:  base + "cgroup_net_allow",
+		CgroupManagedPath:   base + "cgroup_managed",
+		KillSwitchPath:      base + "kill_switch",
+		EnforceEventsPath:   base + "enforce_events",
+	}
+}
+
+// LoadAndAttachProcessGuardEBPFPinned is like LoadAndAttachProcessGuardEBPF
+// but adds BPF link- and map-pinning for restart survival (issue #124: prior
+// to this, every daemon restart detached the guard's LSM hooks and dropped
+// every applied policy — cgroup_managed, cgroup_op_policy, etc. all rebuilt
+// empty — so a governed agent ran completely unenforced from the moment the
+// daemon process exited until apply_policy was called again, if ever).
+//
+// On first start (no pinned state at paths): loads and attaches the eBPF
+// program as usual (LoadAndAttachProcessGuardEBPF), then pins all three LSM
+// links and the six policy-state maps (+ the enforce_events ringbuf map) to
+// bpffs. The pinned links keep the LSM hooks — and thus enforcement — live in
+// the kernel even after this daemon process exits; the pinned maps keep every
+// applied policy's contents intact, so there is nothing to "re-apply" after a
+// restart that successfully reuses these pins: the kernel never stopped
+// enforcing what was already applied.
+//
+// On restart (all ten pins present): loads them back without re-attaching or
+// re-applying anything, matching the tracepoint's restart path. The three LSM
+// programs have been continuously attached and enforcing in the kernel since
+// the prior daemon start; this call just re-establishes this process's
+// userspace handle on that unbroken state, including a fresh ringbuf.Reader
+// bound to the exact (still-being-written-to) enforce_events map.
+//
+// If any pin is missing (a prior pin attempt partially failed, or this is
+// truly the first start), the pinned state is treated as unusable in its
+// entirety and this falls back to a fresh load/attach/pin — never a partial
+// reuse, which could bind a reader or policy write path to inconsistent state.
+//
+// If pinning itself fails (e.g. bpffs not mounted, insufficient permissions),
+// the function returns the handles without pins and logs nothing itself (the
+// caller — runGuardConsumer — already logs guard-load outcomes); the daemon
+// still enforces for this run, it just loses the restart-survival property,
+// identical to the tracepoint's accepted degradation in that case.
+//
+// Caller must call Close on the returned handles when done. Close does NOT
+// remove the bpffs pins; call RemovePinnedGuardState to do that explicitly.
+func LoadAndAttachProcessGuardEBPFPinned(paths PinnedGuardPaths) (*ProcessGuardHandles, error) {
+	if h, ok := tryLoadPinnedGuardState(paths); ok {
+		return h, nil
+	}
+
+	h, err := LoadAndAttachProcessGuardEBPF()
+	if err != nil {
+		return nil, err
+	}
+
+	// Each pin is independently non-fatal: a partial pin set (e.g. links
+	// pinned but a map pin fails) makes tryLoadPinnedGuardState fail on the
+	// next restart — by design, since it requires all ten — falling back to
+	// this fresh-load path again rather than reusing inconsistent state.
+	pins := []struct {
+		path string
+		pin  func(string) error
+	}{
+		{paths.BprmLinkPath, h.bprmLink.Pin},
+		{paths.FileOpenLinkPath, h.fileOpenLink.Pin},
+		{paths.SocketConnLinkPath, h.socketConnLink.Pin},
+		{paths.CgroupOpPolicyPath, h.objs.CgroupOpPolicy.Pin},
+		{paths.CgroupPathAllowPath, h.objs.CgroupPathAllow.Pin},
+		{paths.CgroupFileAllowPath, h.objs.CgroupFileAllow.Pin},
+		{paths.CgroupNetAllowPath, h.objs.CgroupNetAllow.Pin},
+		{paths.CgroupManagedPath, h.objs.CgroupManaged.Pin},
+		{paths.KillSwitchPath, h.objs.KillSwitch.Pin},
+		{paths.EnforceEventsPath, h.objs.EnforceEvents.Pin},
+	}
+	for _, p := range pins {
+		if mkErr := os.MkdirAll(filepath.Dir(p.path), 0o700); mkErr == nil {
+			_ = p.pin(p.path)
+		}
+	}
+
+	return h, nil
+}
+
+// RemovePinnedGuardState removes every bpffs pin in paths, if present. Used
+// to force a truly fresh load (e.g. an operator-invoked "unstick" path) —
+// not called anywhere in the normal daemon lifecycle.
+func RemovePinnedGuardState(paths PinnedGuardPaths) {
+	for _, p := range paths.allPaths() {
+		_ = os.Remove(p)
+	}
+}
+
+// tryLoadPinnedGuardState attempts to load all three LSM links and all seven
+// (six policy + enforce_events) maps from bpffs. Returns ok=true only if
+// every one of the ten succeeds; otherwise it closes any partially-opened
+// handles and returns ok=false so the caller falls back to a fresh
+// load/attach/pin rather than binding a reader or policy maps to inconsistent
+// state (e.g. links attached but pointing at maps this process never
+// verified are the matching generation).
+func tryLoadPinnedGuardState(paths PinnedGuardPaths) (*ProcessGuardHandles, bool) {
+	var opened []io.Closer
+	closeAll := func() {
+		for i := len(opened) - 1; i >= 0; i-- {
+			opened[i].Close()
+		}
+	}
+
+	loadLink := func(path string) (link.Link, bool) {
+		l, err := link.LoadPinnedLink(path, nil)
+		if err != nil {
+			return nil, false
+		}
+		opened = append(opened, l)
+		return l, true
+	}
+	loadMap := func(path string) (*ebpf.Map, bool) {
+		m, err := ebpf.LoadPinnedMap(path, nil)
+		if err != nil {
+			return nil, false
+		}
+		opened = append(opened, m)
+		return m, true
+	}
+
+	bprmLink, ok := loadLink(paths.BprmLinkPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	fileOpenLink, ok := loadLink(paths.FileOpenLinkPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	socketConnLink, ok := loadLink(paths.SocketConnLinkPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+
+	cgroupOpPolicy, ok := loadMap(paths.CgroupOpPolicyPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	cgroupPathAllow, ok := loadMap(paths.CgroupPathAllowPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	cgroupFileAllow, ok := loadMap(paths.CgroupFileAllowPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	cgroupNetAllow, ok := loadMap(paths.CgroupNetAllowPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	cgroupManaged, ok := loadMap(paths.CgroupManagedPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	killSwitch, ok := loadMap(paths.KillSwitchPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+	enforceEvents, ok := loadMap(paths.EnforceEventsPath)
+	if !ok {
+		closeAll()
+		return nil, false
+	}
+
+	bprmProgID, err := linkProgramID(bprmLink)
+	if err != nil {
+		closeAll()
+		return nil, false
+	}
+	fileOpenProgID, err := linkProgramID(fileOpenLink)
+	if err != nil {
+		closeAll()
+		return nil, false
+	}
+	socketConnProgID, err := linkProgramID(socketConnLink)
+	if err != nil {
+		closeAll()
+		return nil, false
+	}
+
+	reader, err := ringbuf.NewReader(enforceEvents)
+	if err != nil {
+		closeAll()
+		return nil, false
+	}
+
+	h := &ProcessGuardHandles{
+		bprmLink:         bprmLink,
+		fileOpenLink:     fileOpenLink,
+		socketConnLink:   socketConnLink,
+		bprmProgID:       bprmProgID,
+		fileOpenProgID:   fileOpenProgID,
+		socketConnProgID: socketConnProgID,
+		reader:           reader,
+	}
+	h.objs.CgroupOpPolicy = cgroupOpPolicy
+	h.objs.CgroupPathAllow = cgroupPathAllow
+	h.objs.CgroupFileAllow = cgroupFileAllow
+	h.objs.CgroupNetAllow = cgroupNetAllow
+	h.objs.CgroupManaged = cgroupManaged
+	h.objs.KillSwitch = killSwitch
+	h.objs.EnforceEvents = enforceEvents
+	// processGuardPrograms fields are left at their zero value (nil
+	// *ebpf.Program): cilium/ebpf's Program.Close() and Map.Close() are both
+	// nil-receiver-safe, so ProcessGuardHandles.Close() -> objs.Close() works
+	// unchanged; nothing on the restart-reuse path needs the *ebpf.Program
+	// handles themselves, only the program IDs already captured above via
+	// each pinned link's own Info().
+	return h, true
+}
+
+// linkProgramID reads back the program ID a pinned link currently reports
+// itself attached to — the restart-path equivalent of attachedProgramID,
+// which needs a live *ebpf.Program this path never loads. Using the link's
+// own Info() instead is exactly as trustworthy: it is the same call
+// AuditLinks later uses to detect drift, just invoked once here to establish
+// the post-restart baseline.
+func linkProgramID(l link.Link) (ebpf.ProgramID, error) {
+	info, err := l.Info()
+	if err != nil {
+		return 0, fmt.Errorf("link info: %w", err)
+	}
+	return info.Program, nil
 }
 
 // attachedProgramID reads back the kernel-assigned ID for prog immediately

--- a/go/pkg/kernelcapture/bpf_policy_apply_pinned_linux_test.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_pinned_linux_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package kernelcapture
+
+// bpf_policy_apply_pinned_linux_test.go — tests for the issue #124 pinning
+// paths that don't require a real BPF-LSM-enabled kernel: PinnedGuardPaths'
+// pure path logic, and tryLoadPinnedGuardState's "no pins exist yet" fallback
+// path, which fails at the bpf_obj_get(2)/ENOENT level before ever touching
+// BPF-LSM verification -- this runs in the bpf-generate CI job (plain
+// ubuntu-24.04, real generated bindings, no privileged VM needed), unlike
+// go/cmd/ardur-guard-smoke's end-to-end restart-survival scenario, which
+// needs the kernel-smoke job's virtme-ng VM to prove actual enforcement
+// (see that scenario's doc comment for what only a real kernel can prove).
+
+import (
+	"testing"
+)
+
+func TestDefaultPinnedGuardPaths_AllTenPathsDistinctAndNonEmpty(t *testing.T) {
+	paths := DefaultPinnedGuardPaths()
+	all := paths.allPaths()
+	if len(all) != 10 {
+		t.Fatalf("allPaths() returned %d paths, want 10", len(all))
+	}
+	seen := make(map[string]bool, len(all))
+	for _, p := range all {
+		if p == "" {
+			t.Error("a pin path is empty")
+		}
+		if seen[p] {
+			t.Errorf("duplicate pin path %q -- two fields would collide on bpffs", p)
+		}
+		seen[p] = true
+	}
+}
+
+func TestDefaultPinnedGuardPaths_UnderArdurBpffsNamespace(t *testing.T) {
+	paths := DefaultPinnedGuardPaths()
+	const prefix = "/sys/fs/bpf/ardur/"
+	for _, p := range paths.allPaths() {
+		if len(p) <= len(prefix) || p[:len(prefix)] != prefix {
+			t.Errorf("pin path %q is not under the ardur-owned bpffs namespace %q", p, prefix)
+		}
+	}
+}
+
+// TestTryLoadPinnedGuardState_FalseWhenNoPinsExist proves the "first start,
+// nothing pinned yet" fallback path: every LoadPinnedLink/LoadPinnedMap call
+// fails against paths that don't exist, so the function must report ok=false
+// (triggering LoadAndAttachProcessGuardEBPFPinned's fresh-load fallback)
+// rather than panicking or returning a partially-populated handle.
+func TestTryLoadPinnedGuardState_FalseWhenNoPinsExist(t *testing.T) {
+	base := t.TempDir() + "/does-not-exist/"
+	paths := PinnedGuardPaths{
+		BprmLinkPath:        base + "bprm_link",
+		FileOpenLinkPath:    base + "file_open_link",
+		SocketConnLinkPath:  base + "socket_connect_link",
+		CgroupOpPolicyPath:  base + "cgroup_op_policy",
+		CgroupPathAllowPath: base + "cgroup_path_allow",
+		CgroupFileAllowPath: base + "cgroup_file_allow",
+		CgroupNetAllowPath:  base + "cgroup_net_allow",
+		CgroupManagedPath:   base + "cgroup_managed",
+		KillSwitchPath:      base + "kill_switch",
+		EnforceEventsPath:   base + "enforce_events",
+	}
+
+	h, ok := tryLoadPinnedGuardState(paths)
+	if ok {
+		t.Fatal("tryLoadPinnedGuardState reported ok=true against nonexistent pin paths")
+	}
+	if h != nil {
+		t.Fatal("tryLoadPinnedGuardState returned a non-nil handle alongside ok=false")
+	}
+}
+
+// TestRemovePinnedGuardState_NeverErrorsOnMissingPins confirms the cleanup
+// helper is safe to call unconditionally (e.g. from a test's defer) even when
+// nothing was ever pinned.
+func TestRemovePinnedGuardState_NeverErrorsOnMissingPins(t *testing.T) {
+	base := t.TempDir() + "/never-pinned/"
+	paths := PinnedGuardPaths{
+		BprmLinkPath:        base + "bprm_link",
+		FileOpenLinkPath:    base + "file_open_link",
+		SocketConnLinkPath:  base + "socket_connect_link",
+		CgroupOpPolicyPath:  base + "cgroup_op_policy",
+		CgroupPathAllowPath: base + "cgroup_path_allow",
+		CgroupFileAllowPath: base + "cgroup_file_allow",
+		CgroupNetAllowPath:  base + "cgroup_net_allow",
+		CgroupManagedPath:   base + "cgroup_managed",
+		KillSwitchPath:      base + "kill_switch",
+		EnforceEventsPath:   base + "enforce_events",
+	}
+	// Must not panic.
+	RemovePinnedGuardState(paths)
+}


### PR DESCRIPTION
## Summary

Epic A holistic review (#125), issues #121 and #124.

**#121 (HIGH) — fail-open on guard-consumer death.** If `runGuardConsumer` returned mid-run — a real error, or a clean ringbuf close caused by something other than the daemon's own shutdown watcher (e.g. an external force-detach) — its `defer` cleared `d.policyMaps`, but nothing ever moved `activeTier` off `"bpf_lsm"`. Health kept reporting enforcement that no longer existed.

Fixed:
- The goroutine awaiting `runGuardConsumer` now calls `degradeGuardTier` on any non-shutdown exit (whether `err` is nil or not — both mean the guard is no longer attached).
- `degradeGuardTier` atomically moves `activeTier` to `"none"` and records the transition as a hash-chained tamper-audit entry — the *same* auditable evidence trail `RunTamperAudit`'s periodic ticks already write to (`_tamper/tamper_audit.jsonl`), not just a log line that can be missed.
- `activeTier` reads/writes are now consistently `mu`-guarded (`getActiveTier`/`setActiveTier`) — this change adds a second concurrent writer to a field that was previously only ever set once at startup, so the existing unsynchronized access needed fixing to stay race-free under `-race` (which `kernel-enforce.yml` already runs).
- Deliberately does **not** attempt to retroactively stand up the seccomp fallback tier — that tier's supervisor/socket lifecycle is wired only at startup, and retrofitting a second start site would need its own careful lifecycle handling for a case this fix already reports correctly. "Loudly signal degradation," per the issue's own acceptance framing.

**#124 (MED) — guard unpinned.** A daemon restart detached the three LSM hooks and rebuilt every policy map empty (`cgroup_managed`, `cgroup_op_policy`, etc.), so a governed agent ran completely unenforced from process exit until (if ever) `apply_policy` was called again.

Fixed: `LoadAndAttachProcessGuardEBPFPinned` mirrors #99's tracepoint pinning — pins the three LSM links and the six policy-state maps (+ the `enforce_events` ringbuf) under `/sys/fs/bpf/ardur/`, all-or-nothing (never a partial reuse). A restart that finds every pin re-attaches to kernel state that was **never actually detached**: the LSM hooks kept enforcing the whole time, so there is nothing to "re-apply" — the pinned maps' contents are exactly what was last applied. If pinning is unavailable (bpffs not mounted, etc.), it falls back to a fresh load, the same accepted degradation #99 already has for the tracepoint.

## Tests

- `daemon_guard_degrade_test.go` — proves health reflects the true tier after a simulated consumer death (pure state-transition logic, no real kernel needed): tier moves to none, the transition is hash-chained and appended to evidence, the no-op case (guard never actually reached bpf_lsm) doesn't spuriously fire, and a concurrent-access test exercises `getActiveTier`/`setActiveTier`/`degradeGuardTier` under `-race`.
- `bpf_policy_apply_pinned_linux_test.go` — pin-path logic (all 10 paths distinct, under the ardur bpffs namespace) and the "no pins exist yet" fallback (`tryLoadPinnedGuardState` failing cleanly at the `ENOENT` level, before ever touching BPF-LSM) — runs on real Linux in the `bpf-generate` CI job, no privileged VM needed.
- `ardur-guard-smoke` gained a third scenario, `restart_survival_scenario.go` (runs in `kernel-smoke`'s virtme-ng VM): applies `OP_EXEC:DENY` through a pinned load, confirms EPERM, simulates a daemon restart (`Close`, then load again from the same pins), and asserts execve is **still** denied with no re-apply call in between. This can't pass by accident — a regression here (silent fallback to a fresh, unpinned attach) shows up as execve unexpectedly *succeeding* post-restart, not an ambiguous error.

## Verification

- `go build/vet/test -race ./...` green on darwin
- `go build/vet/test -race ./...` green on a real Linux container (`golang:1.26`) — the new pinned-path tests actually executed there (confirmed via `-v`), not just cross-compiled
- `ardur-guard-smoke` binary builds and runs on real Linux, failing exactly where expected outside a privileged BPF-LSM kernel (confirms the control flow reaches the real loader correctly)
- Existing test suites (daemon, kernelcapture, guard-smoke build) all still green — no regressions

Refs: #121, #124, Epic A #63.