### PR TITLE
fix(ci): handle unchecked svr.Close() error in ardur-kernelcaptured daemon

### DIFF
--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -1289,7 +1289,9 @@ func main() {
 	<-ctx.Done()
 	log.Info("shutting down", "reason", ctx.Err())
 	_ = sdNotify("STOPPING=1")
-	svr.Close()
+	if err := svr.Close(); err != nil {
+		log.Error("failed to close control socket server", "error", err)
+	}
 	wg.Wait()
 	log.Info("ardur-kernelcaptured stopped")
 }


### PR DESCRIPTION
### Context / Problem
CodeQL flagged an unchecked Close() on the Unix domain socket server (svr) during the ardur-kernelcaptured daemon shutdown process.

### Solution
- Checked the error returned by svr.Close().
- Logged any failure using the daemon's slog logger.

Resolves #153