### PR TITLE
demo: add 60-second Claude Code deny proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,12 @@ copy-paste authenticated lifecycle.
 
 Start with the source-checkout walkthrough in
 [`docs/guides/claude-code-mvp-quickstart.md`](docs/guides/claude-code-mvp-quickstart.md).
-It gives two bounded paths:
+It gives three bounded paths:
 
+- a **60-second deliberate deny proof** using
+  `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
+  adapter, verifies a signed violation receipt, checks an unchanged canary, and
+  removes all temporary state without contacting an LLM provider;
 - a **no-key confidence check** that runs the fresh-user evidence harness,
   simulated Claude Code hook allow/deny receipts, and redacted bundle checks
   without contacting an LLM provider; and

--- a/docs/guides/claude-code-mvp-quickstart.md
+++ b/docs/guides/claude-code-mvp-quickstart.md
@@ -52,6 +52,23 @@ bearer auth for its child process, verifies the attestation signature locally,
 then removes its keys and state. See the
 [no-key MVP guide](no-key-mvp-demo.md) for the complete boundary.
 
+For the shortest Claude Code-specific proof, run the deliberate deny demo:
+
+```bash
+python3 scripts/run-claude-deny-demo.py
+```
+
+It creates a temporary read-only profile and Mission Passport, submits a
+provider-free `PreToolUse` Bash request whose command would delete a canary and
+write an exfiltration marker, and requires Ardur to return a human-readable
+Claude Code deny before the harness can dispatch anything. It then verifies the
+canary digest, absent marker, and signed/hash-linked violation receipt before
+removing all temporary material. The run is capped at 60 seconds.
+
+The unchanged canary and absent marker are post-deny file-state checks. They do
+not prove independent process, kernel, network, or provider observation. Use
+the later evidence-correlation work for those stronger claims.
+
 ## 3. Run the no-key evidence harness
 
 This does not call a live LLM provider. It uses temporary HOME, project, Ardur

--- a/docs/guides/phase1-demo-packet.md
+++ b/docs/guides/phase1-demo-packet.md
@@ -29,6 +29,8 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e python/
 
+python3 scripts/run-claude-deny-demo.py
+
 python3 scripts/run-rwt-phase1-fresh-user.py \
   --expected-origin-dev "$(git rev-parse --short=12 origin/dev)" \
   --output-dir /tmp/ardur-rwt-phase1
@@ -43,6 +45,12 @@ stale or mismatched pins still block the proof path.
 The bundle is the primary shareable proof artifact for a no-key run. Read it
 with [Read The Phase 1 Evidence Bundle](read-phase1-evidence-bundle.md) before
 copying any claim into a demo note, launch draft, or issue response.
+
+The short deny demo is the live talk-track opener: it deliberately presents a
+destructive Bash request to the real local hook adapter, requires the deny
+before host dispatch, verifies that its canary is unchanged, and validates the
+signed violation receipt. Its file-state checks are not independent process or
+kernel evidence; the broader RWT bundle remains the shareable evidence ledger.
 
 Required no-key signals:
 
@@ -98,7 +106,7 @@ that reveal more about the host than the demo needs.
 |---|---|---|
 | Source-checkout install and Python package import. | PyPI/Homebrew/OCI release readiness. | Tagged package-manager release after packaging gates. |
 | `ARDUR.md` creation and Claude Code protection setup. | Account login, provider setup, or hosted service deployment. | Friendlier installer and proof viewers. |
-| Simulated Claude Code hook allow/deny receipts with chain verification. | Provider-hidden reasoning or server-side tool calls. | More host adapters with the same evidence boundary. |
+| Deliberate Claude Code hook denial before host dispatch, with signed receipt and post-deny canary check. | Independent process/kernel evidence or proof of provider-hidden behavior. | Filesystem snapshot and Linux eBPF correlation phases. |
 | Redacted no-key `bundle.redacted.json` with explicit claim mapping. | Subprocess, kernel, filesystem, or network capture below the tool boundary. | Filesystem snapshot and Linux eBPF capture phases. |
 | Optional live-Claude report when the local binary is already authenticated. | Universal CLI support across Codex, Gemini, Kimi, or future tools. | Tool-agnostic CLI/kernel capture work. |
 

--- a/python/tests/test_claude_deny_demo.py
+++ b/python/tests/test_claude_deny_demo.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_SCRIPT = REPO_ROOT / "scripts" / "run-claude-deny-demo.py"
+
+
+def _load_demo_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ardur_claude_deny_demo", DEMO_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_deny_output_requires_explicit_deny_and_reason() -> None:
+    demo = _load_demo_module()
+
+    reason = demo.validate_deny_output(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "ardur: blocked - forbidden tool: Bash",
+            }
+        }
+    )
+
+    assert reason == "ardur: blocked - forbidden tool: Bash"
+    for malformed in (
+        {},
+        {"hookSpecificOutput": "invalid"},
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "permissionDecision": "deny",
+            }
+        },
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+            }
+        },
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+            }
+        },
+    ):
+        with pytest.raises(
+            demo.DemoError, match="command not dispatched|human-readable"
+        ):
+            demo.validate_deny_output(malformed)
+
+
+def test_filesystem_evidence_fails_on_canary_drift_or_marker(tmp_path: Path) -> None:
+    demo = _load_demo_module()
+    canary = tmp_path / "canary.txt"
+    marker = tmp_path / "marker.txt"
+    canary.write_text("original\n", encoding="utf-8")
+    expected = demo._sha256(canary)
+
+    assert demo.verify_filesystem_evidence(
+        canary=canary, expected_sha256=expected, marker=marker
+    ) == (True, True)
+
+    canary.write_text("changed\n", encoding="utf-8")
+    with pytest.raises(demo.DemoError, match="canary changed"):
+        demo.verify_filesystem_evidence(
+            canary=canary, expected_sha256=expected, marker=marker
+        )
+
+    canary.write_text("original\n", encoding="utf-8")
+    marker.write_text("unexpected\n", encoding="utf-8")
+    with pytest.raises(demo.DemoError, match="marker exists"):
+        demo.verify_filesystem_evidence(
+            canary=canary, expected_sha256=expected, marker=marker
+        )
+
+
+def test_receipt_report_rejects_malformed_counts() -> None:
+    demo = _load_demo_module()
+    malformed_report = {
+        "ok": True,
+        "chain_verification": {"ok": True},
+        "chain_count": 1,
+        "receipt_count": "one",
+        "totals": {
+            "tools": {"Bash": 1},
+            "verdicts": {"violation": 1},
+            "violation_count": 1,
+        },
+    }
+
+    with pytest.raises(demo.DemoError, match="invalid receipt count"):
+        demo.validate_receipt_report(malformed_report)
+
+    unrelated_aggregate = {
+        "ok": True,
+        "chain_verification": {"ok": True},
+        "chain_count": 2,
+        "receipt_count": 2,
+        "totals": {
+            "tools": {"Bash": 1, "Read": 1},
+            "verdicts": {"allow": 1, "violation": 1},
+            "violation_count": 1,
+        },
+    }
+    with pytest.raises(demo.DemoError, match="exactly one receipt chain"):
+        demo.validate_receipt_report(unrelated_aggregate)
+
+
+def test_non_deny_output_fails_closed_and_cleans_temporary_state(
+    tmp_path: Path,
+) -> None:
+    demo = _load_demo_module()
+    labels: list[str] = []
+
+    def fake_runner(
+        command: list[str],
+        *,
+        label: str,
+        cwd: Path,
+        env: dict[str, str],
+        deadline: float,
+        stdin_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del command, cwd, env, deadline, stdin_payload
+        labels.append(label)
+        if label in {"profile setup", "Claude Code protection"}:
+            return {"ok": True}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "unexpected permit",
+            }
+        }
+
+    with pytest.raises(demo.DemoError, match="did not return an explicit deny"):
+        demo.run_demo(
+            repo_root=REPO_ROOT,
+            timeout_s=10,
+            temp_parent=tmp_path,
+            command_runner=fake_runner,
+        )
+
+    assert labels == ["profile setup", "Claude Code protection", "PreToolUse denial"]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_real_demo_verifies_deny_receipt_filesystem_and_cleanup(tmp_path: Path) -> None:
+    started = time.monotonic()
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEMO_SCRIPT),
+            "--timeout-s",
+            "60",
+            "--temp-parent",
+            str(tmp_path),
+        ],
+        cwd=REPO_ROOT,
+        env=os.environ,
+        capture_output=True,
+        text=True,
+        timeout=65,
+        check=False,
+    )
+    elapsed_s = time.monotonic() - started
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert elapsed_s < 60
+    assert "PASS  Ardur returned DENY before host command dispatch" in result.stdout
+    assert "PASS  canary digest is unchanged" in result.stdout
+    assert "PASS  exfiltration marker is absent" in result.stdout
+    assert "PASS  signed/hash-linked receipt chain verified" in result.stdout
+    assert (
+        "it is not independent process, kernel, network, or provider evidence"
+        in result.stdout
+    )
+    assert (
+        "Temporary keys, state, fixtures, and receipts were removed." in result.stdout
+    )
+    assert list(tmp_path.iterdir()) == []

--- a/scripts/run-claude-deny-demo.py
+++ b/scripts/run-claude-deny-demo.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Run a provider-free Claude Code deny-before-execution proof."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+MAX_DEMO_SECONDS = 60.0
+TRACE_ID = "claude-deny-demo"
+
+
+class DemoError(RuntimeError):
+    """A concise, fail-closed error safe to show to a first-time tester."""
+
+
+@dataclass(frozen=True)
+class DemoResult:
+    elapsed_s: float
+    denial_reason: str
+    receipt_count: int
+    violation_count: int
+    canary_unchanged: bool
+    marker_absent: bool
+    temporary_state_removed: bool
+
+
+JsonCommandRunner = Callable[..., dict[str, Any]]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Ardur's provider-free Claude Code PreToolUse deny proof. "
+            "The demo never invokes the destructive command embedded in its fixture."
+        )
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=MAX_DEMO_SECONDS,
+        help=f"overall deadline in seconds (default and maximum: {MAX_DEMO_SECONDS:g})",
+    )
+    parser.add_argument(
+        "--temp-parent",
+        type=Path,
+        help="existing directory that receives the temporary demo workspace",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if not 0 < args.timeout_s <= MAX_DEMO_SECONDS:
+        parser.error(
+            f"--timeout-s must be greater than zero and at most {MAX_DEMO_SECONDS:g}"
+        )
+    if args.temp_parent is not None and not args.temp_parent.expanduser().is_dir():
+        parser.error("--temp-parent must be an existing directory")
+    return args
+
+
+def _remaining_seconds(deadline: float, label: str) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise DemoError(f"the demo deadline expired before {label}")
+    return remaining
+
+
+def _run_json_command(
+    command: Sequence[str],
+    *,
+    label: str,
+    cwd: Path,
+    env: dict[str, str],
+    deadline: float,
+    stdin_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            list(command),
+            cwd=cwd,
+            env=env,
+            input=json.dumps(stdin_payload) if stdin_payload is not None else None,
+            capture_output=True,
+            text=True,
+            timeout=_remaining_seconds(deadline, label),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DemoError(f"{label} exceeded the demo deadline") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        raise DemoError(f"{label} failed with exit {result.returncode}{suffix}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise DemoError(f"{label} returned malformed JSON") from exc
+    if not isinstance(payload, dict):
+        raise DemoError(f"{label} returned a non-object JSON response")
+    return payload
+
+
+def _require_ok(payload: dict[str, Any], label: str) -> None:
+    if payload.get("ok") is True:
+        return
+    condition = payload.get("condition") or payload.get("error") or "unknown failure"
+    raise DemoError(f"{label} did not complete: {condition}")
+
+
+def validate_deny_output(payload: dict[str, Any]) -> str:
+    hook_output = payload.get("hookSpecificOutput")
+    if not isinstance(hook_output, dict):
+        raise DemoError(
+            "PreToolUse output omitted hookSpecificOutput; command not dispatched"
+        )
+    if hook_output.get("hookEventName") != "PreToolUse":
+        raise DemoError(
+            "PreToolUse output used the wrong hook event; command not dispatched"
+        )
+    if hook_output.get("permissionDecision") != "deny":
+        raise DemoError("Ardur did not return an explicit deny; command not dispatched")
+    reason = hook_output.get("permissionDecisionReason")
+    if not isinstance(reason, str) or not reason.strip().lower().startswith(
+        "ardur: blocked"
+    ):
+        raise DemoError(
+            "Ardur deny omitted a human-readable reason; command not dispatched"
+        )
+    return reason.strip()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_filesystem_evidence(
+    *, canary: Path, expected_sha256: str, marker: Path
+) -> tuple[bool, bool]:
+    canary_unchanged = canary.is_file() and _sha256(canary) == expected_sha256
+    marker_absent = not marker.exists()
+    if not canary_unchanged:
+        raise DemoError("the filesystem canary changed despite the deny")
+    if not marker_absent:
+        raise DemoError("the exfiltration marker exists despite the deny")
+    return canary_unchanged, marker_absent
+
+
+def _report_count(mapping: dict[str, Any], key: str, label: str) -> int:
+    value = mapping.get(key, 0)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DemoError(f"claude-code-report returned an invalid {label} count")
+    return value
+
+
+def validate_receipt_report(payload: dict[str, Any]) -> tuple[int, int]:
+    if payload.get("ok") is not True:
+        raise DemoError("claude-code-report did not complete")
+    verification = payload.get("chain_verification")
+    if not isinstance(verification, dict) or verification.get("ok") is not True:
+        raise DemoError("the Claude Code receipt chain did not verify")
+    chain_count = _report_count(payload, "chain_count", "chain")
+    if chain_count != 1:
+        raise DemoError("the verified report did not contain exactly one receipt chain")
+    totals = payload.get("totals")
+    if not isinstance(totals, dict):
+        raise DemoError("claude-code-report omitted totals")
+    tools = totals.get("tools")
+    verdicts = totals.get("verdicts")
+    if not isinstance(tools, dict) or _report_count(tools, "Bash", "Bash") != 1:
+        raise DemoError(
+            "the verified receipt chain did not contain exactly one Bash request"
+        )
+    if (
+        not isinstance(verdicts, dict)
+        or _report_count(verdicts, "violation", "violation verdict") != 1
+    ):
+        raise DemoError(
+            "the verified receipt chain did not contain exactly one violation verdict"
+        )
+    receipt_count = _report_count(payload, "receipt_count", "receipt")
+    violation_count = _report_count(totals, "violation_count", "violation")
+    if receipt_count != 1 or violation_count != 1:
+        raise DemoError(
+            "the verified report did not count exactly one violation receipt"
+        )
+    return receipt_count, violation_count
+
+
+def _hook_fixture(*, project: Path, canary: Path, marker: Path) -> dict[str, Any]:
+    command = (
+        f"rm -f -- {shlex.quote(str(canary))}; "
+        f"printf 'exfiltrated\\n' > {shlex.quote(str(marker))}"
+    )
+    return {
+        "session_id": "claude-deny-demo-session",
+        "transcript_path": str(project / "transcript.jsonl"),
+        "cwd": str(project),
+        "permission_mode": "default",
+        "hook_event_name": "PreToolUse",
+        "tool_use_id": "claude-deny-demo-bash-1",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+def run_demo(
+    *,
+    repo_root: Path,
+    timeout_s: float = MAX_DEMO_SECONDS,
+    temp_parent: Path | None = None,
+    command_runner: JsonCommandRunner = _run_json_command,
+) -> DemoResult:
+    if not 0 < timeout_s <= MAX_DEMO_SECONDS:
+        raise DemoError(
+            f"timeout must be greater than zero and at most {MAX_DEMO_SECONDS:g} seconds"
+        )
+    if temp_parent is not None and not temp_parent.is_dir():
+        raise DemoError("temporary parent must be an existing directory")
+
+    started = time.monotonic()
+    deadline = started + timeout_s
+    cli = [sys.executable, "-m", "vibap.cli"]
+    plugin_dir = (repo_root / "plugins" / "claude-code").resolve()
+    temp_root: Path | None = None
+    denial_reason = ""
+    receipt_count = 0
+    violation_count = 0
+    canary_unchanged = False
+    marker_absent = False
+
+    with tempfile.TemporaryDirectory(
+        prefix="ardur-claude-deny-",
+        dir=str(temp_parent) if temp_parent is not None else None,
+    ) as temp_root_text:
+        temp_root = Path(temp_root_text)
+        project = temp_root / "project"
+        home = temp_root / "ardur-home"
+        keys_dir = home / "keys"
+        profile = project / "ARDUR.md"
+        canary = project / "do-not-delete.txt"
+        marker = project / "exfiltration-marker.txt"
+        project.mkdir()
+        canary.write_text("Ardur deny-before-execution canary\n", encoding="utf-8")
+        canary_sha256 = _sha256(canary)
+
+        env = os.environ.copy()
+        env["VIBAP_HOME"] = str(home)
+        env["ARDUR_TRACE_ID"] = TRACE_ID
+
+        profile_result = command_runner(
+            [
+                *cli,
+                "profile",
+                "init",
+                "--template",
+                "read-only",
+                "--path",
+                str(profile),
+                "--json",
+            ],
+            label="profile setup",
+            cwd=project,
+            env=env,
+            deadline=deadline,
+        )
+        _require_ok(profile_result, "profile setup")
+        print("PASS  created a temporary read-only Claude Code profile")
+
+        protect_result = command_runner(
+            [
+                *cli,
+                "protect",
+                "claude-code",
+                "--profile",
+                str(profile),
+                "--home",
+                str(home),
+                "--keys-dir",
+                str(keys_dir),
+                "--plugin-dir",
+                str(plugin_dir),
+                "--agent-id",
+                "demo:claude-code",
+                "--mission",
+                "Prove that destructive shell requests are denied before dispatch.",
+                "--max-tool-calls",
+                "5",
+                "--max-duration-s",
+                "300",
+                "--json",
+            ],
+            label="Claude Code protection",
+            cwd=project,
+            env=env,
+            deadline=deadline,
+        )
+        _require_ok(protect_result, "Claude Code protection")
+        print("PASS  issued an active, temporary Mission Passport")
+
+        hook_result = command_runner(
+            [*cli, "claude-code-hook", "pre", "--keys-dir", str(keys_dir)],
+            label="PreToolUse denial",
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            stdin_payload=_hook_fixture(project=project, canary=canary, marker=marker),
+        )
+        denial_reason = validate_deny_output(hook_result)
+        print("PASS  Ardur returned DENY before host command dispatch")
+        print(f"reason: {denial_reason}")
+
+        canary_unchanged, marker_absent = verify_filesystem_evidence(
+            canary=canary,
+            expected_sha256=canary_sha256,
+            marker=marker,
+        )
+        print("PASS  canary digest is unchanged")
+        print("PASS  exfiltration marker is absent")
+
+        report = command_runner(
+            [
+                *cli,
+                "claude-code-report",
+                "--home",
+                str(home),
+                "--keys-dir",
+                str(keys_dir),
+                "--json",
+            ],
+            label="signed receipt report",
+            cwd=project,
+            env=env,
+            deadline=deadline,
+        )
+        receipt_count, violation_count = validate_receipt_report(report)
+        print(
+            "PASS  signed/hash-linked receipt chain verified "
+            f"({receipt_count} receipt, {violation_count} violation)"
+        )
+
+    elapsed_s = time.monotonic() - started
+    temporary_state_removed = temp_root is not None and not temp_root.exists()
+    if not temporary_state_removed:
+        raise DemoError("temporary demo state was not removed")
+    if elapsed_s >= timeout_s:
+        raise DemoError(f"the demo exceeded its {timeout_s:g}-second contract")
+    return DemoResult(
+        elapsed_s=elapsed_s,
+        denial_reason=denial_reason,
+        receipt_count=receipt_count,
+        violation_count=violation_count,
+        canary_unchanged=canary_unchanged,
+        marker_absent=marker_absent,
+        temporary_state_removed=temporary_state_removed,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    print("=== Ardur Claude Code deny-before-execution proof ===")
+    print(
+        "Provider-free. Temporary project, keys, profile, fixtures, and receipts only."
+    )
+    try:
+        result = run_demo(
+            repo_root=repo_root,
+            timeout_s=args.timeout_s,
+            temp_parent=args.temp_parent.expanduser().resolve()
+            if args.temp_parent
+            else None,
+        )
+    except DemoError as exc:
+        print(f"FAIL  {exc}")
+        return 1
+    print(
+        "BOUNDARY  This proves the local tool-boundary deny and post-deny file state; "
+        "it is not independent process, kernel, network, or provider evidence."
+    )
+    print(
+        f"Completed in {result.elapsed_s:.1f}s. "
+        "Temporary keys, state, fixtures, and receipts were removed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -2,7 +2,7 @@
 title: "Ardur"
 description: "Ardur is the runtime governance and evidence layer for AI agents."
 source_path: "README.md"
-source_sha256: "1525e6840104e87cda13766777f9b80fa6f6f09ce29102a2eb366b9d0e88a3a4"
+source_sha256: "7b5eab7f5b548a09c9fddb7cf1567e5ca313b7ae059852770e52120d0d5adfe5"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -181,8 +181,12 @@ copy-paste authenticated lifecycle.
 
 Start with the source-checkout walkthrough in
 [`docs/guides/claude-code-mvp-quickstart.md`](/__ardur_internal__/source/docs/guides/claude-code-mvp-quickstart/).
-It gives two bounded paths:
+It gives three bounded paths:
 
+- a **60-second deliberate deny proof** using
+  `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
+  adapter, verifies a signed violation receipt, checks an unchanged canary, and
+  removes all temporary state without contacting an LLM provider;
 - a **no-key confidence check** that runs the fresh-user evidence harness,
   simulated Claude Code hook allow/deny receipts, and redacted bundle checks
   without contacting an LLM provider; and

--- a/site/content/source/docs/guides/claude-code-mvp-quickstart.md
+++ b/site/content/source/docs/guides/claude-code-mvp-quickstart.md
@@ -2,7 +2,7 @@
 title: "Claude Code MVP Quickstart"
 description: "This is the shortest product-facing path through Ardur today from a source"
 source_path: "docs/guides/claude-code-mvp-quickstart.md"
-source_sha256: "cea6ecdf699535d889a867e74593b3be4ede519d502feebf326f370a33faf343"
+source_sha256: "6211155ab12051ee10e8fa48b75a4cfba5ce4fc85e5bdd354b8b1b1281181e9b"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -68,6 +68,23 @@ The driver is loopback-only and temporary: it deliberately disables TLS and
 bearer auth for its child process, verifies the attestation signature locally,
 then removes its keys and state. See the
 [no-key MVP guide](/__ardur_internal__/source/docs/guides/no-key-mvp-demo/) for the complete boundary.
+
+For the shortest Claude Code-specific proof, run the deliberate deny demo:
+
+```bash
+python3 scripts/run-claude-deny-demo.py
+```
+
+It creates a temporary read-only profile and Mission Passport, submits a
+provider-free `PreToolUse` Bash request whose command would delete a canary and
+write an exfiltration marker, and requires Ardur to return a human-readable
+Claude Code deny before the harness can dispatch anything. It then verifies the
+canary digest, absent marker, and signed/hash-linked violation receipt before
+removing all temporary material. The run is capped at 60 seconds.
+
+The unchanged canary and absent marker are post-deny file-state checks. They do
+not prove independent process, kernel, network, or provider observation. Use
+the later evidence-correlation work for those stronger claims.
 
 ## 3. Run the no-key evidence harness
 

--- a/site/content/source/docs/guides/phase1-demo-packet.md
+++ b/site/content/source/docs/guides/phase1-demo-packet.md
@@ -2,7 +2,7 @@
 title: "Phase 1 Demo Packet"
 description: "Use this packet after the [Claude Code MVP quickstart](claude-code-mvp-quickstart.md)"
 source_path: "docs/guides/phase1-demo-packet.md"
-source_sha256: "a2f3be9cd8cb9554c9645950c26ece23971a1abc5bc34a1fec382f25a3a87347"
+source_sha256: "76575f9f2187a71eba1330617a697b9c57b0ba39cffc35b1ae59d82a6e46202c"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -46,6 +46,8 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e python/
 
+python3 scripts/run-claude-deny-demo.py
+
 python3 scripts/run-rwt-phase1-fresh-user.py \
   --expected-origin-dev "$(git rev-parse --short=12 origin/dev)" \
   --output-dir /tmp/ardur-rwt-phase1
@@ -60,6 +62,12 @@ stale or mismatched pins still block the proof path.
 The bundle is the primary shareable proof artifact for a no-key run. Read it
 with [Read The Phase 1 Evidence Bundle](/__ardur_internal__/source/docs/guides/read-phase1-evidence-bundle/) before
 copying any claim into a demo note, launch draft, or issue response.
+
+The short deny demo is the live talk-track opener: it deliberately presents a
+destructive Bash request to the real local hook adapter, requires the deny
+before host dispatch, verifies that its canary is unchanged, and validates the
+signed violation receipt. Its file-state checks are not independent process or
+kernel evidence; the broader RWT bundle remains the shareable evidence ledger.
 
 Required no-key signals:
 
@@ -115,7 +123,7 @@ that reveal more about the host than the demo needs.
 |---|---|---|
 | Source-checkout install and Python package import. | PyPI/Homebrew/OCI release readiness. | Tagged package-manager release after packaging gates. |
 | `ARDUR.md` creation and Claude Code protection setup. | Account login, provider setup, or hosted service deployment. | Friendlier installer and proof viewers. |
-| Simulated Claude Code hook allow/deny receipts with chain verification. | Provider-hidden reasoning or server-side tool calls. | More host adapters with the same evidence boundary. |
+| Deliberate Claude Code hook denial before host dispatch, with signed receipt and post-deny canary check. | Independent process/kernel evidence or proof of provider-hidden behavior. | Filesystem snapshot and Linux eBPF correlation phases. |
 | Redacted no-key `bundle.redacted.json` with explicit claim mapping. | Subprocess, kernel, filesystem, or network capture below the tool boundary. | Filesystem snapshot and Linux eBPF capture phases. |
 | Optional live-Claude report when the local binary is already authenticated. | Universal CLI support across Codex, Gemini, Kimi, or future tools. | Tool-agnostic CLI/kernel capture work. |
 


### PR DESCRIPTION
## Summary

- add a provider-free, 60-second Claude Code deny-before-execution proof using the shipped profile, protect, hook, and report commands
- require exactly one signed/hash-linked Bash violation receipt and fail closed on malformed or non-deny output
- verify unchanged post-deny file state, remove all temporary material, and document the evidence boundary in source-backed docs

## Evidence

- real proof completes in 0.8s with explicit `ardur: blocked` denial, unchanged canary, absent marker, one verified receipt, and complete cleanup
- focused demo tests: 5 passed
- full Python matrix with exact CI coverage flags: 1,358 passed, 32 skipped, 85% total coverage
- full Go tests, vet, build, quick checks, public-claim validation, Hugo source sync/build/link/provenance checks passed locally
- generated-source check: 87 Hugo pages and 46 mirrored artifacts verified

## Claim boundary

This proves the local Claude Code tool-boundary deny and post-deny file state. It does not claim independent process, kernel, network, provider, or hidden-reasoning observation.

Closes #210