### PR TITLE
fix(hook): install native client across filesystems

### DIFF
--- a/python/tests/test_claude_code_daemon_install.py
+++ b/python/tests/test_claude_code_daemon_install.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import errno
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from vibap import claude_code_daemon as daemon
+
+
+def _fake_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    binary: bytes,
+) -> None:
+    monkeypatch.setattr(daemon, "_candidate_native_compilers", lambda: ["fake-cc"])
+
+    def fake_run(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        output = Path(command[command.index("-o") + 1])
+        output.write_bytes(binary)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+
+
+def _stamp_path(command: Path) -> Path:
+    return command.with_name(f"{command.name}.sha256")
+
+
+def _staging_files(home: Path) -> list[Path]:
+    return sorted(home.glob(".*.tmp"))
+
+
+def test_native_hook_install_replaces_only_destination_staging_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_compiler(monkeypatch, binary=b"native-hook-v1")
+    real_replace = daemon.os.replace
+    replacements: list[tuple[Path, Path]] = []
+
+    def require_same_directory(
+        source: os.PathLike[str], destination: os.PathLike[str]
+    ) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        assert source_path.parent == destination_path.parent
+        replacements.append((source_path, destination_path))
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(daemon.os, "replace", require_same_directory)
+
+    installed = daemon.install_native_pre_tool_use_command(home=tmp_path, force=True)
+
+    assert installed is not None
+    stamp = _stamp_path(installed)
+    assert installed.read_bytes() == b"native-hook-v1"
+    assert stat.S_IMODE(installed.stat().st_mode) == 0o700
+    assert stat.S_IMODE(stamp.stat().st_mode) == 0o600
+    assert daemon._native_pre_tool_use_stamp_matches(
+        installed,
+        daemon._native_pre_tool_use_source_digest(
+            daemon._native_pre_tool_use_client_c_source()
+        ),
+    )
+    assert len(replacements) == 2
+    assert _staging_files(tmp_path) == []
+
+
+def test_native_hook_install_restores_valid_pair_when_stamp_commit_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_compiler(monkeypatch, binary=b"native-hook-original")
+    installed = daemon.install_native_pre_tool_use_command(home=tmp_path, force=True)
+    assert installed is not None
+    stamp = _stamp_path(installed)
+    original_command = installed.read_bytes()
+    original_stamp = stamp.read_bytes()
+
+    _fake_compiler(monkeypatch, binary=b"native-hook-replacement")
+    real_replace = daemon.os.replace
+    failed = False
+
+    def fail_first_stamp_replace(
+        source: os.PathLike[str],
+        destination: os.PathLike[str],
+    ) -> None:
+        nonlocal failed
+        destination_path = Path(destination)
+        if destination_path == stamp and not failed:
+            failed = True
+            raise OSError(errno.EIO, "simulated stamp replacement failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(daemon.os, "replace", fail_first_stamp_replace)
+
+    with pytest.raises(OSError, match="simulated stamp replacement failure"):
+        daemon.install_native_pre_tool_use_command(home=tmp_path, force=True)
+
+    assert failed is True
+    assert installed.read_bytes() == original_command
+    assert stamp.read_bytes() == original_stamp
+    assert stat.S_IMODE(installed.stat().st_mode) == 0o700
+    assert stat.S_IMODE(stamp.stat().st_mode) == 0o600
+    assert _staging_files(tmp_path) == []
+
+
+def test_native_hook_install_across_real_filesystems_when_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_tmp = Path("/tmp")
+    if not system_tmp.is_dir() or not os.access(system_tmp, os.W_OK):
+        pytest.skip("/tmp is not writable on this host")
+    if system_tmp.stat().st_dev == tmp_path.stat().st_dev:
+        pytest.skip("host exposes only one writable test filesystem")
+
+    build_parent = Path(tempfile.mkdtemp(prefix="ardur-exdev-build-", dir=system_tmp))
+    try:
+        monkeypatch.setattr(tempfile, "tempdir", str(build_parent))
+        installed = daemon.install_native_pre_tool_use_command(
+            home=tmp_path,
+            force=True,
+        )
+    finally:
+        shutil.rmtree(build_parent, ignore_errors=True)
+
+    if installed is None:
+        pytest.xfail("native PreToolUse daemon client could not be built on this host")
+    assert installed.stat().st_dev == tmp_path.stat().st_dev
+    assert _stamp_path(installed).stat().st_dev == tmp_path.stat().st_dev
+    assert _staging_files(tmp_path) == []

--- a/python/vibap/claude_code_daemon.py
+++ b/python/vibap/claude_code_daemon.py
@@ -46,6 +46,7 @@ _ACTIVE_SOCKET_PROBE_INTERVAL_S = 0.01
 # Installed native fast path command for Claude Code PreToolUse hooks.
 _NATIVE_PRE_TOOL_USE_COMMAND_BASENAME = "claude-code-pre_tool_use"
 _NATIVE_PRE_TOOL_USE_COMMAND_MODE = 0o700
+_NATIVE_PRE_TOOL_USE_STAMP_MODE = 0o600
 
 
 def _native_pre_tool_use_client_c_source() -> str:
@@ -646,6 +647,171 @@ def _candidate_native_compilers() -> list[str]:
     return discovered
 
 
+def _copy_to_destination_staging_file(
+    source: Path,
+    destination: Path,
+    *,
+    mode: int,
+    purpose: str,
+) -> Path:
+    """Copy source into a private, durable staging file beside destination."""
+    fd = -1
+    staged: Path | None = None
+    try:
+        fd, raw_path = tempfile.mkstemp(
+            prefix=f".{destination.name}.{purpose}.",
+            suffix=".tmp",
+            dir=destination.parent,
+        )
+        staged = Path(raw_path)
+        with source.open("rb") as source_handle, os.fdopen(fd, "wb") as staged_handle:
+            fd = -1
+            shutil.copyfileobj(source_handle, staged_handle)
+            staged_handle.flush()
+            os.fchmod(staged_handle.fileno(), mode)
+            os.fsync(staged_handle.fileno())
+        return staged
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        if staged is not None:
+            try:
+                staged.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def _stage_existing_destination(path: Path) -> tuple[bool, Path | None]:
+    """Snapshot an existing regular destination for transactional rollback."""
+    if path.is_symlink():
+        raise OSError(f"refusing to replace symlinked native hook artifact: {path}")
+    if not path.exists():
+        return False, None
+    if not path.is_file():
+        raise OSError(f"native hook artifact is not a regular file: {path}")
+    mode = stat.S_IMODE(path.stat().st_mode)
+    backup = _copy_to_destination_staging_file(
+        path,
+        path,
+        mode=mode,
+        purpose="rollback",
+    )
+    return True, backup
+
+
+def _remove_staging_file(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _restore_destination(path: Path, *, existed: bool, backup: Path | None) -> None:
+    if backup is not None:
+        os.replace(backup, path)
+    elif not existed:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _fsync_directory_best_effort(path: Path) -> None:
+    """Persist directory entries where the host filesystem supports it."""
+    directory_fd = -1
+    try:
+        directory_fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        os.fsync(directory_fd)
+    except OSError:
+        # Windows and some network filesystems do not support directory fsync.
+        pass
+    finally:
+        if directory_fd >= 0:
+            os.close(directory_fd)
+
+
+def _install_native_pre_tool_use_artifacts(
+    *,
+    built_command: Path,
+    built_stamp: Path,
+    target: Path,
+    target_stamp: Path,
+) -> None:
+    """Install the command and stamp atomically per file with pair rollback."""
+    staged_command: Path | None = None
+    staged_stamp: Path | None = None
+    command_backup: Path | None = None
+    stamp_backup: Path | None = None
+    command_existed = False
+    stamp_existed = False
+    command_replaced = False
+    stamp_replaced = False
+
+    try:
+        staged_command = _copy_to_destination_staging_file(
+            built_command,
+            target,
+            mode=_NATIVE_PRE_TOOL_USE_COMMAND_MODE,
+            purpose="install",
+        )
+        staged_stamp = _copy_to_destination_staging_file(
+            built_stamp,
+            target_stamp,
+            mode=_NATIVE_PRE_TOOL_USE_STAMP_MODE,
+            purpose="install",
+        )
+        command_existed, command_backup = _stage_existing_destination(target)
+        stamp_existed, stamp_backup = _stage_existing_destination(target_stamp)
+
+        os.replace(staged_command, target)
+        staged_command = None
+        command_replaced = True
+        os.replace(staged_stamp, target_stamp)
+        staged_stamp = None
+        stamp_replaced = True
+        _fsync_directory_best_effort(target.parent)
+    except Exception as exc:
+        rollback_errors: list[OSError] = []
+        if stamp_replaced:
+            try:
+                _restore_destination(
+                    target_stamp,
+                    existed=stamp_existed,
+                    backup=stamp_backup,
+                )
+                stamp_backup = None
+            except OSError as rollback_error:
+                rollback_errors.append(rollback_error)
+        if command_replaced:
+            try:
+                _restore_destination(
+                    target,
+                    existed=command_existed,
+                    backup=command_backup,
+                )
+                command_backup = None
+            except OSError as rollback_error:
+                rollback_errors.append(rollback_error)
+        _fsync_directory_best_effort(target.parent)
+        if rollback_errors and hasattr(exc, "add_note"):
+            exc.add_note(
+                "native hook rollback also failed: "
+                + "; ".join(str(error) for error in rollback_errors)
+            )
+        raise
+    finally:
+        for path in (
+            staged_command,
+            staged_stamp,
+            command_backup,
+            stamp_backup,
+        ):
+            _remove_staging_file(path)
+
+
 def install_native_pre_tool_use_command(
     *,
     home: Path | None = None,
@@ -706,9 +872,12 @@ def install_native_pre_tool_use_command(
                 + "\n",
                 encoding="utf-8",
             )
-            out.replace(target)
-            target.chmod(_NATIVE_PRE_TOOL_USE_COMMAND_MODE)
-            stamp.replace(target_stamp)
+            _install_native_pre_tool_use_artifacts(
+                built_command=out,
+                built_stamp=stamp,
+                target=target,
+                target_stamp=target_stamp,
+            )
             return target
 
     return None


### PR DESCRIPTION
## Summary
- stage the compiled Claude Code hook and digest in private files on the destination filesystem
- fsync and apply final modes before same-directory atomic replacement
- restore the previous valid binary/stamp pair and clean staging files when a midpoint commit fails
- cover deterministic filesystem operations and an organic distinct-filesystem path

## Validation
- real `ardur protect claude-code` from system `/tmp` (device 16777231) to EXTENDED home (device 16777240): `ok: true`, no traceback
- installed binary `0700`, digest stamp `0600`, recorded SHA-256 matches installed bytes, zero staging files
- focused hook tests: `66 passed`
- full Python suite: `1351 passed, 32 skipped`
- Go test, vet, and build: passed
- repository quick checks and packaged-asset drift check: passed
- changed-file Ruff and format checks: passed

Known baseline: a full-tree Ruff sweep reports 42 pre-existing findings outside this diff.

Closes #192