### PR TITLE
test(deps): migrate to pytest-cov 7

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 dev = [
     "build==1.5.1",
     "pytest>=8.0,<10",
-    "pytest-cov>=5.0,<7",
+    "pytest-cov>=5.0,<8",
     "setuptools==83.0.0",
     "wheel==0.47.0",
     "PyYAML>=6.0,<7",
@@ -57,6 +57,10 @@ dev = [
 # Emit stack traces during CI hangs before GitHub's 15-minute pytest step
 # timeout. This is diagnostics-only; it does not change pytest pass/fail logic.
 faulthandler_timeout = "120"
+
+[tool.coverage.run]
+# pytest-cov 7 delegates subprocess measurement to coverage.py.
+patch = ["subprocess"]
 
 [project.scripts]
 ardur = "vibap.cli:main"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -46,29 +46,35 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "biscuit-python" },
+    { name = "build" },
     { name = "cedarpy" },
     { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "setuptools" },
     { name = "spiffe" },
+    { name = "wheel" },
     { name = "z3-solver" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "biscuit-python", marker = "extra == 'dev'", specifier = "==0.4.0" },
+    { name = "build", marker = "extra == 'dev'", specifier = "==1.5.1" },
     { name = "cedarpy", marker = "extra == 'dev'", specifier = ">=4.0,<6" },
     { name = "cryptography", specifier = ">=41.0,<50" },
     { name = "jsonschema", specifier = ">=4.0,<5" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.23.0,<2" },
     { name = "pyjwt", specifier = ">=2.12.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<10" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0,<7" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0,<8" },
     { name = "python-multipart", marker = "extra == 'dev'", specifier = ">=0.0.26,<1" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0,<7" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = "==83.0.0" },
     { name = "spiffe", marker = "extra == 'dev'", specifier = ">=0.2,<0.4" },
+    { name = "wheel", marker = "extra == 'dev'", specifier = "==0.47.0" },
     { name = "z3-solver", marker = "extra == 'dev'", specifier = ">=4.16,<5" },
 ]
 provides-extras = ["dev"]
@@ -165,6 +171,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/29/70a455a692f4c0f9719f5e592dd200fbeb167ec25a17d6ddd9d97dba896f/biscuit_python-0.4.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:3a35c9c420ea6a9eac7ed230aa2041643c0a81226a237756cb1944239bb4ba24", size = 2127735, upload-time = "2025-09-26T15:37:45.365Z" },
     { url = "https://files.pythonhosted.org/packages/98/38/c8ee8836c61a56b651f7032cb2aaff4f5b2083a4972711d76d00512c8069/biscuit_python-0.4.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:29e932854034eb4ebb6619ef64580c54868c6bdb8a17503a130a68ce0a07c876", size = 2169521, upload-time = "2025-09-26T15:38:16.199Z" },
     { url = "https://files.pythonhosted.org/packages/64/4c/685038b5568654466e0bfc3bb8be0f1b332f8ad833c88bc9dac9b328af38/biscuit_python-0.4.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2140021af44766cdeaf7700b03de41b931ad574bdbbc8b37a40521cb96b6350f", size = 2167955, upload-time = "2025-09-26T15:38:30.286Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
 ]
 
 [[package]]
@@ -507,7 +529,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -628,6 +650,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -936,6 +970,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -955,16 +998,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "6.3.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1345,6 +1388,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "spiffe"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1478,6 +1530,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wheel"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
+]
+
+[[package]]
 name = "z3-solver"
 version = "4.16.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1490,4 +1554,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/df/29816ce4de24cca3acb007412f9c6fba603e55fcc27ce8c2aade0939057a/z3_solver-4.16.0.0-py3-none-win32.whl", hash = "sha256:cc64c4d41fbebe419fccddb044979c3d95b41214547db65eecdaa67fafef7fe0", size = 13341643, upload-time = "2026-02-19T04:13:58.88Z" },
     { url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl", hash = "sha256:eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462", size = 16419861, upload-time = "2026-02-19T04:14:03.232Z" },
     { url = "https://files.pythonhosted.org/packages/e1/18/7dc1051093abfd6db56ce9addb63c624bfa31946ccb9cfc9be5e75237a26/z3_solver-4.16.0.0-py3-none-win_arm64.whl", hash = "sha256:28729eae2c89112e37697acce4d4517f5e44c6c54d36fed9cf914b06f380cbd6", size = 15084866, upload-time = "2026-02-19T04:14:06.355Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

- widen the pytest-cov dev constraint to `>=5.0,<8`, matching Dependabot #23
- preserve subprocess coverage using pytest-cov 7's documented coverage.py patch
- refresh the stale uv lock so all declared dev build pins install under `--locked`

## Compatibility and trust review

- pytest-cov 7.1.0 supports Python >=3.9 and pytest >=7; Ardur supports Python >=3.10 and resolves pytest 9.1.1
- it requires coverage >=7.10.6; Ardur already locks coverage 7.15.0
- official migration guidance requires `[tool.coverage.run] patch = ["subprocess"]`; coverage confirms that this also enables parallel collection
- upstream tag/commit are unsigned and PyPI has hashes but no provenance attestation; lock hashes match PyPI's published 7.1.0 artifacts

## Reproducibility repair

The prior `uv.lock` omitted already-declared `build==1.5.1`, `setuptools==83.0.0`, and `wheel==0.47.0`, so `uv run --locked --extra dev` failed. Regenerating with only pytest-cov selected for upgrade adds those declared tools and restores a current lock.

## Validation

- controlled pytest-cov 6.3.0 baseline: 1,353 passed, 32 skipped, 12,956 statements / 1,987 missed / 85%
- pytest-cov 7.1.0 on Python 3.12: identical tests and coverage vector
- pytest-cov 7.1.0 on Python 3.13: identical tests and coverage vector
- `coverage debug config`: `patch=subprocess`, `parallel=True`
- fresh external `uv sync --locked --extra dev` includes all declared build tools
- `uv lock --check`, TOML parsing, diff hygiene, and PyPI advisory audit pass

Official migration docs: https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
Coverage patch reference: https://coverage.readthedocs.io/en/latest/config.html#run-patch

Supersedes #23 after this PR is merged and proven on `dev`.

Refs #80