### PR TITLE
fix(ci): bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/docs/demo/enforce-e2e/Dockerfile
+++ b/docs/demo/enforce-e2e/Dockerfile
@@ -13,7 +13,7 @@
 # needed at build time. Stage 2 installs the Python `ardur` CLI. Run the
 # image privileged with --pid=host — see docs/demo/enforce-e2e.md.
 
-FROM golang:1.26-bookworm AS build
+FROM golang:1.26.5-bookworm AS build
 WORKDIR /src
 COPY go/go.mod go/go.sum ./go/
 RUN cd go && go mod download

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArdurAI/ardur/go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -13,6 +13,7 @@ import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
+import vibap.claude_code_hook as claude_code_hook
 from vibap.claude_code_hook import (
     ChainState,
     append_receipt,
@@ -198,6 +199,9 @@ def test_empty_vibap_home_falls_back_to_default_home(tmp_path, monkeypatch):
     generate_keypair(keys_dir=tmp_path)
     monkeypatch.delenv("ARDUR_MISSION_PASSPORT", raising=False)
     monkeypatch.setenv("VIBAP_HOME", "")  # explicit empty string
+    # Other tests may materialize the process-level default under the repo
+    # CWD. Give this fallback assertion an empty default home of its own.
+    monkeypatch.setattr(claude_code_hook, "DEFAULT_HOME", tmp_path / "default-home")
 
     with pytest.raises(MissionLoadError) as exc_info:
         load_active_passport(keys_dir=tmp_path)

--- a/python/tests/test_go_toolchain_contract.py
+++ b/python/tests/test_go_toolchain_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GO_MOD = REPO_ROOT / "go" / "go.mod"
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "tests.yml",
+    REPO_ROOT / ".github" / "workflows" / "kernel-enforce.yml",
+)
+WORKFLOW_MIRRORS = tuple(
+    REPO_ROOT / "site" / "static" / "repo" / workflow.relative_to(REPO_ROOT)
+    for workflow in WORKFLOWS
+)
+DEMO_DOCKERFILE = REPO_ROOT / "docs" / "demo" / "enforce-e2e" / "Dockerfile"
+
+
+def _go_module_version() -> str:
+    match = re.search(
+        r"^go (?P<version>\d+\.\d+\.\d+)$",
+        GO_MOD.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, "go/go.mod must declare an exact Go toolchain version"
+    return match.group("version")
+
+
+def _workflow_versions(workflow: Path) -> list[str]:
+    return re.findall(
+        r"^\s*go-version:\s*['\"]?(?P<version>\d+\.\d+\.\d+)['\"]?\s*$",
+        workflow.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+
+
+def test_go_toolchain_versions_stay_in_lockstep() -> None:
+    """Keep the module, CI workflows, published mirrors, and demo builder aligned."""
+
+    expected_version = _go_module_version()
+
+    for workflow, mirror in zip(WORKFLOWS, WORKFLOW_MIRRORS, strict=True):
+        assert _workflow_versions(workflow), (
+            f"expected at least one Go setup in {workflow.relative_to(REPO_ROOT)}"
+        )
+        assert set(_workflow_versions(workflow)) == {expected_version}
+        assert mirror.read_text(encoding="utf-8") == workflow.read_text(
+            encoding="utf-8"
+        )
+
+    dockerfile = DEMO_DOCKERFILE.read_text(encoding="utf-8")
+    assert f"FROM golang:{expected_version}-bookworm AS build" in dockerfile

--- a/site/static/repo/.github/workflows/kernel-enforce.yml
+++ b/site/static/repo/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 


### PR DESCRIPTION
## Summary
- Bump the Go module, live CI workflows, and published workflow mirrors to Go 1.26.5.
- Pin the enforcement demo builder to `golang:1.26.5-bookworm`; the prior minor tag resolved to Go 1.26.4 and could not build the updated module.
- Add a cross-surface toolchain contract test and make the existing empty-`VIBAP_HOME` fallback test deterministic.

## Validation
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- `govulncheck ./...` (no reachable vulnerabilities)
- `python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml` (1318 passed, 32 skipped)
- Docker enforcement E2E in enforce and permissive modes
- `./scripts/check-local.sh --quick`

## Environment note
The KVM-backed kernel-smoke scenario could not run locally because Docker Desktop does not expose `/dev/kvm`. The Docker seccomp E2E completed successfully.

Closes #138