### PR TITLE
deps(go): update cilium ebpf to 0.22.0

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0
-	github.com/cilium/ebpf v0.21.0
+	github.com/cilium/ebpf v0.22.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/sigstore/sigstore-go v1.2.2
 	github.com/spiffe/go-spiffe/v2 v2.6.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -81,8 +81,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
-github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
+github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
+github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go/pkg/kernelcapture/bpf_policy_apply_linux.go
+++ b/go/pkg/kernelcapture/bpf_policy_apply_linux.go
@@ -88,8 +88,9 @@ func PolicyMapsFromHandles(h *ProcessGuardHandles) PolicyMaps {
 // LoadAndAttachProcessGuardEBPF loads the process_guard BPF object, attaches
 // the three LSM hooks, and opens the enforce_events ringbuf reader.
 //
-// Requires CAP_BPF (or CAP_SYS_ADMIN on older kernels), CONFIG_BPF_LSM=y,
-// and "bpf" listed in /sys/kernel/security/lsm (or the lsm= kernel cmdline).
+// Requires BPF syscall authority via effective CAP_BPF/CAP_SYS_ADMIN (the
+// supported Ardur installer path) or an explicitly delegated BPF token,
+// plus CONFIG_BPF_LSM=y and "bpf" listed in /sys/kernel/security/lsm.
 func LoadAndAttachProcessGuardEBPF() (*ProcessGuardHandles, error) {
 	h := &ProcessGuardHandles{}
 

--- a/go/pkg/kernelcapture/processexec_bpfel.go
+++ b/go/pkg/kernelcapture/processexec_bpfel.go
@@ -12,6 +12,17 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	processExecMapAllowedCgroups          = "allowed_cgroups"
+	processExecMapEvents                  = "events"
+	processExecMapFilterControl           = "filter_control"
+	processExecProgHandleSchedProcessExec = "handle_sched_process_exec"
+	processExecProgHandleSchedProcessExit = "handle_sched_process_exit"
+)
+
 // loadProcessExec returns the embedded CollectionSpec for processExec.
 func loadProcessExec() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_ProcessExecBytes)
@@ -32,7 +43,7 @@ func loadProcessExec() (*ebpf.CollectionSpec, error) {
 //	*processExecMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadProcessExecObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadProcessExecObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadProcessExec()
 	if err != nil {
 		return err

--- a/go/pkg/kernelcapture/processguard_bpfel.go
+++ b/go/pkg/kernelcapture/processguard_bpfel.go
@@ -65,6 +65,26 @@ type processGuardArdurPathLpmKey struct {
 	Path      [248]int8
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	processGuardMapCgroupFileAllow      = "cgroup_file_allow"
+	processGuardMapCgroupManaged        = "cgroup_managed"
+	processGuardMapCgroupNetAllow       = "cgroup_net_allow"
+	processGuardMapCgroupOpPolicy       = "cgroup_op_policy"
+	processGuardMapCgroupPathAllow      = "cgroup_path_allow"
+	processGuardMapEnforceEvents        = "enforce_events"
+	processGuardMapEnforceEventsDropped = "enforce_events_dropped"
+	processGuardMapFileAllowScratch     = "file_allow_scratch"
+	processGuardMapKillSwitch           = "kill_switch"
+	processGuardMapNetLpmScratch        = "net_lpm_scratch"
+	processGuardMapPathLpmScratch       = "path_lpm_scratch"
+	processGuardProgGuardBprmCheck      = "guard_bprm_check"
+	processGuardProgGuardFileOpen       = "guard_file_open"
+	processGuardProgGuardSocketConnect  = "guard_socket_connect"
+)
+
 // loadProcessGuard returns the embedded CollectionSpec for processGuard.
 func loadProcessGuard() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_ProcessGuardBytes)
@@ -85,7 +105,7 @@ func loadProcessGuard() (*ebpf.CollectionSpec, error) {
 //	*processGuardMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadProcessGuardObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadProcessGuardObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadProcessGuard()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- update cilium/ebpf from v0.21.0 to v0.22.0 with Dependabot #133's exact version and sumdb values
- commit the deterministic bpf2go 0.22 binding drift that #133's protected generator check exposed
- document delegated BPF tokens as an alternate direct-loader authority path while preserving Ardur's capability-gated installer

## Upstream review

- v0.22.0 resolves to `e55144e17360b60cc4583229c35c2dbf0935b308`; the tag commit is unsigned but DCO-signed
- sum.golang.org confirms `h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=`
- adds Linux 7.1 extended BTF-header compatibility and malformed ELF/BTF hardening
- removes the global vmlinux BTF cache and makes caching opt-in
- automatically consumes explicitly delegated BPF tokens when a host runtime provides one

Ardur loads two collections only once on a fresh daemon start, so retaining roughly 20 MiB to save one additional BTF parse is not justified. The supported installer still requires effective `CAP_BPF` and `CAP_SYS_ADMIN`.

## Generated artifacts

- bpf2go adds map/program name constants and emits `any` in the two generated Go bindings
- process-guard ELF blob remains `476224bddc55ab824f4e1bd7b597e5f15e2dced3`
- process-exec ELF blob remains `6b6a57fe313d3438ace2be74a3d64e8ccba70376`

## Validation

- module verification and `go mod tidy -diff`
- full native Go tests, vet, build, and race
- Linux amd64/arm64 builds of daemon, sensor, guard smoke, seccomp smoke, and exec shim
- Linux amd64/arm64 kernelcapture test compilation
- repository quick checks
- govulncheck: zero reachable/imported-package findings; baseline-only module advisory remains unreachable

The protected Linux `bpf-generate` and kernel-smoke jobs are the final source/ELF reproducibility and runtime gates.

Supersedes #133 after this PR is merged and proven on `dev`.

Refs #80