### PR TITLE
ci(deps): update and group CodeQL Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       time: "04:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
     labels:
       - "ci"
       - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       # Pin to the commit SHA per the same discipline as the other
       # workflows; comment shows the human-readable version.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: ${{ matrix.language }}
           # `security-and-quality` is the broadest pack — covers
@@ -78,10 +78,10 @@ jobs:
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/site/static/repo/.github/workflows/codeql.yml
+++ b/site/static/repo/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       # Pin to the commit SHA per the same discipline as the other
       # workflows; comment shows the human-readable version.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: ${{ matrix.language }}
           # `security-and-quality` is the broadest pack — covers
@@ -78,10 +78,10 @@ jobs:
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3 (commit)
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"
 


### PR DESCRIPTION
## Summary

- update CodeQL `init`, `autobuild`, and `analyze` together to the immutable v4.37.0 commit
- synchronize the generated workflow mirror
- group `github/codeql-action/*` updates so Dependabot cannot split the three phases across incompatible versions again

## Why

Dependabot PR #135 updates only `analyze` while `init` and `autobuild` remain on v4.36.2. Both language jobs then fail with:

```
Loaded a configuration file for version '4.36.2', but running version '4.37.0'
```

This replaces the fragmented updates in #130, #131, and #135 with one coherent change.

## Provenance and risk

- official release: https://github.com/github/codeql-action/releases/tag/v4.37.0
- immutable commit: `99df26d4f13ea111d4ec1a7dddef6063f76b97e9`
- the annotated upstream tag peels to that commit and matches Dependabot's proposed SHA
- the upstream tag is not signed; the residual provenance risk is bounded by the immutable full-SHA pin and behavioral validation in both CodeQL language jobs

## Validation

- full Python test suite
- full Go tests, `go vet`, and Go build
- Actionlint v1.7.12 and workflow YAML parsing
- repository quick checks
- source synchronization: 87 pages and 46 mirrored artifacts
- nine public claim checks
- Hugo build: 245 pages and 49 static files
- rendered link validation
- immutable source provenance scan
- `git diff --check`

Refs #80
