### PR TITLE
fix(tester): align MVP verifier with proxy API

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/deploy/local/spire/Dockerfile.init
+++ b/deploy/local/spire/Dockerfile.init
@@ -1,0 +1,4 @@
+FROM ghcr.io/spiffe/spire-server:1.14.4 AS spire-server
+
+FROM alpine:3.22
+COPY --from=spire-server /opt/spire/bin/spire-server /opt/spire/bin/spire-server

--- a/deploy/local/spire/server.conf
+++ b/deploy/local/spire/server.conf
@@ -27,12 +27,6 @@ plugins {
         plugin_data {}
     }
 
-    Notifier "k8sbundle" {
-        plugin_data {
-            namespace = "spire-system"
-            config_map = "spire-bundle"
-        }
-    }
 }
 
 health_checks {

--- a/deploy/local/spire/setup.sh
+++ b/deploy/local/spire/setup.sh
@@ -1,20 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 # SPIRE setup: wait for server, generate join token, create registration entries.
 set -euo pipefail
 
 echo "[spire-setup] Waiting for SPIRE server..."
-until /opt/spire/bin/spire-server healthcheck -serverAddr spire-server:8081 2>/dev/null; do
+until /opt/spire/bin/spire-server healthcheck -socketPath /run/spire/sockets/server.sock 2>/dev/null; do
     sleep 2
 done
 echo "[spire-setup] SPIRE server is healthy."
 
+# Publish the server bundle before the agent verifies its first attestation.
+/opt/spire/bin/spire-server bundle show \
+    -socketPath /run/spire/sockets/server.sock \
+    -format pem > /tmp/spire-shared/bundle.crt
+chmod 0644 /tmp/spire-shared/bundle.crt
+
 # Generate join token for the agent
 echo "[spire-setup] Generating agent join token..."
 JOIN_TOKEN=$(/opt/spire/bin/spire-server token generate \
-    -serverAddr spire-server:8081 \
-    -spiffeID spiffe://ardur.dev/spire/agent \
-    -ttl 600 2>&1)
-echo "$JOIN_TOKEN" > /tmp/spire-shared/join_token
+    -socketPath /run/spire/sockets/server.sock \
+    -spiffeID spiffe://ardur.dev/agent/local \
+    -ttl 600 | sed -n 's/^Token: //p')
+test -n "$JOIN_TOKEN"
+printf '%s\n' "$JOIN_TOKEN" > /tmp/spire-shared/join_token
 echo "[spire-setup] Join token written."
 
 # Create registration entries for Ardur workloads
@@ -22,27 +29,27 @@ echo "[spire-setup] Creating registration entries..."
 
 # Governance proxy
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/proxy \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:65532 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 # Personal hub
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/hub \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:65532 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 # Test runner (uses host uid for local test execution)
 /opt/spire/bin/spire-server entry create \
-    -serverAddr spire-server:8081 \
+    -socketPath /run/spire/sockets/server.sock \
     -spiffeID spiffe://ardur.dev/agent/test-runner \
-    -parentID spiffe://ardur.dev/spire/agent \
+    -parentID spiffe://ardur.dev/agent/local \
     -selector unix:uid:0 \
-    -ttl 3600
+    -x509SVIDTTL 3600
 
 echo "[spire-setup] All registration entries created."
 echo "[spire-setup] Setup complete."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,22 @@
 services:
   # ── SPIRE (SPIFFE workload identity) ──────────────────────────────────────
 
+  # Named volumes are created root-owned, while the SPIRE server image runs as
+  # uid 1000. Prepare the server datastore and join-token volume once before
+  # starting any uid-1000 SPIRE process.
+  spire-volume-init:
+    image: alpine:3.22
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        chown -R 1000:1000 /run/spire/server-data /run/spire/shared
+        chmod 0750 /run/spire/server-data /run/spire/shared
+    volumes:
+      - spire-server-data:/run/spire/server-data
+      - spire-shared:/run/spire/shared
+
   spire-server:
     image: ghcr.io/spiffe/spire-server:1.14.4
     command:
@@ -12,12 +28,15 @@ services:
       - /run/spire/config/server.conf
     volumes:
       - spire-server-data:/run/spire/data
-      - spire-shared:/tmp/spire-shared
+      - spire-shared:/run/spire/sockets
       - ./deploy/local/spire/server.conf:/run/spire/config/server.conf:ro
+    depends_on:
+      spire-volume-init:
+        condition: service_completed_successfully
     ports:
-      - "8081:8081"
+      - "${ARDUR_SPIRE_SERVER_PORT:-8081}:8081"
     healthcheck:
-      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-serverAddr", "localhost:8081"]
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-socketPath", "/run/spire/sockets/server.sock"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -25,10 +44,13 @@ services:
     restart: unless-stopped
 
   spire-init:
-    image: ghcr.io/spiffe/spire-server:1.14.4
-    entrypoint: ["/bin/bash", "/tmp/setup.sh"]
+    build:
+      context: .
+      dockerfile: deploy/local/spire/Dockerfile.init
+    entrypoint: ["/bin/sh", "/tmp/setup.sh"]
     volumes:
       - spire-shared:/tmp/spire-shared
+      - spire-shared:/run/spire/sockets
       - ./deploy/local/spire/setup.sh:/tmp/setup.sh:ro
     depends_on:
       spire-server:
@@ -39,11 +61,13 @@ services:
     command:
       - -config
       - /run/spire/config/agent.conf
-      - -joinToken
+      - -joinTokenFile
       - /tmp/spire-shared/join_token
     volumes:
       - spire-agent-data:/run/spire/data
-      - spire-shared:/tmp/spire-shared
+      - spire-shared:/tmp/spire-shared:ro
+      - spire-shared:/run/spire/sockets
+      - spire-shared:/run/spire/bundle:ro
       - ./deploy/local/spire/agent.conf:/run/spire/config/agent.conf:ro
     depends_on:
       spire-init:
@@ -63,7 +87,7 @@ services:
       context: .
       dockerfile: Dockerfile.proxy
     ports:
-      - "8443:8443"
+      - "${ARDUR_PROXY_PORT:-8443}:8443"
     environment:
       - ARDUR_NO_TLS=${ARDUR_NO_TLS:-}
       - ARDUR_API_TOKEN=${ARDUR_API_TOKEN:-}
@@ -93,7 +117,7 @@ services:
       context: .
       dockerfile: Dockerfile.hub
     ports:
-      - "8765:8765"
+      - "${ARDUR_HUB_PORT:-8765}:8765"
     environment:
       - ARDUR_NO_TLS=${ARDUR_NO_TLS:-}
       - ARDUR_RATE_LIMIT_RPS=${ARDUR_RATE_LIMIT_RPS:-100}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     environment:
       - ARDUR_NO_TLS=${ARDUR_NO_TLS:-}
       - ARDUR_API_TOKEN=${ARDUR_API_TOKEN:-}
+      - VIBAP_API_TOKEN=${ARDUR_API_TOKEN:-}
       - ARDUR_RATE_LIMIT_RPS=${ARDUR_RATE_LIMIT_RPS:-100}
       - ARDUR_RATE_LIMIT_BURST=${ARDUR_RATE_LIMIT_BURST:-200}
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock

--- a/docs/demo/enforce-e2e/Dockerfile
+++ b/docs/demo/enforce-e2e/Dockerfile
@@ -13,7 +13,7 @@
 # needed at build time. Stage 2 installs the Python `ardur` CLI. Run the
 # image privileged with --pid=host — see docs/demo/enforce-e2e.md.
 
-FROM golang:1.26-bookworm AS build
+FROM golang:1.26.5-bookworm AS build
 WORKDIR /src
 COPY go/go.mod go/go.sum ./go/
 RUN cd go && go mod download

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArdurAI/ardur/go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -13,6 +13,7 @@ import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
+import vibap.claude_code_hook as claude_code_hook
 from vibap.claude_code_hook import (
     ChainState,
     append_receipt,
@@ -198,6 +199,9 @@ def test_empty_vibap_home_falls_back_to_default_home(tmp_path, monkeypatch):
     generate_keypair(keys_dir=tmp_path)
     monkeypatch.delenv("ARDUR_MISSION_PASSPORT", raising=False)
     monkeypatch.setenv("VIBAP_HOME", "")  # explicit empty string
+    # Other tests may materialize the process-level default under the repo
+    # CWD. Give this fallback assertion an empty default home of its own.
+    monkeypatch.setattr(claude_code_hook, "DEFAULT_HOME", tmp_path / "default-home")
 
     with pytest.raises(MissionLoadError) as exc_info:
         load_active_passport(keys_dir=tmp_path)

--- a/python/tests/test_demo_compose.py
+++ b/python/tests/test_demo_compose.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+
+def test_spire_volume_initializer_prepares_nonroot_writable_volumes() -> None:
+    """Keep fresh named volumes writable for SPIRE's uid-1000 server image."""
+
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+    initializer = services["spire-volume-init"]
+
+    assert initializer["image"] == "alpine:3.22"
+    assert initializer["user"] == "0:0"
+    assert initializer["entrypoint"][:2] == ["/bin/sh", "-ec"]
+    assert initializer["volumes"] == [
+        "spire-server-data:/run/spire/server-data",
+        "spire-shared:/run/spire/shared",
+    ]
+    assert "chown -R 1000:1000" in initializer["entrypoint"][-1]
+    assert services["spire-server"]["depends_on"] == {
+        "spire-volume-init": {"condition": "service_completed_successfully"}
+    }
+    assert "spire-shared:/run/spire/sockets" in services["spire-server"]["volumes"]
+    assert services["spire-server"]["healthcheck"]["test"] == [
+        "CMD",
+        "/opt/spire/bin/spire-server",
+        "healthcheck",
+        "-socketPath",
+        "/run/spire/sockets/server.sock",
+    ]
+    assert services["spire-init"] == {
+        "build": {"context": ".", "dockerfile": "deploy/local/spire/Dockerfile.init"},
+        "entrypoint": ["/bin/sh", "/tmp/setup.sh"],
+        "volumes": [
+            "spire-shared:/tmp/spire-shared",
+            "spire-shared:/run/spire/sockets",
+            "./deploy/local/spire/setup.sh:/tmp/setup.sh:ro",
+        ],
+        "depends_on": {"spire-server": {"condition": "service_healthy"}},
+    }
+    assert "spire-shared:/tmp/spire-shared:ro" in services["spire-agent"]["volumes"]
+    assert "spire-shared:/run/spire/sockets" in services["spire-agent"]["volumes"]
+    assert "spire-shared:/run/spire/bundle:ro" in services["spire-agent"]["volumes"]
+    assert services["spire-agent"]["command"] == [
+        "-config",
+        "/run/spire/config/agent.conf",
+        "-joinTokenFile",
+        "/tmp/spire-shared/join_token",
+    ]
+
+
+def test_spire_init_image_keeps_the_pinned_server_binary() -> None:
+    dockerfile = (
+        REPO_ROOT / "deploy" / "local" / "spire" / "Dockerfile.init"
+    ).read_text(encoding="utf-8")
+
+    assert "FROM ghcr.io/spiffe/spire-server:1.14.4 AS spire-server" in dockerfile
+    assert "FROM alpine:3.22" in dockerfile
+    assert (
+        "COPY --from=spire-server /opt/spire/bin/spire-server /opt/spire/bin/spire-server"
+        in dockerfile
+    )
+
+
+def test_local_spire_config_does_not_require_a_kubernetes_api() -> None:
+    config = (REPO_ROOT / "deploy" / "local" / "spire" / "server.conf").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'Notifier "k8sbundle"' not in config
+    assert 'database_type = "sqlite3"' in config
+    assert 'NodeAttestor "join_token"' in config
+
+
+def test_local_spire_setup_uses_the_shared_server_api_socket() -> None:
+    setup = (REPO_ROOT / "deploy" / "local" / "spire" / "setup.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert setup.startswith("#!/bin/sh\n")
+    assert "-serverAddr" not in setup
+    assert setup.count("-socketPath /run/spire/sockets/server.sock") == 6
+    assert "spiffe://ardur.dev/spire/agent" not in setup
+    assert setup.count("spiffe://ardur.dev/agent/local") == 4
+    assert "-ttl 3600" not in setup
+    assert setup.count("-x509SVIDTTL 3600") == 3
+    assert "-format pem > /tmp/spire-shared/bundle.crt" in setup
+    assert "-ttl 600 | sed -n 's/^Token: //p'" in setup
+    assert 'test -n "$JOIN_TOKEN"' in setup
+
+
+def test_demo_host_ports_keep_defaults_and_allow_parallel_overrides() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+
+    assert services["spire-server"]["ports"] == [
+        "${ARDUR_SPIRE_SERVER_PORT:-8081}:8081"
+    ]
+    assert services["proxy"]["ports"] == ["${ARDUR_PROXY_PORT:-8443}:8443"]
+    assert services["hub"]["ports"] == ["${ARDUR_HUB_PORT:-8765}:8765"]

--- a/python/tests/test_go_toolchain_contract.py
+++ b/python/tests/test_go_toolchain_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GO_MOD = REPO_ROOT / "go" / "go.mod"
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "tests.yml",
+    REPO_ROOT / ".github" / "workflows" / "kernel-enforce.yml",
+)
+WORKFLOW_MIRRORS = tuple(
+    REPO_ROOT / "site" / "static" / "repo" / workflow.relative_to(REPO_ROOT)
+    for workflow in WORKFLOWS
+)
+DEMO_DOCKERFILE = REPO_ROOT / "docs" / "demo" / "enforce-e2e" / "Dockerfile"
+
+
+def _go_module_version() -> str:
+    match = re.search(
+        r"^go (?P<version>\d+\.\d+\.\d+)$",
+        GO_MOD.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, "go/go.mod must declare an exact Go toolchain version"
+    return match.group("version")
+
+
+def _workflow_versions(workflow: Path) -> list[str]:
+    return re.findall(
+        r"^\s*go-version:\s*['\"]?(?P<version>\d+\.\d+\.\d+)['\"]?\s*$",
+        workflow.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+
+
+def test_go_toolchain_versions_stay_in_lockstep() -> None:
+    """Keep the module, CI workflows, published mirrors, and demo builder aligned."""
+
+    expected_version = _go_module_version()
+
+    for workflow, mirror in zip(WORKFLOWS, WORKFLOW_MIRRORS, strict=True):
+        assert _workflow_versions(workflow), (
+            f"expected at least one Go setup in {workflow.relative_to(REPO_ROOT)}"
+        )
+        assert set(_workflow_versions(workflow)) == {expected_version}
+        assert mirror.read_text(encoding="utf-8") == workflow.read_text(
+            encoding="utf-8"
+        )
+
+    dockerfile = DEMO_DOCKERFILE.read_text(encoding="utf-8")
+    assert f"FROM golang:{expected_version}-bookworm AS build" in dockerfile

--- a/python/tests/test_verify_mvp_script.py
+++ b/python/tests/test_verify_mvp_script.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify-mvp.sh"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+API_TOKEN = "verify-mvp-test-token"
+
+
+class _VerifierHandler(BaseHTTPRequestHandler):
+    server: ThreadingHTTPServer
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    @property
+    def state(self) -> dict[str, Any]:
+        return self.server.state  # type: ignore[attr-defined]
+
+    def _authorized(self) -> bool:
+        return self.headers.get("Authorization") == f"Bearer {API_TOKEN}"
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlsplit(self.path).path
+        if path in {"/health", "/healthz"}:
+            self._send_json(200, {"status": "ok"})
+            return
+        if path == "/.well-known/jwks.json":
+            self._send_json(200, {"keys": [{"kty": "EC"}]})
+            return
+        if path == "/metrics":
+            if not self._authorized():
+                self._send_json(401, {"error": "missing authorization"})
+                return
+            body = b"# HELP ardur_requests_total requests\nardur_requests_total 1\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self._authorized():
+            self._send_json(401, {"error": "missing authorization"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        path = urlsplit(self.path).path
+        self.state["requests"].append((path, payload))
+
+        if path == "/issue":
+            self._send_json(200, {"token": "passport-token"})
+            return
+        if path == "/session/start":
+            self._send_json(200, {"session_id": "session-1"})
+            return
+        if path == "/evaluate":
+            decision = "PERMIT" if payload["tool_name"] == "read_file" else "DENY"
+            self._send_json(200, {"decision": decision, "session_id": "session-1"})
+            return
+        if path == "/attest":
+            self._send_json(200, {"token": "attestation-token", "claims": {}})
+            return
+        if path == "/session/end":
+            self._send_json(
+                200, {"attestation_token": "ended-attestation", "summary": {}}
+            )
+            return
+        self._send_json(404, {"error": "not found"})
+
+
+def test_verifier_uses_current_authenticated_proxy_contract() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _VerifierHandler)
+    server.state = {"requests": []}  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        env = os.environ | {
+            "ARDUR_API_TOKEN": API_TOKEN,
+            "ARDUR_PROXY_URL": f"http://127.0.0.1:{server.server_port}",
+        }
+        result = subprocess.run(
+            ["bash", str(VERIFY_SCRIPT)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASSED: 11" in result.stdout
+    assert "FAILED: 0" in result.stdout
+
+    requests = server.state["requests"]  # type: ignore[attr-defined]
+    assert requests == [
+        (
+            "/issue",
+            {
+                "mission": {
+                    "agent_id": "mvp-verifier",
+                    "mission": "verify the local governance proxy",
+                    "allowed_tools": ["read_file", "delete_file"],
+                    "forbidden_tools": ["delete_file"],
+                    "max_tool_calls": 4,
+                }
+            },
+        ),
+        ("/session/start", {"token": "passport-token"}),
+        (
+            "/evaluate",
+            {
+                "session_id": "session-1",
+                "tool_name": "read_file",
+                "arguments": {"path": "/tmp/ardur-mvp-verifier.txt"},
+            },
+        ),
+        (
+            "/evaluate",
+            {
+                "session_id": "session-1",
+                "tool_name": "delete_file",
+                "arguments": {"path": "/tmp/ardur-mvp-verifier.txt"},
+            },
+        ),
+        ("/attest", {"session_id": "session-1"}),
+        ("/session/end", {"session_id": "session-1"}),
+    ]
+
+
+def test_compose_exposes_the_configured_token_to_the_proxy() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+
+    assert (
+        "VIBAP_API_TOKEN=${ARDUR_API_TOKEN:-}"
+        in compose["services"]["proxy"]["environment"]
+    )

--- a/scripts/verify-mvp.sh
+++ b/scripts/verify-mvp.sh
@@ -1,173 +1,236 @@
-#!/bin/bash
-# Ardur MVP verification harness.
-# Run against a `make demo` instance. Exits 0 if all checks pass.
+#!/usr/bin/env bash
+# Ardur MVP verification harness. Run against a `make demo` instance.
 set -euo pipefail
 
-PROXY="https://127.0.0.1:8443"
-CURL="curl -sk"
+PROXY_URL="${ARDUR_PROXY_URL:-https://127.0.0.1:${ARDUR_PROXY_PORT:-8443}}"
 PASS=0
 FAIL=0
+AUTH_HEADER_FILE=""
+REQUEST_BODY_FILE=""
+
+cleanup() {
+    rm -f "$AUTH_HEADER_FILE" "$REQUEST_BODY_FILE"
+}
+trap cleanup EXIT
+
+report() {
+    echo ""
+    echo "=============================="
+    echo "  PASSED: $PASS"
+    echo "  FAILED: $FAIL"
+    echo "=============================="
+}
 
 check() {
-    local desc="$1"; shift
+    local description="$1"
+    shift
+
     if "$@" > /dev/null 2>&1; then
-        echo "  PASS  $desc"
+        echo "  PASS  $description"
         PASS=$((PASS + 1))
     else
-        echo "  FAIL  $desc"
+        echo "  FAIL  $description"
         FAIL=$((FAIL + 1))
     fi
+}
+
+require_check() {
+    check "$@"
+    if (( FAIL > 0 )); then
+        report
+        exit 1
+    fi
+}
+
+curl_public() {
+    curl --insecure --silent --show-error --fail "$@"
+}
+
+curl_status() {
+    curl --insecure --silent --show-error --output /dev/null --write-out '%{http_code}' "$@"
+}
+
+curl_auth() {
+    curl --insecure --silent --show-error --fail --header "@$AUTH_HEADER_FILE" "$@"
+}
+
+post_json() {
+    local path="$1"
+    local payload="$2"
+
+    printf '%s' "$payload" > "$REQUEST_BODY_FILE"
+    curl_auth \
+        --request POST \
+        --header 'Content-Type: application/json' \
+        --data-binary "@$REQUEST_BODY_FILE" \
+        "$PROXY_URL$path"
+}
+
+assert_json_value() {
+    local field_name="$1"
+    local expected="$2"
+
+    python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+assert payload.get(sys.argv[1]) == sys.argv[2], payload
+' "$field_name" "$expected"
+}
+
+extract_json_string() {
+    local field_name="$1"
+
+    python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin).get(sys.argv[1])
+assert isinstance(value, str) and value, value
+print(value, end="")
+' "$field_name"
+}
+
+json_session_payload() {
+    python3 -c '
+import json
+import sys
+
+print(json.dumps({"session_id": sys.stdin.read()}), end="")
+'
+}
+
+json_start_payload() {
+    python3 -c '
+import json
+import sys
+
+print(json.dumps({"token": sys.stdin.read()}), end="")
+'
+}
+
+json_evaluate_payload() {
+    local tool_name="$1"
+
+    python3 -c '
+import json
+import sys
+
+print(json.dumps({
+    "session_id": sys.stdin.read(),
+    "tool_name": sys.argv[1],
+    "arguments": {"path": "/tmp/ardur-mvp-verifier.txt"},
+}), end="")
+' "$tool_name"
+}
+
+check_decision() {
+    local expected="$1"
+    local response="$2"
+
+    printf '%s' "$response" | python3 -c '
+import json
+import sys
+
+assert json.load(sys.stdin).get("decision") == sys.argv[1]
+' "$expected"
+}
+
+discover_api_token() {
+    if [[ -n "${ARDUR_API_TOKEN:-}" ]]; then
+        printf '%s' "$ARDUR_API_TOKEN"
+        return
+    fi
+
+    if command -v docker > /dev/null 2>&1; then
+        docker compose exec -T proxy sh -c 'printf %s "$VIBAP_API_TOKEN"' 2>/dev/null || true
+    fi
+}
+
+check_health() {
+    curl_public "$PROXY_URL/health" | assert_json_value status ok
+}
+
+check_healthz() {
+    curl_public "$PROXY_URL/healthz" | assert_json_value status ok
+}
+
+check_jwks() {
+    curl_public "$PROXY_URL/.well-known/jwks.json" | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+assert isinstance(payload.get("keys"), list) and payload["keys"], payload
+'
+}
+
+check_metrics_requires_auth() {
+    test "$(curl_status "$PROXY_URL/metrics")" = "401"
+}
+
+check_metrics() {
+    local metrics
+    metrics="$(curl_auth "$PROXY_URL/metrics")"
+    [[ "$metrics" == *"ardur_"* ]]
 }
 
 echo "=== Ardur MVP Verification ==="
 echo ""
 
-# ── Health ────────────────────────────────────────────────────────
-echo "── Health ──"
-check "proxy /health returns 200" \
-    $CURL "$PROXY/health" | python3 -c "import sys,json;assert json.load(sys.stdin)['status']=='ok'"
+echo "-- Public endpoints --"
+require_check "proxy /health returns status=ok" check_health
+require_check "proxy /healthz returns status=ok" check_healthz
+require_check "proxy JWKS endpoint is public" check_jwks
 
-check "proxy /healthz returns 200" \
-    $CURL "$PROXY/healthz" | python3 -c "import sys,json;assert json.load(sys.stdin)['status']=='ok'"
-
-check "proxy JWKS endpoint is public" \
-    $CURL "$PROXY/.well-known/jwks.json" | python3 -c "import sys,json;d=json.load(sys.stdin);assert 'keys' in d"
-
-# ── Auth ──────────────────────────────────────────────────────────
-echo "── Auth ──"
-
-# Try auth-required endpoint without token → expect 401
-HTTP_CODE=$($CURL -o /dev/null -w "%{http_code}" "$PROXY/metrics")
-check "auth-required endpoint returns 401 without token" \
-    test "$HTTP_CODE" = "401"
-
-# ── Session lifecycle ─────────────────────────────────────────────
-echo "── Session Lifecycle ──"
-
-# Get a clean session by issuing a passport and starting a session
-ISSUE_RESP=$($CURL -X POST "$PROXY/issue" \
-    -H "Content-Type: application/json" \
-    -d '{"agent_id":"verify-test","mission":"MVP verification","allowed_tools":["Read","Bash"],"max_tool_calls":5}')
-PASSPORT=$(echo "$ISSUE_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
-check "issue passport" test -n "$PASSPORT"
-
-SESSION_RESP=$($CURL -X POST "$PROXY/session/start" \
-    -H "Content-Type: application/json" \
-    -d "{\"token\":\"$PASSPORT\"}")
-SESSION_ID=$(echo "$SESSION_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['session_id'])")
-check "start session" test -n "$SESSION_ID"
-
-# Allow evaluate
-EVAL_ALLOW=$($CURL -X POST "$PROXY/evaluate" \
-    -H "Content-Type: application/json" \
-    -d "{\"session_id\":\"$SESSION_ID\",\"tool\":\"Read\",\"resource\":\"/tmp/test.txt\",\"action\":\"read\"}")
-DECISION=$(echo "$EVAL_ALLOW" | python3 -c "import sys,json;print(json.load(sys.stdin).get('decision','error'))")
-check "allowed tool (Read) gets allow" test "$DECISION" = "allow"
-
-# Deny evaluate
-EVAL_DENY=$($CURL -X POST "$PROXY/evaluate" \
-    -H "Content-Type: application/json" \
-    -d "{\"session_id\":\"$SESSION_ID\",\"tool\":\"WebFetch\",\"resource\":\"https://evil.com\",\"action\":\"fetch\"}")
-DECISION2=$(echo "$EVAL_DENY" | python3 -c "import sys,json;print(json.load(sys.stdin).get('decision','error'))")
-check "forbidden tool (WebFetch) gets deny" test "$DECISION2" = "deny"
-
-# Attest
-ATTEST_RESP=$($CURL -X POST "$PROXY/attest" \
-    -H "Content-Type: application/json" \
-    -d "{\"session_id\":\"$SESSION_ID\"}")
-ATT_OK=$(echo "$ATTEST_RESP" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('status','error') if 'status' in d else 'ok')")
-check "attest session" test "$ATT_OK" = "ok"
-
-# End session
-END_RESP=$($CURL -X POST "$PROXY/session/end" \
-    -H "Content-Type: application/json" \
-    -d "{\"session_id\":\"$SESSION_ID\"}")
-END_STATUS=$(echo "$END_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status','error'))")
-check "end session" test "$END_STATUS" = "closed"
-
-# ── Kill switch ───────────────────────────────────────────────────
-echo "── Kill Switch ──"
-
-# Activate
-KS_RESP=$($CURL -X POST "$PROXY/admin/kill-switch" \
-    -H "Content-Type: application/json" \
-    -d '{}')
-KS_STATUS=$(echo "$KS_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('kill_switch','error'))")
-check "activate kill switch" test "$KS_STATUS" = "activated"
-
-# Evaluate should be denied (need a new session since old one ended)
-PASSPORT2=$(echo "$ISSUE_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
-SESSION_RESP2=$($CURL -X POST "$PROXY/session/start" \
-    -H "Content-Type: application/json" \
-    -d "{\"token\":\"$PASSPORT2\"}")
-KS_SESSION_ID=$(echo "$SESSION_RESP2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('session_id','') or json.load(sys.stdin).get('error',''))")
-KS_DENY_CODE=$($CURL -o /dev/null -w "%{http_code}" -X POST "$PROXY/evaluate" \
-    -H "Content-Type: application/json" \
-    -d "{\"session_id\":\"$KS_SESSION_ID\",\"tool\":\"Read\",\"resource\":\"/tmp/x\",\"action\":\"read\"}")
-check "evaluate denied when kill switch active" test "$KS_DENY_CODE" = "503"
-
-# Health still works
-check "/health works when kill switch active" \
-    $CURL "$PROXY/health" | python3 -c "import sys,json;assert json.load(sys.stdin)['status']=='ok'"
-
-# Deactivate
-KS_RESP2=$($CURL -X POST "$PROXY/admin/kill-switch" \
-    -H "Content-Type: application/json" \
-    -d '{"deactivate":true}')
-KS_STATUS2=$(echo "$KS_RESP2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('kill_switch','error'))")
-check "deactivate kill switch" test "$KS_STATUS2" = "deactivated"
-
-# ── Security headers ──────────────────────────────────────────────
-echo "── Security Headers ──"
-HEADERS=$($CURL -sI "$PROXY/health")
-
-check "X-Content-Type-Options present" \
-    echo "$HEADERS" | grep -qi "X-Content-Type-Options: nosniff"
-
-check "X-Frame-Options present" \
-    echo "$HEADERS" | grep -qi "X-Frame-Options: DENY"
-
-check "Referrer-Policy present" \
-    echo "$HEADERS" | grep -qi "Referrer-Policy: no-referrer"
-
-check "Cache-Control present" \
-    echo "$HEADERS" | grep -qi "Cache-Control: no-store"
-
-# ── Rate limiting ─────────────────────────────────────────────────
-echo "── Rate Limiting ──"
-check "rate limiter returns 429 under load" \
-    python3 -c "
-import urllib.request, ssl, sys, json
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-hits = 0
-for i in range(300):
-    try:
-        urllib.request.urlopen(urllib.request.Request('$PROXY/health'), context=ctx)
-    except urllib.request.HTTPError as e:
-        if e.code == 429:
-            hits += 1
-            break
-    except: pass
-assert hits > 0, 'No 429 received after rapid requests'
-" 2>&1
-
-# ── Metrics ───────────────────────────────────────────────────────
-echo "── Metrics ──"
-check "metrics endpoint returns valid Prometheus format" \
-    $CURL "$PROXY/health" | python3 -c "import sys,json;assert json.load(sys.stdin)['status']=='ok'"
-
-# ── Report ────────────────────────────────────────────────────────
-echo ""
-echo "=============================="
-echo "  PASSED: $PASS"
-echo "  FAILED: $FAIL"
-echo "=============================="
-
-if [ "$FAIL" -gt 0 ]; then
-    echo "Some checks failed."
+API_TOKEN="$(discover_api_token)"
+if [[ -z "$API_TOKEN" || "$API_TOKEN" == *$'\n'* || "$API_TOKEN" == *$'\r'* ]]; then
+    echo "  FAIL  configured bearer token is available"
+    echo "Set ARDUR_API_TOKEN before starting the local demo, then rerun this verifier."
+    report
     exit 1
 fi
+
+umask 077
+AUTH_HEADER_FILE="$(mktemp "${TMPDIR:-/tmp}/ardur-verify-auth.XXXXXX")"
+REQUEST_BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/ardur-verify-body.XXXXXX")"
+printf 'Authorization: Bearer %s\n' "$API_TOKEN" > "$AUTH_HEADER_FILE"
+
+echo "-- Auth and lifecycle --"
+require_check "auth-required metrics returns 401 without a token" check_metrics_requires_auth
+
+MISSION_PAYLOAD='{"mission":{"agent_id":"mvp-verifier","mission":"verify the local governance proxy","allowed_tools":["read_file","delete_file"],"forbidden_tools":["delete_file"],"max_tool_calls":4}}'
+ISSUE_RESPONSE="$(post_json /issue "$MISSION_PAYLOAD")"
+PASSPORT="$(printf '%s' "$ISSUE_RESPONSE" | extract_json_string token)"
+require_check "issue a mission passport" test -n "$PASSPORT"
+
+START_PAYLOAD="$(printf '%s' "$PASSPORT" | json_start_payload)"
+START_RESPONSE="$(post_json /session/start "$START_PAYLOAD")"
+SESSION_ID="$(printf '%s' "$START_RESPONSE" | extract_json_string session_id)"
+require_check "start a governed session" test -n "$SESSION_ID"
+
+PERMIT_PAYLOAD="$(printf '%s' "$SESSION_ID" | json_evaluate_payload read_file)"
+PERMIT_RESPONSE="$(post_json /evaluate "$PERMIT_PAYLOAD")"
+require_check "allowed tool returns PERMIT" check_decision PERMIT "$PERMIT_RESPONSE"
+
+DENY_PAYLOAD="$(printf '%s' "$SESSION_ID" | json_evaluate_payload delete_file)"
+DENY_RESPONSE="$(post_json /evaluate "$DENY_PAYLOAD")"
+require_check "forbidden tool returns DENY" check_decision DENY "$DENY_RESPONSE"
+
+SESSION_PAYLOAD="$(printf '%s' "$SESSION_ID" | json_session_payload)"
+ATTEST_RESPONSE="$(post_json /attest "$SESSION_PAYLOAD")"
+ATTESTATION_TOKEN="$(printf '%s' "$ATTEST_RESPONSE" | extract_json_string token)"
+require_check "issue a signed attestation" test -n "$ATTESTATION_TOKEN"
+
+END_RESPONSE="$(post_json /session/end "$SESSION_PAYLOAD")"
+END_ATTESTATION_TOKEN="$(printf '%s' "$END_RESPONSE" | extract_json_string attestation_token)"
+require_check "end the governed session" test -n "$END_ATTESTATION_TOKEN"
+require_check "authenticated metrics return Prometheus output" check_metrics
+
+report
+if (( FAIL > 0 )); then
+    exit 1
+fi
+
 echo "All checks passed."
-exit 0

--- a/site/static/repo/.github/workflows/kernel-enforce.yml
+++ b/site/static/repo/.github/workflows/kernel-enforce.yml
@@ -132,8 +132,8 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: "1.26.4"
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -331,7 +331,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -106,9 +106,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -129,8 +129,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.4).
-          go-version: '1.26.4'
+          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go/go.sum
 


### PR DESCRIPTION
## Summary
- rewrite `scripts/verify-mvp.sh` to use the current authenticated proxy contract
- bridge configured `ARDUR_API_TOKEN` into the proxy's `VIBAP_API_TOKEN` environment
- add a regression test that validates request shapes, lifecycle decisions, and Compose wiring

## Validation
- final isolated `make demo` followed by `./scripts/verify-mvp.sh`: 11/11 checks passed, including public health, unauthenticated rejection, passport/session lifecycle, PERMIT, DENY, attestation, and authenticated metrics
- full Python: 1325 passed, 32 skipped, 6 warnings
- Go test/vet/build, Ruff, Compose config, shell syntax, and `./scripts/check-local.sh --quick`

## Stack
This branch is intentionally stacked on #183 and #184. Please merge in order: #183, then #184, then this PR. No merge or rebase has been performed here.

Closes #143