### PR TITLE
fix(demo): bootstrap local SPIRE stack on fresh volumes

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/deploy/local/spire/Dockerfile.init
+++ b/deploy/local/spire/Dockerfile.init
@@ -1,0 +1,4 @@
+FROM ghcr.io/spiffe/spire-server:1.14.4 AS spire-server
+
+FROM alpine:3.22
+COPY --from=spire-server /opt/spire/bin/spire-server /opt/spire/bin/spire-server

--- a/deploy/local/spire/server.conf
+++ b/deploy/local/spire/server.conf
@@ -27,12 +27,6 @@ plugins {
         plugin_data {}
     }
 
-    Notifier "k8sbundle" {
-        plugin_data {
-            namespace = "spire-system"
-            config_map = "spire-bundle"
-        }
-    }
 }
 
 health_checks {

--- a/deploy/local/spire/setup.sh
+++ b/deploy/local/spire/setup.sh
@@ -1,20 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 # SPIRE setup: wait for server, generate join token, create registration entries.
 set -euo pipefail
 
 echo "[spire-setup] Waiting for SPIRE server..."
-until /opt/spire/bin/spire-server healthcheck -serverAddr spire-server:8081 2>/dev/null; do
+until /opt/spire/bin/spire-server healthcheck -socketPath /run/spire/sockets/server.sock 2>/dev/null; do
     sleep 2
 done
 echo "[spire-setup] SPIRE server is healthy."
 
+# Publish the server bundle before the agent verifies its first attestation.
+/opt/spire/bin/spire-server bundle show \
+    -socketPath /run/spire/sockets/server.sock \
+    -format pem > /tmp/spire-shared/bundle.crt
+chmod 0644 /tmp/spire-shared/bundle.crt
+
 # Generate join token for the agent
 echo "[spire-setup] Generating agent join token..."
 JOIN_TOKEN=$(/opt/spire/bin/spire-server token generate \
-    -serverAddr spire-server:8081 \
-    -spiffeID spiffe://ardur.dev/spire/agent \
-    -ttl 600 2>&1)
-echo "$JOIN_TOKEN" > /tmp/spire-shared/join_token
+    -socketPath /run/spire/sockets/server.sock \
+    -spiffeID spiffe://ardur.dev/agent/local \
+    -ttl 600 | sed -n 's/^Token: //p')
+test -n "$JOIN_TOKEN"
+printf '%s\n' "$JOIN_TOKEN" > /tmp/spire-shared/join_token
 echo "[spire-setup] Join token written."
 
 # Create registration entries for Ardur workloads
@@ -22,27 +29,27 @@ echo "[spire-setup] Creating registration entries..."
 
 # Governance proxy
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/proxy \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:65532 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 # Personal hub
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/hub \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:65532 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 # Test runner (uses host uid for local test execution)
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/agent/test-runner \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:0 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 echo "[spire-setup] All registration entries created."
 echo "[spire-setup] Setup complete."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,22 @@
 services:
   # ── SPIRE (SPIFFE workload identity) ──────────────────────────────────────
 
+  # Named volumes are created root-owned, while the SPIRE server image runs as
+  # uid 1000. Prepare the server datastore and join-token volume once before
+  # starting any uid-1000 SPIRE process.
+  spire-volume-init:
+    image: alpine:3.22
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        chown -R 1000:1000 /run/spire/server-data /run/spire/shared
+        chmod 0750 /run/spire/server-data /run/spire/shared
+    volumes:
+      - spire-server-data:/run/spire/server-data
+      - spire-shared:/run/spire/shared
+
   spire-server:
     image: ghcr.io/spiffe/spire-server:1.14.4
     command:
@@ -12,12 +28,15 @@ services:
       - /run/spire/config/server.conf
     volumes:
       - spire-server-data:/run/spire/data
-      - spire-shared:/tmp/spire-shared
+      - spire-shared:/run/spire/sockets
       - ./deploy/local/spire/server.conf:/run/spire/config/server.conf:ro
+    depends_on:
+      spire-volume-init:
+        condition: service_completed_successfully
     ports:
-      - "8081:8081"
+      - "${ARDUR_SPIRE_SERVER_PORT:-8081}:8081"
     healthcheck:
-      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-serverAddr", "localhost:8081"]
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-socketPath", "/run/spire/sockets/server.sock"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -25,10 +44,13 @@ services:
     restart: unless-stopped
 
   spire-init:
-    image: ghcr.io/spiffe/spire-server:1.14.4
-    entrypoint: ["/bin/bash", "/tmp/setup.sh"]
+    build:
+      context: .
+      dockerfile: deploy/local/spire/Dockerfile.init
+    entrypoint: ["/bin/sh", "/tmp/setup.sh"]
     volumes:
       - spire-shared:/tmp/spire-shared
+      - spire-shared:/run/spire/sockets
       - ./deploy/local/spire/setup.sh:/tmp/setup.sh:ro
     depends_on:
       spire-server:
@@ -39,11 +61,13 @@ services:
     command:
       - -config
       - /run/spire/config/agent.conf
-      - -joinToken
+      - -joinTokenFile
       - /tmp/spire-shared/join_token
     volumes:
       - spire-agent-data:/run/spire/data
-      - spire-shared:/tmp/spire-shared
+      - spire-shared:/tmp/spire-shared:ro
+      - spire-shared:/run/spire/sockets
+      - spire-shared:/run/spire/bundle:ro
       - ./deploy/local/spire/agent.conf:/run/spire/config/agent.conf:ro
     depends_on:
       spire-init:
@@ -63,7 +87,7 @@ services:
       context: .
       dockerfile: Dockerfile.proxy
     ports:
-      - "8443:8443"
+      - "${ARDUR_PROXY_PORT:-8443}:8443"
     environment:
       - ARDUR_NO_TLS=${ARDUR_NO_TLS:-}
       - ARDUR_API_TOKEN=${ARDUR_API_TOKEN:-}
@@ -93,7 +117,7 @@ services:
       context: .
       dockerfile: Dockerfile.hub
     ports:
-      - "8765:8765"
+      - "${ARDUR_HUB_PORT:-8765}:8765"
     environment:
       - ARDUR_NO_TLS=${ARDUR_NO_TLS:-}
       - ARDUR_RATE_LIMIT_RPS=${ARDUR_RATE_LIMIT_RPS:-100}

--- a/docs/demo/enforce-e2e/Dockerfile
+++ b/docs/demo/enforce-e2e/Dockerfile
@@ -13,7 +13,7 @@
 # needed at build time. Stage 2 installs the Python `ardur` CLI. Run the
 # image privileged with --pid=host — see docs/demo/enforce-e2e.md.
 
-FROM golang:1.26-bookworm AS build
+FROM golang:1.26.5-bookworm AS build
 WORKDIR /src
 COPY go/go.mod go/go.sum ./go/
 RUN cd go && go mod download

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArdurAI/ardur/go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -13,6 +13,7 @@ import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
+import vibap.claude_code_hook as claude_code_hook
 from vibap.claude_code_hook import (
     ChainState,
     append_receipt,
@@ -198,6 +199,9 @@ def test_empty_vibap_home_falls_back_to_default_home(tmp_path, monkeypatch):
     generate_keypair(keys_dir=tmp_path)
     monkeypatch.delenv("ARDUR_MISSION_PASSPORT", raising=False)
     monkeypatch.setenv("VIBAP_HOME", "")  # explicit empty string
+    # Other tests may materialize the process-level default under the repo
+    # CWD. Give this fallback assertion an empty default home of its own.
+    monkeypatch.setattr(claude_code_hook, "DEFAULT_HOME", tmp_path / "default-home")
 
     with pytest.raises(MissionLoadError) as exc_info:
         load_active_passport(keys_dir=tmp_path)

--- a/python/tests/test_demo_compose.py
+++ b/python/tests/test_demo_compose.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+
+def test_spire_volume_initializer_prepares_nonroot_writable_volumes() -> None:
+    """Keep fresh named volumes writable for SPIRE's uid-1000 server image."""
+
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+    initializer = services["spire-volume-init"]
+
+    assert initializer["image"] == "alpine:3.22"
+    assert initializer["user"] == "0:0"
+    assert initializer["entrypoint"][:2] == ["/bin/sh", "-ec"]
+    assert initializer["volumes"] == [
+        "spire-server-data:/run/spire/server-data",
+        "spire-shared:/run/spire/shared",
+    ]
+    assert "chown -R 1000:1000" in initializer["entrypoint"][-1]
+    assert services["spire-server"]["depends_on"] == {
+        "spire-volume-init": {"condition": "service_completed_successfully"}
+    }
+    assert "spire-shared:/run/spire/sockets" in services["spire-server"]["volumes"]
+    assert services["spire-server"]["healthcheck"]["test"] == [
+        "CMD",
+        "/opt/spire/bin/spire-server",
+        "healthcheck",
+        "-socketPath",
+        "/run/spire/sockets/server.sock",
+    ]
+    assert services["spire-init"] == {
+        "build": {"context": ".", "dockerfile": "deploy/local/spire/Dockerfile.init"},
+        "entrypoint": ["/bin/sh", "/tmp/setup.sh"],
+        "volumes": [
+            "spire-shared:/tmp/spire-shared",
+            "spire-shared:/run/spire/sockets",
+            "./deploy/local/spire/setup.sh:/tmp/setup.sh:ro",
+        ],
+        "depends_on": {"spire-server": {"condition": "service_healthy"}},
+    }
+    assert "spire-shared:/tmp/spire-shared:ro" in services["spire-agent"]["volumes"]
+    assert "spire-shared:/run/spire/sockets" in services["spire-agent"]["volumes"]
+    assert "spire-shared:/run/spire/bundle:ro" in services["spire-agent"]["volumes"]
+    assert services["spire-agent"]["command"] == [
+        "-config",
+        "/run/spire/config/agent.conf",
+        "-joinTokenFile",
+        "/tmp/spire-shared/join_token",
+    ]
+
+
+def test_spire_init_image_keeps_the_pinned_server_binary() -> None:
+    dockerfile = (
+        REPO_ROOT / "deploy" / "local" / "spire" / "Dockerfile.init"
+    ).read_text(encoding="utf-8")
+
+    assert "FROM ghcr.io/spiffe/spire-server:1.14.4 AS spire-server" in dockerfile
+    assert "FROM alpine:3.22" in dockerfile
+    assert (
+        "COPY --from=spire-server /opt/spire/bin/spire-server /opt/spire/bin/spire-server"
+        in dockerfile
+    )
+
+
+def test_local_spire_config_does_not_require_a_kubernetes_api() -> None:
+    config = (REPO_ROOT / "deploy" / "local" / "spire" / "server.conf").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'Notifier "k8sbundle"' not in config
+    assert 'database_type = "sqlite3"' in config
+    assert 'NodeAttestor "join_token"' in config
+
+
+def test_local_spire_setup_uses_the_shared_server_api_socket() -> None:
+    setup = (REPO_ROOT / "deploy" / "local" / "spire" / "setup.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert setup.startswith("#!/bin/sh\n")
+    assert "-serverAddr" not in setup
+    assert setup.count("-socketPath /run/spire/sockets/server.sock") == 6
+    assert "spiffe://ardur.dev/spire/agent" not in setup
+    assert setup.count("spiffe://ardur.dev/agent/local") == 4
+    assert "-ttl 3600" not in setup
+    assert setup.count("-x509SVIDTTL 3600") == 3
+    assert "-format pem > /tmp/spire-shared/bundle.crt" in setup
+    assert "-ttl 600 | sed -n 's/^Token: //p'" in setup
+    assert 'test -n "$JOIN_TOKEN"' in setup
+
+
+def test_demo_host_ports_keep_defaults_and_allow_parallel_overrides() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+
+    assert services["spire-server"]["ports"] == [
+        "${ARDUR_SPIRE_SERVER_PORT:-8081}:8081"
+    ]
+    assert services["proxy"]["ports"] == ["${ARDUR_PROXY_PORT:-8443}:8443"]
+    assert services["hub"]["ports"] == ["${ARDUR_HUB_PORT:-8765}:8765"]

--- a/python/tests/test_go_toolchain_contract.py
+++ b/python/tests/test_go_toolchain_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GO_MOD = REPO_ROOT / "go" / "go.mod"
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "tests.yml",
+    REPO_ROOT / ".github" / "workflows" / "kernel-enforce.yml",
+)
+WORKFLOW_MIRRORS = tuple(
+    REPO_ROOT / "site" / "static" / "repo" / workflow.relative_to(REPO_ROOT)
+    for workflow in WORKFLOWS
+)
+DEMO_DOCKERFILE = REPO_ROOT / "docs" / "demo" / "enforce-e2e" / "Dockerfile"
+
+
+def _go_module_version() -> str:
+    match = re.search(
+        r"^go (?P<version>\d+\.\d+\.\d+)$",
+        GO_MOD.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, "go/go.mod must declare an exact Go toolchain version"
+    return match.group("version")
+
+
+def _workflow_versions(workflow: Path) -> list[str]:
+    return re.findall(
+        r"^\s*go-version:\s*['\"]?(?P<version>\d+\.\d+\.\d+)['\"]?\s*$",
+        workflow.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+
+
+def test_go_toolchain_versions_stay_in_lockstep() -> None:
+    """Keep the module, CI workflows, published mirrors, and demo builder aligned."""
+
+    expected_version = _go_module_version()
+
+    for workflow, mirror in zip(WORKFLOWS, WORKFLOW_MIRRORS, strict=True):
+        assert _workflow_versions(workflow), (
+            f"expected at least one Go setup in {workflow.relative_to(REPO_ROOT)}"
+        )
+        assert set(_workflow_versions(workflow)) == {expected_version}
+        assert mirror.read_text(encoding="utf-8") == workflow.read_text(
+            encoding="utf-8"
+        )
+
+    dockerfile = DEMO_DOCKERFILE.read_text(encoding="utf-8")
+    assert f"FROM golang:{expected_version}-bookworm AS build" in dockerfile

--- a/site/static/repo/.github/workflows/kernel-enforce.yml
+++ b/site/static/repo/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 


### PR DESCRIPTION
## Summary
- initialize fresh Compose volumes for SPIRE's non-root server and use a shell-capable setup image
- align local server bootstrap with the SPIRE 1.14 socket, join-token-file, trust-bundle, and registration-entry interfaces
- make the SPIRE, proxy, and hub host ports overridable while retaining 8081/8443/8765 defaults
- add focused Compose/SPIRE regression coverage

Closes #142

## Dependency
This branch contains a signed merge of the already-green #183 Go 1.26.5 CVE gate. The merge is retained solely so this PR validates the required Phase 0 dependency chain on `dev`; reviewers should merge #183 before #184.

## Verification
- `make demo` from a new Compose project with all published ports overridden; server, agent, proxy, and hub healthy
- proxy and hub `/health` responses succeeded
- `make demo-down` removed all project containers, network, and named volumes
- `pytest python/tests/test_demo_compose.py -q` (5 passed)
- full Python suite: 1322 passed, 32 skipped
- `go test ./...`, `go vet ./...`, `go build ./...`
- `./scripts/check-local.sh --quick`, Compose config validation, shell syntax, and SPIRE init image build

## Scope
`scripts/verify-mvp.sh` remains a separate existing tester-blocker in #143; it currently has a shell-pipeline/API-auth mismatch independent of this fresh-volume bootstrap fix.