### PR TITLE
security(demo): pin SPIRE and Python image bases

### DIFF
--- a/examples/autogen-quickstart/Dockerfile
+++ b/examples/autogen-quickstart/Dockerfile
@@ -14,22 +14,14 @@
 # uses the official `spire-agent` CLI instead (production sidecar-fetch
 # pattern). Same real Workload API, different real client.
 
-# FIX-9 (2026-04-28): production builds MUST digest-pin both base images.
-# Resolve current digests with:
-#   skopeo inspect docker://ghcr.io/spiffe/spire-agent:1.14.2 \
-#     --format '{{.Digest}}'
-#   skopeo inspect docker://docker.io/library/python:3.13-slim \
-#     --format '{{.Digest}}'
-# Then update the FROM lines to use "@sha256:<digest>" form. The
-# published demo images keep tag-pinned references for contributor
-# reproducibility; CI/release builds must swap to digest pinning so a
-# malicious tag re-push at the upstream registry can't poison the
-# governance demo.
+# Keep tags for readable dependency updates while immutable multi-arch index
+# digests prevent a registry tag re-push from changing published demo builds.
 
 # Stage 1: pull the real spire-agent binary from the official image.
-FROM ghcr.io/spiffe/spire-agent:1.15.0 AS spire
+FROM ghcr.io/spiffe/spire-agent:1.15.2@sha256:1d042e4040466686e0ee46f74981ff2167c86adfadca19b3835946f4d6047536 AS spire
 
-FROM python:3.14-slim
+# biscuit-python 0.4.0 embeds PyO3 0.24.1, whose supported ceiling is 3.13.
+FROM python:3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/examples/autogen-quickstart/README.md
+++ b/examples/autogen-quickstart/README.md
@@ -22,7 +22,7 @@ autogen-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`; the CLI is `ardur`, module imports are `vibap`)
 - `autogen-agentchat ^0.4.0` plus `autogen-core` (transitive)
 - `autogen-ext[ollama,openai,anthropic]` for the multi-provider matrix

--- a/examples/langchain-quickstart/Dockerfile
+++ b/examples/langchain-quickstart/Dockerfile
@@ -15,16 +15,10 @@
 # identifiers are baked in — the runtime expects ARDUR_PROVIDER plus
 # the matching *_MODEL env vars at run time.
 
-# FIX-9 (2026-04-28): production builds MUST digest-pin the base image.
-# Resolve the current digest with:
-#   skopeo inspect docker://docker.io/library/python:3.13-slim \
-#     --format '{{.Digest}}'
-# Then change the FROM line to:
-#   FROM python:3.13-slim@sha256:<digest>
-# The published demo image keeps the tag-pinned form so unprivileged
-# contributors can reproduce it; CI/release builds should swap to a
-# digest before pushing to a registry consumers will pull from.
-FROM python:3.14-slim
+# Keep the tag for readable dependency updates while the immutable multi-arch
+# index digest prevents a registry tag re-push from changing published builds.
+# biscuit-python 0.4.0 embeds PyO3 0.24.1, whose supported ceiling is 3.13.
+FROM python:3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/examples/langchain-quickstart/README.md
+++ b/examples/langchain-quickstart/README.md
@@ -22,7 +22,7 @@ langchain-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`; the CLI is `ardur`, module imports are `vibap`)
 - `langchain ^0.3.0` plus `langchain-core ^0.3.0`, `langchain-ollama`, `langchain-openai`, `langchain-anthropic`, `langgraph`
 - LLM access: any provider that LangChain supports — local Ollama, an OpenAI-compatible gateway, an Anthropic API key, etc.

--- a/examples/langgraph-quickstart/README.md
+++ b/examples/langgraph-quickstart/README.md
@@ -21,7 +21,7 @@ langgraph-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`)
 - `langgraph ^0.2.0` plus the `langchain-*` family (already pulled by `[dev]` extras for the LangChain demo)
 - LLM access: local Ollama, an OpenAI-compatible gateway, or an Anthropic API key

--- a/python/tests/test_demo_image_security.py
+++ b/python/tests/test_demo_image_security.py
@@ -1,0 +1,46 @@
+"""Supply-chain invariants for the published governance demo images."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIGEST_PIN = re.compile(r"^.+:[^@\s]+@sha256:[0-9a-f]{64}$")
+PYTHON_BISCUIT_COMPATIBLE_BASE = re.compile(
+    r"^python:3\.(?:10|11|12|13)(?:[.-])"
+)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_base_count"),
+    [
+        ("examples/autogen-quickstart/Dockerfile", 2),
+        ("examples/langchain-quickstart/Dockerfile", 1),
+    ],
+)
+def test_published_demo_images_digest_pin_external_bases(
+    relative_path: str,
+    expected_base_count: int,
+) -> None:
+    dockerfile = REPO_ROOT / relative_path
+    from_lines = [
+        line.strip()
+        for line in dockerfile.read_text(encoding="utf-8").splitlines()
+        if line.startswith("FROM ")
+    ]
+
+    assert len(from_lines) == expected_base_count
+    for line in from_lines:
+        reference = line.split()[1]
+        assert DIGEST_PIN.fullmatch(reference), (
+            f"{relative_path} must pin {reference!r} to a full sha256 digest"
+        )
+        if reference.startswith("python:"):
+            assert PYTHON_BISCUIT_COMPATIBLE_BASE.match(reference), (
+                "biscuit-python 0.4.0 requires Python 3.13 or older; "
+                f"{relative_path} uses {reference!r}"
+            )

--- a/site/content/source/examples/autogen-quickstart/README.md
+++ b/site/content/source/examples/autogen-quickstart/README.md
@@ -2,7 +2,7 @@
 title: "AutoGen + Ardur quickstart"
 description: "An AutoGen agent (v0.4+ architecture, `autogen-agentchat`) making tool calls through Ardur's governance proxy. The agent runs under an Ardur-issued mission credential, calls a smal"
 source_path: "examples/autogen-quickstart/README.md"
-source_sha256: "6a121815b1c4e5b1b0bc2db34e4b8470203c834cdfbc64b784c3b7a06ea1d5f3"
+source_sha256: "878bd2c46b691ff48c95cae074736fe6d6a241eda0597b1dbd94bf2357940501"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["integration"]
@@ -39,7 +39,7 @@ autogen-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`; the CLI is `ardur`, module imports are `vibap`)
 - `autogen-agentchat ^0.4.0` plus `autogen-core` (transitive)
 - `autogen-ext[ollama,openai,anthropic]` for the multi-provider matrix

--- a/site/content/source/examples/langchain-quickstart/README.md
+++ b/site/content/source/examples/langchain-quickstart/README.md
@@ -2,7 +2,7 @@
 title: "LangChain + Ardur quickstart"
 description: "A LangChain agent making tool calls through Ardur's governance proxy. The agent runs under an Ardur-issued mission credential, calls a small set of tools (read, write, summarize), "
 source_path: "examples/langchain-quickstart/README.md"
-source_sha256: "e9a8b8f433d053dae487b6fdc31f1bb9e850cce8b1c4db342332287497792f39"
+source_sha256: "d5e278292309051e8322d7c2fdde549f67f6bf7c3e08d03db32548af0829bc22"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["integration"]
@@ -39,7 +39,7 @@ langchain-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`; the CLI is `ardur`, module imports are `vibap`)
 - `langchain ^0.3.0` plus `langchain-core ^0.3.0`, `langchain-ollama`, `langchain-openai`, `langchain-anthropic`, `langgraph`
 - LLM access: any provider that LangChain supports — local Ollama, an OpenAI-compatible gateway, an Anthropic API key, etc.

--- a/site/content/source/examples/langgraph-quickstart/README.md
+++ b/site/content/source/examples/langgraph-quickstart/README.md
@@ -2,7 +2,7 @@
 title: "LangGraph + Ardur quickstart"
 description: "A LangGraph agent making tool calls through Ardur's governance proxy. The agent runs under an Ardur-issued mission credential, calls a small set of tools (read, write, summarize), "
 source_path: "examples/langgraph-quickstart/README.md"
-source_sha256: "bc739eaef49408bd3d33fea4827e061062f120e33d6d59d8d62611e9b986cc03"
+source_sha256: "8652ff8484ebfec46ab1ebe5c2ea85a7d13209b4c28bd844eed30d01d00b8b0e"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["integration"]
@@ -38,7 +38,7 @@ langgraph-quickstart/
 
 ## Dependencies
 
-- Python 3.13+
+- Python 3.13 (`biscuit-python==0.4.0` does not support Python 3.14)
 - `python/` editable install (this repo, `pip install -e ../../python[dev]`)
 - `langgraph ^0.2.0` plus the `langchain-*` family (already pulled by `[dev]` extras for the LangChain demo)
 - LLM access: local Ollama, an OpenAI-compatible gateway, or an Anthropic API key


### PR DESCRIPTION
## Summary

- update the AutoGen demo's official SPIRE agent stage from 1.15.0 to 1.15.2
- bind SPIRE and Python bases to immutable multi-arch OCI index digests
- restore both published demo images to Python 3.13.14, their latest compatible interpreter
- add regression coverage for digest pins and the current Python compatibility ceiling
- correct AutoGen, LangChain, and LangGraph quickstart requirements and generated public mirrors

## Why this replaces #199

PR #199 is repository-green but changes only the mutable SPIRE tag. Deeper review found two release blockers outside its existing CI:

1. Both demo Dockerfiles say release builds swap tags for digests, but no CI, script, or release implementation performs that substitution.
2. A real AutoGen image build fails on the existing `python:3.14-slim` base. `biscuit-python==0.4.0` is the latest release and embeds PyO3 0.24.1, whose maximum supported interpreter is Python 3.13.

The original demos used Python 3.13; an unbuilt dependency update moved them to 3.14.

## Provenance

- official SPIRE release: https://github.com/spiffe/spire/releases/tag/v1.15.2
- SPIRE release commit: `e78e2eeca03a8a420bfe1b23b6eaf3db0db78630` (GitHub-verified)
- SPIRE 1.15.2 image index: `sha256:1d042e4040466686e0ee46f74981ff2167c86adfadca19b3835946f4d6047536`
- Python 3.13.14 slim-trixie index: `sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280`
- both indexes publish Linux amd64/arm64 images and attestation manifests
- the annotated SPIRE tag is unsigned; immutable image digests and the verified target commit bound the residual provenance risk

## Image validation

AutoGen and LangChain Dockerfiles were each built and run on:

- native Linux arm64
- Linux amd64 under BuildKit emulation

The resulting images:

- start successfully with their documented default command
- run as UID 1000
- report Python 3.13.14
- import their Biscuit and framework dependencies
- report SPIRE 1.15.2 in the AutoGen image

A control build on Python 3.14 failed with PyO3's explicit maximum-supported-version error, proving the guard's necessity.

## Repository validation

- new image-security tests and Ruff
- full Python suite: 1,353 passed, 32 skipped
- repository quick checks
- source synchronization: 87 pages and 46 mirrored artifacts
- nine public claim checks
- Hugo build: 245 pages and 49 static files
- rendered link and immutable provenance checks
- `git diff --check`

Refs #80
Supersedes #199
