### PR TITLE
ci(deps): update lychee action to 2.9.0

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Run lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           # Excludes:
           # - github.com/.../security/advisories/new: requires being

--- a/site/static/repo/.github/workflows/link-check.yml
+++ b/site/static/repo/.github/workflows/link-check.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Run lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           # Excludes:
           # - github.com/.../security/advisories/new: requires being


### PR DESCRIPTION
## Summary

- update the immutable lychee-action pin from v2.8.0 to v2.9.0
- regenerate the governed Hugo mirror omitted by Dependabot #202
- retain read-only workflow permissions and the existing fail-closed link policy

## Upstream review

- v2.9.0 resolves exactly to GitHub-verified commit `e7477775783ea5526144ba13e8db5eec57747ce8`
- the action moves installation to `RUNNER_TEMP` and detects lychee 0.24.x's subdirectory archive layout
- five of six action commits are GitHub-verified; the sole unsigned automated commit only changes the default from lychee 0.24.1 to 0.24.2
- lychee 0.24.2's release commit is GitHub-verified; the downloaded arm64 macOS artifact matched GitHub's published SHA-256 digest

## Validation

- Dependabot source-workflow blob match: `970ca50ee04047d347cb2d717065ea900bc7b810`
- `python3 site/scripts/sync_source_docs.py --check`
- public claim validation
- full Hugo build, rendered documentation links, and rendered provenance checks
- exact lychee 0.24.2 invocation: 311 links, 304 OK, 7 excluded, 0 errors
- YAML parse and `git diff --check`

Supersedes #202 after this PR is merged and proven on `dev`.

Refs #80