### PR TITLE
ci(deps): update setup-go to 6.5.0

### DIFF
--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: "1.26.5"
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.5"
           cache: true
@@ -329,7 +329,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.5"
           cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: '1.26.5'
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: '1.26.5'

--- a/site/static/repo/.github/workflows/kernel-enforce.yml
+++ b/site/static/repo/.github/workflows/kernel-enforce.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: "1.26.5"
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.5"
           cache: true
@@ -329,7 +329,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.5"
           cache: true

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: '1.26.5'
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           # If you bump go.mod, bump this string in the same PR.
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           # Must match the `go` directive in go/go.mod (currently 1.26.5).
           go-version: '1.26.5'


### PR DESCRIPTION
## Summary

- update all six `actions/setup-go` uses to the immutable v6.5.0 commit
- preserve Go 1.26.5 and every existing cache input
- synchronize both generated workflow mirrors

## Why this replaces #132

Dependabot PR #132 changes the two canonical workflows but omits their generated mirrors. Its Python 3.10 and 3.13 jobs fail `test_go_toolchain_versions_stay_in_lockstep` because the public copies still pin v6.4.0. The bot branch has `maintainerCanModify: false`, so this source-synchronized replacement carries the same upstream SHA.

## Provenance

- official release: https://github.com/actions/setup-go/releases/tag/v6.5.0
- immutable commit: `924ae3a1cded613372ab5595356fb5720e22ba16`
- the lightweight v6.5.0 tag points directly to that commit
- GitHub reports a valid verified signature for the commit
- release scope: action dependency updates, npm audit remediation, `@actions/cache` 5.1.0, and cache-write-denied logging

## Validation

- formerly failing Go toolchain lockstep contract
- workflow YAML and Actionlint v1.7.12
- repository quick checks
- full Python suite: 1,351 passed, 32 skipped
- full Go tests, `go vet`, and Go build
- source synchronization: 87 pages and 46 mirrored artifacts
- nine public claim checks
- Hugo build: 245 pages and 49 static files
- rendered link and immutable provenance checks
- `git diff --check`

Live GitHub CI is the publication gate for actual setup-go installation and cache behavior.

Refs #80
Supersedes #132
