### PR TITLE
fix(ci): publish stable protected-check aggregates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,3 +84,27 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
         with:
           category: "/language:${{ matrix.language }}"
+
+  codeql:
+    name: codeql
+    if: ${{ always() }}
+    needs:
+      - detect-languages
+      - analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require language detection and applicable analyses
+        env:
+          DETECT: ${{ needs['detect-languages'].result }}
+          LANGUAGES: ${{ needs['detect-languages'].outputs.languages }}
+          ANALYZE: ${{ needs.analyze.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::Language detection concluded $DETECT"
+            exit 1
+          fi
+          if [ "$LANGUAGES" != "[]" ] && [ "$ANALYZE" != "success" ]; then
+            echo "::error::CodeQL analysis concluded $ANALYZE"
+            exit 1
+          fi

--- a/.github/workflows/hugo-site.yml
+++ b/.github/workflows/hugo-site.yml
@@ -2,18 +2,8 @@ name: hugo-site
 
 on:
   pull_request:
-    paths:
-      - "site/**"
-      - "**/*.md"
-      - "media/**"
-      - ".github/workflows/hugo-site.yml"
   push:
     branches: [main, dev]
-    paths:
-      - "site/**"
-      - "**/*.md"
-      - "media/**"
-      - ".github/workflows/hugo-site.yml"
   workflow_dispatch:
 
 permissions:
@@ -98,3 +88,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+
+  hugo-site:
+    name: hugo-site
+    if: ${{ always() }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the source-backed site build
+        env:
+          BUILD: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          if [ "$BUILD" != "success" ]; then
+            echo "::error::Hugo site build concluded $BUILD"
+            exit 1
+          fi

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,9 +2,6 @@ name: link-check
 
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".github/workflows/link-check.yml"
   schedule:
     - cron: "0 14 * * 1"  # Mondays 14:00 UTC
   workflow_dispatch:
@@ -53,3 +50,19 @@ jobs:
             --exclude-path '^site/content/'
             './**/*.md'
           fail: true
+
+  link-check:
+    name: link-check
+    if: ${{ always() }}
+    needs: lychee
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require link validation
+        env:
+          LYCHEE: ${{ needs.lychee.result }}
+        run: |
+          set -euo pipefail
+          if [ "$LYCHEE" != "success" ]; then
+            echo "::error::Link validation concluded $LYCHEE"
+            exit 1
+          fi

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -99,3 +99,34 @@ jobs:
             exit 1
           fi
           echo "No specific LLM model names found."
+
+  secret-scan:
+    name: secret-scan
+    if: ${{ always() }}
+    needs:
+      - local-agent-private-paths
+      - gitleaks
+      - forbidden-terms
+      - llm-model-names
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every secret and publication-safety job
+        env:
+          LOCAL_PATHS: ${{ needs['local-agent-private-paths'].result }}
+          GITLEAKS: ${{ needs.gitleaks.result }}
+          FORBIDDEN_TERMS: ${{ needs['forbidden-terms'].result }}
+          LLM_MODEL_NAMES: ${{ needs['llm-model-names'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success local-agent-private-paths "$LOCAL_PATHS"
+          require_success gitleaks "$GITLEAKS"
+          require_success forbidden-terms "$FORBIDDEN_TERMS"
+          require_success llm-model-names "$LLM_MODEL_NAMES"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,3 +233,43 @@ jobs:
           ARDUR_OLLAMA_API_KEY: ${{ secrets.ARDUR_OLLAMA_API_KEY }}
           ARDUR_OLLAMA_CLOUD_MODEL: ${{ vars.ARDUR_OLLAMA_CLOUD_MODEL }}
         run: python -m pytest tests/test_e2e_showcase.py -v -s --tb=short
+
+  tests:
+    name: tests
+    if: ${{ always() }}
+    needs:
+      - python-lint
+      - go-lint
+      - python
+      - go
+      - go-cve
+      - rwt-phase1
+      - examples-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every blocking test job
+        env:
+          PYTHON_LINT: ${{ needs['python-lint'].result }}
+          GO_LINT: ${{ needs['go-lint'].result }}
+          PYTHON: ${{ needs.python.result }}
+          GO: ${{ needs.go.result }}
+          GO_CVE: ${{ needs['go-cve'].result }}
+          RWT_PHASE1: ${{ needs['rwt-phase1'].result }}
+          EXAMPLES_SMOKE: ${{ needs['examples-smoke'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success python-lint "$PYTHON_LINT"
+          require_success go-lint "$GO_LINT"
+          require_success python "$PYTHON"
+          require_success go "$GO"
+          require_success go-cve "$GO_CVE"
+          require_success rwt-phase1 "$RWT_PHASE1"
+          require_success examples-smoke "$EXAMPLES_SMOKE"

--- a/.github/workflows/validate-formats.yml
+++ b/.github/workflows/validate-formats.yml
@@ -147,3 +147,31 @@ jobs:
             fi
           done
           exit "$fail"
+
+  validate-formats:
+    name: validate-formats
+    if: ${{ always() }}
+    needs:
+      - json
+      - yaml
+      - spec-schema-sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every format and schema job
+        env:
+          JSON_RESULT: ${{ needs.json.result }}
+          YAML_RESULT: ${{ needs.yaml.result }}
+          SPEC_SCHEMA_SYNC: ${{ needs['spec-schema-sync'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success json "$JSON_RESULT"
+          require_success yaml "$YAML_RESULT"
+          require_success spec-schema-sync "$SPEC_SCHEMA_SYNC"

--- a/site/static/repo/.github/workflows/codeql.yml
+++ b/site/static/repo/.github/workflows/codeql.yml
@@ -84,3 +84,27 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
         with:
           category: "/language:${{ matrix.language }}"
+
+  codeql:
+    name: codeql
+    if: ${{ always() }}
+    needs:
+      - detect-languages
+      - analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require language detection and applicable analyses
+        env:
+          DETECT: ${{ needs['detect-languages'].result }}
+          LANGUAGES: ${{ needs['detect-languages'].outputs.languages }}
+          ANALYZE: ${{ needs.analyze.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::Language detection concluded $DETECT"
+            exit 1
+          fi
+          if [ "$LANGUAGES" != "[]" ] && [ "$ANALYZE" != "success" ]; then
+            echo "::error::CodeQL analysis concluded $ANALYZE"
+            exit 1
+          fi

--- a/site/static/repo/.github/workflows/hugo-site.yml
+++ b/site/static/repo/.github/workflows/hugo-site.yml
@@ -2,18 +2,8 @@ name: hugo-site
 
 on:
   pull_request:
-    paths:
-      - "site/**"
-      - "**/*.md"
-      - "media/**"
-      - ".github/workflows/hugo-site.yml"
   push:
     branches: [main, dev]
-    paths:
-      - "site/**"
-      - "**/*.md"
-      - "media/**"
-      - ".github/workflows/hugo-site.yml"
   workflow_dispatch:
 
 permissions:
@@ -98,3 +88,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+
+  hugo-site:
+    name: hugo-site
+    if: ${{ always() }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the source-backed site build
+        env:
+          BUILD: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          if [ "$BUILD" != "success" ]; then
+            echo "::error::Hugo site build concluded $BUILD"
+            exit 1
+          fi

--- a/site/static/repo/.github/workflows/link-check.yml
+++ b/site/static/repo/.github/workflows/link-check.yml
@@ -2,9 +2,6 @@ name: link-check
 
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".github/workflows/link-check.yml"
   schedule:
     - cron: "0 14 * * 1"  # Mondays 14:00 UTC
   workflow_dispatch:
@@ -53,3 +50,19 @@ jobs:
             --exclude-path '^site/content/'
             './**/*.md'
           fail: true
+
+  link-check:
+    name: link-check
+    if: ${{ always() }}
+    needs: lychee
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require link validation
+        env:
+          LYCHEE: ${{ needs.lychee.result }}
+        run: |
+          set -euo pipefail
+          if [ "$LYCHEE" != "success" ]; then
+            echo "::error::Link validation concluded $LYCHEE"
+            exit 1
+          fi

--- a/site/static/repo/.github/workflows/secret-scan.yml
+++ b/site/static/repo/.github/workflows/secret-scan.yml
@@ -99,3 +99,34 @@ jobs:
             exit 1
           fi
           echo "No specific LLM model names found."
+
+  secret-scan:
+    name: secret-scan
+    if: ${{ always() }}
+    needs:
+      - local-agent-private-paths
+      - gitleaks
+      - forbidden-terms
+      - llm-model-names
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every secret and publication-safety job
+        env:
+          LOCAL_PATHS: ${{ needs['local-agent-private-paths'].result }}
+          GITLEAKS: ${{ needs.gitleaks.result }}
+          FORBIDDEN_TERMS: ${{ needs['forbidden-terms'].result }}
+          LLM_MODEL_NAMES: ${{ needs['llm-model-names'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success local-agent-private-paths "$LOCAL_PATHS"
+          require_success gitleaks "$GITLEAKS"
+          require_success forbidden-terms "$FORBIDDEN_TERMS"
+          require_success llm-model-names "$LLM_MODEL_NAMES"

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -233,3 +233,43 @@ jobs:
           ARDUR_OLLAMA_API_KEY: ${{ secrets.ARDUR_OLLAMA_API_KEY }}
           ARDUR_OLLAMA_CLOUD_MODEL: ${{ vars.ARDUR_OLLAMA_CLOUD_MODEL }}
         run: python -m pytest tests/test_e2e_showcase.py -v -s --tb=short
+
+  tests:
+    name: tests
+    if: ${{ always() }}
+    needs:
+      - python-lint
+      - go-lint
+      - python
+      - go
+      - go-cve
+      - rwt-phase1
+      - examples-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every blocking test job
+        env:
+          PYTHON_LINT: ${{ needs['python-lint'].result }}
+          GO_LINT: ${{ needs['go-lint'].result }}
+          PYTHON: ${{ needs.python.result }}
+          GO: ${{ needs.go.result }}
+          GO_CVE: ${{ needs['go-cve'].result }}
+          RWT_PHASE1: ${{ needs['rwt-phase1'].result }}
+          EXAMPLES_SMOKE: ${{ needs['examples-smoke'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success python-lint "$PYTHON_LINT"
+          require_success go-lint "$GO_LINT"
+          require_success python "$PYTHON"
+          require_success go "$GO"
+          require_success go-cve "$GO_CVE"
+          require_success rwt-phase1 "$RWT_PHASE1"
+          require_success examples-smoke "$EXAMPLES_SMOKE"

--- a/site/static/repo/.github/workflows/validate-formats.yml
+++ b/site/static/repo/.github/workflows/validate-formats.yml
@@ -147,3 +147,31 @@ jobs:
             fi
           done
           exit "$fail"
+
+  validate-formats:
+    name: validate-formats
+    if: ${{ always() }}
+    needs:
+      - json
+      - yaml
+      - spec-schema-sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every format and schema job
+        env:
+          JSON_RESULT: ${{ needs.json.result }}
+          YAML_RESULT: ${{ needs.yaml.result }}
+          SPEC_SCHEMA_SYNC: ${{ needs['spec-schema-sync'].result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job $job concluded $result"
+              exit 1
+            fi
+          }
+          require_success json "$JSON_RESULT"
+          require_success yaml "$YAML_RESULT"
+          require_success spec-schema-sync "$SPEC_SCHEMA_SYNC"


### PR DESCRIPTION
Closes #188. Refs #80.

## Problem

Branch protection requires six legacy contexts, but current workflows only publish job-level check runs. Fully green PRs therefore remain blocked and require routine administrator bypass.

## Change

- Add aggregate jobs named exactly `tests`, `secret-scan`, `codeql`, `hugo-site`, `validate-formats`, and `link-check`.
- Run each aggregate under `always()` and fail it unless every blocking dependency succeeded.
- Preserve all current test, secret, CodeQL, source-backed site, format/schema, and link coverage.
- Run Hugo and link validation on every PR so a path filter cannot leave a protected context absent.
- Keep informational latency and real-Ollama jobs non-blocking by their existing design.
- Leave branch-protection settings and repository auto-merge unchanged.

## Validation

- All workflow YAML parses.
- Repository quick checks pass.
- Actionlint v1.7.12 validates the full workflow set with the existing SC2046 baseline suppression.
- `git diff --check` passes.

## Live acceptance

1. This PR must publish and pass all six aggregate checks.
2. After they pass, a disposable PR will deliberately fail an underlying required job; its corresponding aggregate and protected merge state must fail closed.
3. This PR will use the ordinary protected merge path, without `--admin`.