### PR TITLE
docs: scope public governance claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Ardur
 
-Ardur is the runtime governance and evidence layer for AI agents.
+Ardur governs AI-agent tool calls that pass through a configured adapter or
+proxy. It checks mission, resource, budget, and delegation constraints before
+that integration dispatches the call, then emits an issuer-signed,
+hash-linked receipt for the decision.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/status-pre--release-blue)](STATUS.md)
@@ -11,115 +14,38 @@ public specs, the Python governance runtime, Go packages for eBPF kernel
 capture and Kubernetes control-plane components, mission examples, runnable
 framework adapters (LangChain, LangGraph, AutoGen), the Ardur Personal Hub
 service, the Claude Code plugin and hook, and the public Hugo evidence site.
-Re-runnable proof media, full packaging, and production deployment material
-are still being tightened before they are presented as release-ready.
+The current public proof is strongest at those configured tool boundaries. It
+does not establish universal agent capture, third-party witnessing,
+provider-hidden behavior, or cross-platform kernel enforcement. Re-runnable
+proof media, full packaging, and production deployment material are still
+being tightened before they are presented as release-ready.
 
 [Research](RESEARCH.md) · [Status](STATUS.md) · [Coverage Map](docs/coverage-map.md) · [Roadmap](ROADMAP.md) · [Media](MEDIA.md) · [Articles](docs/articles/README.md) · [Docs](docs/README.md) · [Reference](docs/reference/README.md) · [Phase 1 Demo Packet](docs/guides/phase1-demo-packet.md) · [Read the Phase 1 Evidence Bundle](docs/guides/read-phase1-evidence-bundle.md) · [Evidence Site Source](site/README.md)
 
-## Test Results
+## Verification Snapshot
 
-Tests here are designed to prove three things:
+At the reviewed `dev` tree on 2026-07-09, the current gates were:
 
-1. **Correctness** — the governance proxy enforces the spec faithfully: visibility, envelope integrity, manifest digest, delegation narrowing, hidden-hop detection, per-class budgets, rate limiting, and kill-switch semantics.
-2. **Resilience** — adversarial models cannot bypass policy boundaries through prompt injection, jailbreaking, social engineering, path traversal, multi-turn steering, or chained-tool attacks.
-3. **Real-model integration** — live models routed through the proxy can build substantial software (multi-file applications with tests and documentation) while every tool call flows through governance first.
+| Gate | Verified result |
+|---|---|
+| Python local matrix with the CI coverage flags (Python 3.12) | 1,358 passed, 32 skipped, 85% coverage |
+| Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
+| Go CI | Tests, vet, lint, and vulnerability scan passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E passed |
+| Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
-### Unit & Integration Suite
+These gates verify the checked-in runtime and its configured integration
+paths: policy evaluation, fail-closed error handling, signed/hash-linked
+receipts, delegation, package contracts, and the explicitly gated Linux
+enforcement harnesses. They do **not** prove that Ardur observes calls that
+bypass an adapter, provider-hidden actions, every effect below a tool call, or
+production readiness on every platform.
 
-| Suite | Passed | Skipped | Failed |
-|-------|--------|---------|--------|
-| Core governance (proxy, passport, mission, receipts) | 581 | 21 | 0 |
-
-Covers the Delegation-Core, MIC-State, and MIC-Evidence conformance profiles — all 4 verifier-contract gaps closed as of the hardening round ending 2026-05-14. Includes visibility checks (§6.4), envelope signature verification (§9.5), manifest digest comparison (§9.6), hidden-hop detection (§9.1), and `last_seen_receipts` tracking (§5.7).
-
-### Comprehensive Protocol Composition
-
-Single end-to-end test exercising all protocol layers over real TLS with SPIFFE identity, Biscuit attenuation, JWT delegation, and policy backends.
-
-| Scenario | Duration | What it proves |
-|----------|----------|---------------|
-| Health & baseline | 0.02s | Server responds correctly, content-type negotiation works |
-| JWT session lifecycle | 0.07s | Start → evaluate → attest → end produces verifiable receipts |
-| Biscuit + SPIFFE binding | 0.13s | Biscuit bearer token bound to SPIFFE SVID holder |
-| **Ollama multi-turn build** | **106.6s** | Live cloud model builds a complete journal API across 20 turns — write_file, read_file, list_directory — all through the proxy |
-| JWT delegation chain | 0.11s | Parent → child → grandchild narrowing: tools and budget strictly contract |
-| Biscuit attenuation chain | 0.13s | Root → child → grandchild: each hop narrows authority, escalation blocked |
-| Kill switch mid-session | 0.08s | Activate blocks /evaluate (503), deactivate restores, health stays available |
-| Rate limit flooding | 0.31s | Burst beyond 50 requests triggers 429 with Retry-After header |
-| Metrics verification | 0.03s | Prometheus text format, all 6 required metric families present |
-| Receipt chain integrity | 0.01s | Multi-trace receipts form independently verifiable hash-linked chains |
-| ForbidRules composition | 0.05s | Regex-based forbid-rules backend denies while native permits |
-| Three-backend composition | 0.07s | Native + ForbidRules + Cedar: each backend can independently deny |
-| Integrity hash enforcement | 0.03s | policy_sha256 mismatch → DENY (fail-closed) |
-
-**13/13 passed. Total: 118.3s.**
-
-### Ollama Integration
-
-| Suite | Passed | Failed |
-|-------|--------|--------|
-| Connectivity (model listing, chat, tool calling) | 3 | 0 |
-| Governance integration (proxy routing, denial, multi-turn, delegation) | 8 | 0 |
-| Security headers | 2 | 0 |
-| Concurrency | 1 | 0 |
-| Model capabilities (denial understanding, self-description, constraint respect) | 3 | 0 |
-
-**17/17 passed. Total: 26.1s.**
-
-### Phase 1 — Adversarial Boundary Testing
-
-10 hostile scenarios across 5 cloud models spanning multiple providers. Every scenario is designed to trigger a DENY — models attempt direct forbidden-tool use, mid-execution prompt injection, DAN-style jailbreaking, social engineering, resource-scope violations, path traversal, budget exhaustion, obfuscated command injection, multi-turn gradual steering toward forbidden actions, and chained tool attacks (write script → execute). The public redaction keeps the aggregate result here and omits raw per-model fixture artifacts from the repository.
-
-| Metric | Value |
-|--------|-------|
-| Tool calls evaluated | 143 |
-| PERMIT | 63 |
-| DENY | 106 |
-| **BYPASS** | **0** |
-
-**Zero bypasses.** Proxy boundaries held across all 5 models, all 10 attack vectors. The proxy denied 106 violation attempts. Models that refused before calling tools (ethical refusal) were counted as passes — the scenario's goal is exercising the proxy's enforcement boundary, and a model-level refusal means the attack didn't reach the runtime.
-
-### Phase 2 — Advanced Enforcement Checks
-
-22 programmatic checks verifying specific enforcement points — no model in the loop. Direct API calls against the proxy exercising edge cases:
-
-| Category | Checks | Highlights |
-|----------|--------|-----------|
-| Approval policy | 2 | operator_id required, fatigue threshold exceeded |
-| Delegation | 1 | child tool escalation beyond parent scope rejected |
-| Memory governance | 2 | FIX-8: private key material rejected on memory write/read |
-| Token replay | 1 | JTI replay on session start rejected |
-| Kill switch | 2 | /evaluate and /session/start both return 503 |
-| Per-class budget | 2 | internal_write budget exhaustion, side_effect_class not in allowlist |
-| CWD confinement | 2 | absolute path escape and path traversal escape from CWD both blocked |
-| Policy backends | 1 | ForbidRules backend blocks targeted tool |
-| Tool scope | 1 | forbidden tool directly denied |
-| Resource scope | 1 | write outside resource_scope denied |
-| Budget | 1 | main budget exhausted after max_tool_calls |
-| Session lifecycle | 2 | ended session rejects, multiple sessions coexist |
-| Token validation | 2 | invalid JWT rejected, nonexistent session_id rejected |
-| Input sanitization | 1 | null-byte and unicode dot-confusable traversal paths rejected (U+2024/U+FE52/U+FF0E folded to ASCII '.', and U+2025/U+FE30 caught via NFKC-form backstop, so a tool that NFKC-normalizes before opening cannot escape scope) |
-| Infrastructure | 1 | health endpoint returns ok |
-
-**22/22 passed. Total: <1s.**
-
-### Go AAT — Credential Attenuation Engine
-
-The Go `pkg/aat` package implements 13 constraint types, token serialization, delegation-chain verification, and constraint subsumption. All tests pass with zero failures.
-
-### Aggregate
-
-| Suite | Count | Status |
-|-------|-------|--------|
-| Python unit + integration | 581 + 21 skipped | All passing |
-| Comprehensive protocol composition | 13 scenarios | All passing |
-| Ollama integration | 17 | All passing |
-| Phase 1 adversarial (5 models) | 10 scenarios × 5 models | 0 bypasses |
-| Phase 2 advanced enforcement | 22 checks | All passing |
-| Go AAT | full suite | All passing |
-| MIC conformance (new) | 29 | All passing |
-
-[Python test suite →](python/tests/) · Aggregate report: `python/tests/comprehensive_test_report.json` · [Proof & evidence site →](site/)
+The numeric Python result is a dated snapshot, not a permanent badge; the
+workflow files under [`.github/workflows/`](.github/workflows/) are the current
+source of truth. Historical model/adversarial aggregates remain at
+`python/tests/comprehensive_test_report.json`, but they are not presented here
+as evidence for the current tree.
 
 ## First-Run Paths
 
@@ -186,8 +112,9 @@ After a run, use the
 handoff: tested commit, `bundle.redacted.json`, optional live-Claude report, and
 the exact claims the artifacts do and do not support.
 
-> **Capture boundary today (v0.1):** Ardur signs every Claude Code tool-call
-> invocation. Side effects below the tool boundary — subprocess trees,
+> **Capture boundary today (v0.1):** Ardur signs the Claude Code tool-call
+> events delivered to its installed hooks. Side effects below the tool
+> boundary — subprocess trees,
 > kernel events, network connections initiated by tool-spawned processes —
 > are not yet captured; the roadmap closes that gap in v0.2 (filesystem
 > snapshots), v0.5 (Linux eBPF), and v1.0 (macOS Endpoint Security
@@ -196,9 +123,10 @@ the exact claims the artifacts do and do not support.
 
 ## Why Ardur
 
-Many agent stacks can log what happened. Fewer can stop an out-of-scope action
-before it executes. Fewer still can prove later, with verifier-backed evidence,
-what the runtime allowed, denied, or left unknown.
+Many agent stacks can log what happened. A configured Ardur adapter can stop an
+out-of-scope tool request before that adapter dispatches it. Its receipts let a
+reviewer verify the issuer signature and hash linkage later, including what the
+runtime allowed, denied, or left unknown.
 
 Ardur is being built to do all three:
 
@@ -223,7 +151,7 @@ This repo currently includes:
 - a short research-informed positioning summary
 - current status and what is still being resolved
 - public v0.1 specs for mission declarations, execution receipts, verifier contracts, conformance profiles, and related protocol surfaces
-- Python governance runtime under `python/`; Go eBPF/K8s packages and a complete AAT credential-attenuation engine under `go/`
+- Python governance runtime under `python/`; Go eBPF/K8s packages and a JWT AAT credential-attenuation implementation under `go/` (CWT integer-key mapping remains incomplete)
 - the Ardur Personal Hub service and CLI under `python/vibap/` (`ardur hub`, `ardur setup`, `ardur status`, `ardur protect claude-code`, `ardur profile init`, `ardur doctor-claude-code`)
 - the Claude Code plugin under `plugins/claude-code/` with `PreToolUse`, `PostToolUse`, `SubagentStart`, and `SubagentStop` hooks emitting signed receipts
 - runnable framework adapters under `examples/`: LangChain, LangGraph, AutoGen, browser extension, desktop-observe, native-host, and offline/no-key OpenAI Agents SDK and Google ADK fixtures. JSON mission examples remain in `examples/missions/`
@@ -257,7 +185,7 @@ Ardur sits between an AI agent and the tools it calls — so the integration sto
 |----------------------|-------------|---------------------------------|
 | **Agent framework**  | JSON mission examples; Claude Code plugin; runnable LangChain, LangGraph, AutoGen, browser, desktop-observe, native-host, and offline/no-key OpenAI Agents SDK and Google ADK fixture examples | live-provider wrappers and more runnable framework adapters |
 | **Model provider**   | provider-agnostic tool boundary in the runtime design | local Ollama quickstarts and live-provider examples |
-| **Policy engine**    | native checks, forbid-rules, Cedar bridge, AAT constraint engine (13 types) | OPA and broader Biscuit datalog examples |
+| **Policy engine**    | native checks, forbid-rules, Cedar bridge, JWT AAT constraint engine (13 types) | AAT CWT integer-key mapping, OPA, and broader Biscuit datalog examples |
 | **Identity**         | SPIFFE / SPIRE-oriented code and docs | full cluster deployment walkthrough |
 | **Receipts sink**    | local JSON / stdout-oriented receipt surfaces | OTel emitters and durable storage examples |
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,10 +2,12 @@
 
 ## Capture Boundary
 
-Today, Ardur captures every Claude Code tool-call invocation — file reads
-(`Read`), file writes (`Edit`/`Write`), shell command invocations (`Bash`),
-web access (`WebFetch`/`WebSearch`), and subagent dispatches (`Task`). Each
-invocation is signed (ES256) and chained (SHA-256).
+Today, an installed Ardur Claude Code hook records the tool-call events Claude
+Code delivers to that hook — file reads (`Read`), file writes (`Edit`/`Write`),
+shell command invocations (`Bash`), web access (`WebFetch`/`WebSearch`), and
+subagent dispatches (`Task`). Each observed invocation is signed (ES256) and
+chained (SHA-256). Ardur does not claim visibility into calls that bypass the
+hook or provider-hidden actions.
 
 What we do **not** yet capture:
 
@@ -33,7 +35,7 @@ caveat list, and [`ROADMAP.md`](ROADMAP.md) for the phase plan.
 - curated Python runtime files and tests are present under `python/`, including the Ardur Personal Hub service (`personal_hub.py`), Claude Code hook (`claude_code_hook.py`), Claude telemetry/reporting (`claude_code_telemetry.py`, `claude_code_report.py`), Gemini CLI local-only hook fixture/reporting (`gemini_cli_hook.py`), Codex app-server local host-event fixture/reporting (`codex_app_server_fixture.py`), native-messaging host (`ardur_personal_native_host.py`), and `ARDUR.md` profile compiler (`ardur_profile.py`)
 - the `ardur` CLI ships subcommands for the protocol path (`issue`, `verify`, `attest`, `start`) and the Personal path (`hub`, `setup`, `status`, `doctor`, `doctor-claude-code`, `uninstall`, `run`, `desktop-observe`, `personal-native-host`, `personal-native-manifest`, `profile init`, `protect claude-code`, `claude-code-hook`, `claude-code-report`, `gemini-cli-fixture`, `gemini-cli-hook`, `gemini-cli-report`, `codex-app-server-fixture`, `codex-app-server-event`, `codex-app-server-report`)
 - the Claude Code plugin is present under `plugins/claude-code/` with `PreToolUse`, `PostToolUse`, `SubagentStart`, and `SubagentStop` hooks plus a smoke script
-- curated Go runtime, governance, and operator files are present under `go/` (the AAT package remains a fail-closed skeleton by design and is documented as such in `go/README.md`)
+- curated Go runtime, governance, and operator files are present under `go/`; the AAT package implements the JWT issuance, derivation, proof-of-possession, constraint, and chain-verification path, while CWT integer-key mapping remains incomplete
 - runnable framework examples are present under `examples/`: LangChain, LangGraph, and AutoGen quickstarts; the Ardur Personal browser extension; the Ardur Personal desktop-observe adapter; the Ardur Personal native-messaging host; the Claude Code plugin pointer; and offline/no-key OpenAI Agents SDK and Google ADK fixtures. JSON mission examples remain in `examples/missions/`
 - dedicated Python (3.10 + 3.13) and Go CI workflows run on every push and PR (`.github/workflows/tests.yml`), including the offline examples-smoke regression in `python/tests/test_examples_smoke.py`, alongside CodeQL, link-check, secret-scan, format validation, and the Hugo site build
 - the Hugo public evidence-site source tree is present under `site/`, with start-here / build / evidence sections that link each public claim back to the source file backing it

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -25,11 +25,19 @@ evidence, Ardur must classify the result as `insufficient_evidence` (resulting
 in an `unknown` verdict at the session/verifier level) rather than safe. See
 [`coverage-map.md`](coverage-map.md) for the receipt-level evidence taxonomy.
 
+Ardur's current first-run proof is a configured tool-boundary proof. It can
+verify the issuer signature and hash linkage on receipts for calls observed by
+the adapter or proxy. It does not prove that every host or provider action was
+observed, and it does not add an independent third-party witness to a
+self-issued receipt. Transparency anchoring and receiver co-signing are
+separate roadmap work.
+
 ## Product limits
 
 Ardur is not:
 
 - a sandbox by itself
+- a universal discovery layer for calls that bypass its configured adapter
 - a universal semantic-safety engine
 - a replacement for identity, workload isolation, or network controls
 

--- a/go/README.md
+++ b/go/README.md
@@ -25,7 +25,7 @@ go test -race ./...
 
 | Path | What lives here |
 |---|---|
-| `pkg/aat` | AAT credential-attenuation engine — constraint checks, subsumption, JWT issuance/derivation, PoP binding, and full chain verification per AAT §3-7 |
+| `pkg/aat` | AAT JWT credential-attenuation engine — constraint checks, subsumption, JWT issuance/derivation, PoP binding, and chain verification per AAT sections 3-7 |
 | `pkg/api/v1alpha1` | CRD types for the Kubernetes operator (`AgentPassport`, etc.) |
 | `pkg/credential` | Mission credential issuance + verification (SD-JWT-VC types for the K8s operator) |
 | `pkg/issuer` | Mission Declaration issuer + signing-key management |
@@ -42,8 +42,8 @@ go test -race ./...
 
 ## AAT Package
 
-The `pkg/aat` package implements the full Attenuating Authorization Token
-specification:
+The `pkg/aat` package implements the JWT path of the Attenuating Authorization
+Token profile:
 
 - **Constraint engine** — 13 constraint types (Exact, Pattern, Range, OneOf,
   NotOneOf, Contains, Subset, Regex, Wildcard, All, Any, Not, CEL) with
@@ -59,9 +59,12 @@ specification:
   §7: structural validation → root verification (3a-3n) → link
   verification (4a-4s) → depth match → leaf constraint check → PoP
   verification → verdict.
-- **49 tests** covering constraint checks, subsumption cross-types,
-  issuance, derivation, PoP round-trips, and full chain verification
-  scenarios.
+- **Tests** covering constraint checks, subsumption cross-types, issuance,
+  derivation, PoP round-trips, and full chain verification scenarios.
+
+The companion CWT integer claim-key mapping is still pending. This package is
+therefore substantial and runnable, but it is not a claim of complete support
+for every AAT serialization profile.
 
 ```bash
 cd go && go test ./pkg/aat/... -v   # full AAT test suite

--- a/go/pkg/aat/types.go
+++ b/go/pkg/aat/types.go
@@ -1,23 +1,12 @@
-// Package aat defines the skeleton types for the Attenuating Authorization
-// Tokens (AAT) profile adopted by VIBAP.
-//
-// SECURITY-RELEVANT NOTICE — DO NOT USE THIS PACKAGE AS A VERIFIER (FIX-10
-// from S2 hostile audit, 2026-04-28). The AAT chain verifier in this
-// package is a fail-closed stub: VerifyChain returns VerdictDeny on every
-// call, regardless of inputs. Production callers MUST NOT depend on this
-// package's VerifyChain to enforce AAT §7. Until the TODO list in
-// chain_verify.go is closed, AAT enforcement happens in the Python
-// reference proxy (python/vibap/aat_adapter.py), not here. Importing this
-// package gives you the data types and the fail-closed stub, nothing more.
+// Package aat implements the JWT path of the Attenuating Authorization Tokens
+// (AAT) profile adopted by Ardur. It includes issuance, attenuation,
+// proof-of-possession, constraint, and chain-verification logic.
 //
 // Spec reference:
 //   - draft-niyikiza-oauth-attenuating-agent-tokens-00
 //   - Section 3: Token Types and Structure
 //
-// This package intentionally lands only the type system, function signatures,
-// and verification/derivation scaffolding required by PLAN.md §B.5. The
-// verifier, derivation logic, and PoP handling are left as explicit follow-up
-// work.
+// The companion CWT integer claim-key mapping remains pending; see ClaimKeys.
 package aat
 
 import jose "github.com/go-jose/go-jose/v4"

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -8,9 +8,13 @@ frameworks: ["framework-agnostic"]
 evidence_levels: ["code-and-doc"]
 ---
 
-Ardur is an open-source tool that keeps AI agents honest. You tell it what your
-agent is allowed to do, it blocks anything outside that boundary, and it gives
-you proof of every decision.
+Ardur is an open-source governance layer for configured AI-agent tool paths.
+Calls observed by an Ardur adapter or proxy are checked before that integration
+dispatches them, and each decision gets an issuer-signed, hash-linked receipt.
 
-Built for the open-source AI community. MIT licensed. Works with Claude Code,
-Ollama, LangChain, and any agent that calls tools over HTTP.
+The public source-checkout proof covers Claude Code and proxy-routed framework
+examples. It does not claim universal capture, third-party witnessing, or
+cross-platform kernel enforcement. MIT licensed.
+
+See the [configured tool-boundary claim]({{< relref "/claims/configured-tool-boundary/" >}})
+and [current limitations]({{< relref "/source/docs/known-limitations/" >}}).

--- a/site/content/build/python-go.md
+++ b/site/content/build/python-go.md
@@ -18,26 +18,31 @@ format validation, and the Hugo site build.
 
 ## Go AAT Engine
 
-The `go/pkg/aat` package is a complete implementation of the Attenuating
-Authorization Token specification:
+The `go/pkg/aat` package implements the JWT path of the Attenuating
+Authorization Token profile:
 
 - **13 constraint types** with full check and subsumption semantics
 - **IssueRoot / DeriveChild** with holder binding, depth tracking, and
   cryptographic parent-chain linking
 - **BuildPoPJWT / VerifyPoPJWT** with deterministic HTA canonicalization
 - **VerifyChain** — the 8-step offline verification algorithm per AAT §7
-- **49 tests** covering constraint checks, cross-type subsumption,
-  issuance, derivation, PoP round-trips, and full chain scenarios
+- **Tests** covering constraint checks, cross-type subsumption, issuance,
+  derivation, PoP round-trips, and full chain scenarios
 
-## Cloud Model Governance Tests
+CWT integer claim-key mapping remains pending, so this is not a complete claim
+for every AAT serialization profile.
+
+## Verification Boundary
 
 `python/tests/run_cloud_model_test.py` contains the live-provider governance
-harness. The redacted public tree keeps aggregate reports but does not ship raw
-per-model fixture artifacts:
+harness. It routes configured tool requests through the proxy. The redacted
+public tree keeps historical aggregate reports but does not ship raw per-model
+fixture artifacts, so those reports are not presented as proof for the current
+tree.
 
-- **Cloud Model (1T params):** 18/20 files created, 35 tool calls, zero denials
-- **Local Model (8B):** 4/20 files, 4 tool calls, zero denials
-- Every tool call flows through evaluate → attest → receipt
-- Average proxy overhead: ~4ms per call
+Current CI covers Python 3.10 and 3.13, Go, CodeQL, package contracts, and the
+gated Linux BPF-LSM/seccomp proof harnesses. These checks do not establish
+universal capture, provider-hidden visibility, or production kernel support on
+macOS and Windows.
 
 Sources: {{< repo-link "python/README.md" >}}, {{< repo-link "go/README.md" >}}, {{< repo-link "python/tests/run_cloud_model_test.py" "Cloud model harness" >}}, aggregate report path `python/tests/comprehensive_test_report.json`, and {{< repo-link ".github/workflows/tests.yml" "tests workflow" >}}.

--- a/site/content/build/use-and-troubleshooting.md
+++ b/site/content/build/use-and-troubleshooting.md
@@ -36,7 +36,7 @@ build until the change is promoted through a reviewed public deploy.
 - {{< repo-link "docs/guides/claude-code-mvp-quickstart.md" "Claude Code MVP quickstart" >}} — current source-checkout path with the no-key fresh-user harness, evidence-bundle reader, and optional live-Claude path.
 - {{< repo-link "docs/guides/read-phase1-evidence-bundle.md" "Phase 1 evidence-bundle guide" >}} — how to read `bundle.redacted.json` without overstating live-provider or kernel-capture claims.
 - {{< repo-link "docs/guides/ardur-personal-hub.md" "Ardur Personal Hub guide" >}} — local product walkthrough covering `ardur protect claude-code`, `ardur hub`, browser extension, and desktop observe.
-- {{< repo-link "plugins/claude-code/README.md" "Claude Code plugin" >}} — runnable plugin with signed receipts on every tool call. The [Claude Code recording](/build/claude-code-demo/) is archival context; use the MVP quickstart for fresh Phase 1 evidence.
+- {{< repo-link "plugins/claude-code/README.md" "Claude Code plugin" >}} — runnable plugin with signed receipts for tool-call events delivered to its installed hooks. The [Claude Code recording](/build/claude-code-demo/) is archival context; use the MVP quickstart for fresh Phase 1 evidence.
 - {{< repo-link "examples/README.md" "Examples index" >}} — framework examples and their maturity labels.
 - {{< repo-link "examples/langchain-quickstart/README.md" "LangChain quickstart" >}}
 - {{< repo-link "examples/langgraph-quickstart/README.md" "LangGraph quickstart" >}}

--- a/site/content/claims/configured-tool-boundary.md
+++ b/site/content/claims/configured-tool-boundary.md
@@ -1,0 +1,12 @@
+---
+title: "Configured Tool Boundary"
+description: "What Ardur can govern and prove when an adapter or proxy routes a tool request through it."
+weight: 1
+maturity: ["public-now"]
+claim_types: ["runtime-boundary"]
+surfaces: ["docs", "python", "scripts"]
+frameworks: ["framework-agnostic", "claude-code"]
+evidence_levels: ["code-and-doc"]
+---
+
+{{< claim "configured-tool-boundary" >}}

--- a/site/content/get-started.md
+++ b/site/content/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: "Get Started"
-description: "Install Ardur and run your first governed AI session in 5 minutes."
+description: "Run the current source-checkout governance proof without a provider API key."
 weight: 5
 maturity: ["public-now"]
 claim_types: ["orientation"]
@@ -11,7 +11,8 @@ evidence_levels: ["code-and-doc"]
 
 ## Pick your path
 
-Ardur works anywhere Python 3.10+ runs. Choose the setup that matches your setup.
+The source-checkout governance loop works anywhere Python 3.10+ runs. Choose
+the setup that matches your host.
 
 ---
 
@@ -26,8 +27,8 @@ cd ardur/python
 python3 -m venv .venv
 source .venv/bin/activate
 
-# 3. Install dependencies
-pip install pyjwt cryptography
+# 3. Install the local package
+pip install -e .
 
 # 4. Verify it works
 PYTHONPATH=. python -c "from vibap.passport import generate_keypair; generate_keypair()"
@@ -44,7 +45,7 @@ PYTHONPATH=. python -c "from vibap.passport import generate_keypair; generate_ke
 git clone https://github.com/ArdurAI/ardur.git
 cd ardur/python
 python3 -m venv .venv && source .venv/bin/activate
-pip install pyjwt cryptography
+pip install -e .
 
 # 2. Optional: build the Go AAT engine
 cd ../go && go build ./...
@@ -63,10 +64,11 @@ for the current `ardur start --host` and TLS boundary.
 
 ---
 
-### Docker (coming soon)
+### Docker
 
-A Docker Compose file and prebuilt images are on the roadmap. For now, clone
-the repo and run directly.
+The authenticated evaluator stack is available from a source checkout through
+`make demo`. Published release images remain gated; see the
+[MVP evaluator guide]({{< relref "/source/docs/mvp-evaluator-guide/" >}}).
 
 ---
 
@@ -74,8 +76,9 @@ the repo and run directly.
 
 ### With Ollama (local models)
 
-Ardur works with any model running in Ollama. The proxy is provider-agnostic —
-it evaluates tool calls, not model outputs.
+The proxy evaluates tool requests routed to it, not model outputs. Ollama can
+be used by a configured harness; this is not automatic discovery of every
+model action.
 
 ```bash
 # Start Ollama with a local model
@@ -97,8 +100,8 @@ export OLLAMA_API_KEY="your-api-key"
 PYTHONPATH=python python tests/run_cloud_model_test.py "$MODEL_NAME"
 ```
 
-This runs a real-world test: a cloud model builds a complete web application
-while every tool call goes through Ardur's governance check.
+This optional harness routes its configured tool requests through Ardur's
+governance check. Its historical aggregate report is not the first-run proof.
 
 ### With Claude Code
 
@@ -126,40 +129,27 @@ Runnable quickstarts live in the examples directory:
 
 ## Run your first governed session
 
-Here's the shortest end-to-end path:
+The shortest current end-to-end path is provider-free and cleans up its own
+temporary state:
 
 ```bash
-# 1. Start the governance proxy
-cd python
-PYTHONPATH=. python -m vibap.cli hub start
-
-# 2. In another terminal, issue a mission passport
-PYTHONPATH=. python -m vibap.cli issue \
-  --agent-id "my-agent" \
-  --mission "read files in /tmp and write reports" \
-  --allowed-tools read_file write_file \
-  --resource-scope /tmp \
-  --max-tool-calls 50
-
-# 3. Use the token to start a session
-# (The CLI prints the token — copy it)
-curl -k -X POST https://127.0.0.1:<port>/session/start \
-  -H "Content-Type: application/json" \
-  -d '{"token": "<your-token>"}'
-
-# 4. Evaluate tool calls through the proxy
-curl -k -X POST https://127.0.0.1:<port>/evaluate \
-  -H "Content-Type: application/json" \
-  -d '{"session_id": "<session-id>", "tool_name": "read_file", "arguments": {"path": "/tmp/test.txt"}}'
+git clone https://github.com/ArdurAI/ardur.git
+cd ardur
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e python/
+python scripts/run-no-key-mvp-demo.py
 ```
 
-Each `/evaluate` call returns PERMIT or DENY with a signed receipt.
+The demo reaches a `PERMIT`, a `DENY`, and a locally verified signed
+attestation. It disables TLS and bearer auth only for its loopback child
+process; it is not a production launch command.
 
 ---
 
 ## Next steps
 
-- [See real-world test results]({{< relref "/proof" >}}) — cloud models governed by Ardur
+- [Review current evidence]({{< relref "/evidence" >}})
 - [Read the CLI reference]({{< relref "/source/docs/reference/cli/" >}})
 - [Understand the security model]({{< relref "/source/docs/security-model/" >}})
 - [Browse the examples]({{< relref "/examples" >}})

--- a/site/content/how-it-works.md
+++ b/site/content/how-it-works.md
@@ -44,9 +44,10 @@ That's it. No JSON, no YAML, no custom language. Ardur compiles this into a
 signed Mission Passport — a JWT that cryptographically binds the agent to
 these rules.
 
-## 2. Ardur enforces the rules at runtime
+## 2. A configured integration checks the request
 
-Every time the agent tries to call a tool, Ardur checks:
+When an installed adapter or proxy sends a tool request through Ardur, it
+checks:
 
 - **Is this tool allowed?** If it's not in the allowed list, deny.
 - **Is it forbidden?** Some tools are never OK, regardless.
@@ -54,22 +55,27 @@ Every time the agent tries to call a tool, Ardur checks:
 - **Has the budget been exceeded?** Too many calls or too long running? Deny.
 - **Do the policy backends agree?** Cedar rules, forbid-rules, custom checks.
 
-All of this happens before the tool runs. The agent never touches resources
-it shouldn't.
+The decision happens before that integration dispatches the tool. A deny keeps
+the governed adapter from dispatching the request. Ardur does not claim to
+discover or stop calls that bypass the configured boundary.
 
-## 3. You get signed proof of everything
+## 3. You get signed evidence for observed decisions
 
-Every decision produces an Execution Receipt — a JWT signed with the issuer's
+Each observed decision produces an Execution Receipt — a JWT signed with the issuer's
 private key. Each receipt links to the previous one by SHA-256 hash. The chain
 is tamper-evident: change any receipt and every receipt after it fails
 verification.
 
 A session receipt chain gives you:
 
-- **A complete timeline** — what happened and when
-- **The verdict** — PERMIT or DENY for each tool call
+- **An observed timeline** — calls that reached the configured Ardur boundary
+- **The verdict** — PERMIT or DENY for each observed tool call
 - **The reason** — which rule triggered a denial
 - **Cryptographic integrity** — proof the chain hasn't been modified
+
+Offline verification proves the issuer signature and chain linkage. It does
+not turn a self-issued receipt into independent third-party attestation, and it
+does not prove the side effects that occurred below a permitted tool call.
 
 ## Where Ardur sits
 
@@ -78,7 +84,7 @@ A session receipt chain gives you:
 │  Your AI agent (Claude Code, LangChain,  │
 │  AutoGen, custom, ...)                   │
 └──────────────────┬──────────────────────┘
-                   │ every tool call
+                   │ configured tool-call path
                    ▼
 ┌─────────────────────────────────────────┐
 │            Ardur Governance Proxy         │
@@ -100,14 +106,15 @@ A session receipt chain gives you:
 └─────────────────────────────────────────┘
 ```
 
-The proxy is the enforcement point. No bypass, no direct access, no "oops I
-forgot to turn it on."
+The adapter or proxy is the enforcement point only for traffic routed through
+it. Direct or provider-hidden paths remain outside this proof boundary.
 
 ## What Ardur does NOT do
 
 Honesty matters. Ardur is not:
 
 - **A sandbox** — it governs at the tool-call boundary, not the kernel level (yet)
+- **A universal capture layer** — calls that bypass the adapter are not observed
 - **A model guard** — it doesn't inspect or filter what the model says, only what tools it calls
 - **A replacement for OS security** — use it with, not instead of, file permissions and access controls
 

--- a/site/content/proof.md
+++ b/site/content/proof.md
@@ -1,6 +1,6 @@
 ---
-title: "Proof & Test Results"
-description: "Real-world evidence that Ardur's governance works."
+title: "Verification & Evidence"
+description: "Current rerunnable proofs, CI gates, and the boundaries they do not cross."
 weight: 55
 maturity: ["public-now"]
 claim_types: ["proof-media", "runtime-boundary"]
@@ -9,103 +9,62 @@ frameworks: ["ollama", "framework-agnostic"]
 evidence_levels: ["code-and-doc"]
 ---
 
-Ardur doesn't ask you to trust marketing claims. Here's the actual data from
-tests with real models.
+The evidence below is tied to rerunnable paths in the current public tree.
 
----
+## Fast Local Proofs
 
-## Cloud Model Governance Test
+| Proof | What it establishes | Source |
+|---|---|---|
+| No-key governance loop | A temporary loopback proxy returns PERMIT and DENY and produces a locally verified signed attestation | {{< repo-link "scripts/run-no-key-mvp-demo.py" >}} |
+| Claude Code deny proof | The installed local hook path returns a human-readable deny, verifies exactly one signed/hash-linked Bash violation receipt, checks post-deny file state, and removes temporary material | {{< repo-link "scripts/run-claude-deny-demo.py" >}} |
+| Phase 1 evidence bundle | A redacted bundle covers setup, profile creation, simulated hook receipts, report verification, and claim mapping | {{< repo-link "scripts/run-rwt-phase1-fresh-user.py" >}} |
 
-We asked a cloud model with 1-trillion-parameter capacity to build a complete
-Code Repository Manager — a mini-GitHub clone with repositories, commits,
-branches, issues, pull requests, search, and an admin dashboard. 20 files,
-~2000+ lines of code each, all Python stdlib.
+These are configured-boundary proofs. The file-state checks are not
+independent process/kernel observation, and the no-key harness does not execute
+a live provider.
 
-**Every single tool call went through Ardur first.**
+## Current Verification Snapshot
 
-### Results
+At the reviewed `dev` tree on 2026-07-09:
 
-| Model | Type | Duration | Tool Calls | Files Built | Denials |
-|-------|------|----------|------------|-------------|---------|
-| **Cloud Model** | Cloud · 1T params | 12 min | 35 | 18 of 20 | **0** |
-| **Local Model** | Local · 5GB | 15 min | 4 | 4 of 20 | **0** |
+| Gate | Result |
+|---|---|
+| Python local run with CI coverage flags | 1,358 passed, 32 skipped, 85% coverage |
+| Python CI | Python 3.10 and 3.13, lint, and wheel smoke passed |
+| Go CI | Tests, vet, lint, and vulnerability scan passed |
+| Static/security | Python and Go CodeQL, secret scans, and format checks passed |
+| Linux enforcement | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E passed |
+| Docs/release contracts | Hugo, links, package build, and OCI smoke passed |
 
-### What this proves
+The workflow files under {{< repo-link ".github/workflows/" >}} are the
+current source of truth; numeric results here are a dated snapshot.
 
-1. **Zero false denials.** The proxy never blocked a legitimate tool call.
-   Every `PERMIT` was correct.
-2. **Negligible overhead.** Ardur added ~4ms to each tool call. The model's
-   thinking time dominated — governance is not the bottleneck.
-3. **Works with cloud and local models.** Both Ollama cloud API and local
-   Ollama models work without changes.
-4. **Handles sustained workloads.** The cloud model ran for 12 minutes across 35 tool
-   calls without a single governance failure.
+## AAT JWT Path
 
-### How to reproduce
+The Go AAT package tests 13 constraint types, issuance, child derivation,
+proof-of-possession JWTs, and chain verification. CWT integer claim-key mapping
+remains pending, so this is not a complete claim for every AAT serialization
+profile. See {{< repo-link "go/README.md" >}}.
 
-```bash
-# Set your Ollama API key
-export ARDUR_OLLAMA_API_KEY="your-key"
+## Historical Model Harness
 
-# Run the test
-cd python
-PYTHONPATH=. python tests/run_cloud_model_test.py "$MODEL_NAME"
+{{< repo-link "python/tests/run_cloud_model_test.py" >}} is an opt-in
+live-provider harness, and the redacted tree retains historical aggregates.
+Raw per-model fixtures are not shipped, so those aggregates are context rather
+than current-tree proof and are not used to claim zero false denials, universal
+provider support, or a fixed latency ceiling.
 
-# Results are written as local artifacts for the run.
-```
+## Claim Boundary
 
-The runnable test script is in the repo at
-`python/tests/run_cloud_model_test.py`. The redacted public tree keeps aggregate
-reports but does not ship raw per-model fixture artifacts.
+The checks above do not establish:
 
----
+- visibility into calls that bypass an Ardur adapter or proxy;
+- provider-hidden actions or reasoning;
+- independent third-party witnessing of self-issued receipts;
+- every subprocess, file, network, or kernel effect below a permitted call;
+- production kernel enforcement on Linux, macOS, or Windows.
 
-## Go AAT Engine Tests
-
-The Go AAT package has **49 tests** covering the full Attenuating
-Authorization Token specification:
-
-- All 13 constraint types (Exact, Pattern, Range, OneOf, etc.)
-- Cross-type constraint subsumption
-- Root AAT issuance with holder binding
-- Child derivation with depth tracking and parent-chain linking
-- Proof of Possession (PoP) JWT round-trips
-- Full §7 chain verification (8-step algorithm)
-
-```bash
-cd go && go test ./pkg/aat/... -v
-# 49 passed, 0 failures
-```
-
----
-
-## CI & Automated Checks
-
-Every push and PR runs:
-
-| Check | What it does |
-|-------|-------------|
-| Python 3.10 + 3.13 | Full pytest suite |
-| Go | `go test ./...` + `go vet ./...` |
-| CodeQL | Static analysis for Python + Go |
-| Secret scan | gitleaks + forbidden-term gate |
-| Link check | lychee on all markdown links |
-| Format validation | JSON + YAML parse on all files |
-| Hugo build | Site builds cleanly |
-
----
-
-## The honest caveat
-
-What you see above is real, but the test surface is not yet exhaustive:
-
-- The cloud model test runs 30-turn sessions — longer runs are possible but not
-  yet in the automated suite.
-- Kernel-level capture (eBPF) is implemented but the full integration test
-  harness isn't public yet.
-- These are single-session tests — multi-tenant, concurrent session testing
-  is on the roadmap.
-
-The [coverage map]({{< relref "/source/docs/coverage-map/" >}})
-and [known limitations]({{< relref "/source/docs/known-limitations/" >}})
-keep the full picture current.
+The [configured tool-boundary claim]({{< relref "/claims/configured-tool-boundary/" >}}),
+[coverage map]({{< relref "/source/docs/coverage-map/" >}}), and
+[known limitations]({{< relref "/source/docs/known-limitations/" >}}) keep the
+trust boundary explicit.

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -1,8 +1,8 @@
 ---
 title: "Ardur"
-description: "Ardur is the runtime governance and evidence layer for AI agents."
+description: "Ardur governs AI-agent tool calls that pass through a configured adapter or"
 source_path: "README.md"
-source_sha256: "7b5eab7f5b548a09c9fddb7cf1567e5ca313b7ae059852770e52120d0d5adfe5"
+source_sha256: "d300f1a18670d4c9d3bed42452a5e4bce2cd8fdc0ed0aedc9e5373c910510eeb"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -17,7 +17,10 @@ evidence_levels: ["code-and-doc"]
 This page is generated from the public repository source file. Edit the source file, then run `python3 site/scripts/sync_source_docs.py` to refresh the Hugo mirror.
 {{< /proof-status >}}
 
-Ardur is the runtime governance and evidence layer for AI agents.
+Ardur governs AI-agent tool calls that pass through a configured adapter or
+proxy. It checks mission, resource, budget, and delegation constraints before
+that integration dispatches the call, then emits an issuer-signed,
+hash-linked receipt for the decision.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ArdurAI/ardur/blob/__ARDUR_SOURCE_REF__/LICENSE)
 [![Status](https://img.shields.io/badge/status-pre--release-blue)](/__ardur_internal__/source/status/)
@@ -28,115 +31,38 @@ public specs, the Python governance runtime, Go packages for eBPF kernel
 capture and Kubernetes control-plane components, mission examples, runnable
 framework adapters (LangChain, LangGraph, AutoGen), the Ardur Personal Hub
 service, the Claude Code plugin and hook, and the public Hugo evidence site.
-Re-runnable proof media, full packaging, and production deployment material
-are still being tightened before they are presented as release-ready.
+The current public proof is strongest at those configured tool boundaries. It
+does not establish universal agent capture, third-party witnessing,
+provider-hidden behavior, or cross-platform kernel enforcement. Re-runnable
+proof media, full packaging, and production deployment material are still
+being tightened before they are presented as release-ready.
 
 [Research](/__ardur_internal__/source/research/) · [Status](/__ardur_internal__/source/status/) · [Coverage Map](/__ardur_internal__/source/docs/coverage-map/) · [Roadmap](/__ardur_internal__/source/roadmap/) · [Media](/__ardur_internal__/source/media-notes/) · [Articles](/__ardur_internal__/source/docs/articles/readme/) · [Docs](/__ardur_internal__/source/docs/readme/) · [Reference](/__ardur_internal__/source/docs/reference/readme/) · [Phase 1 Demo Packet](/__ardur_internal__/source/docs/guides/phase1-demo-packet/) · [Read the Phase 1 Evidence Bundle](/__ardur_internal__/source/docs/guides/read-phase1-evidence-bundle/) · [Evidence Site Source](/__ardur_internal__/source/site/readme/)
 
-## Test Results
+## Verification Snapshot
 
-Tests here are designed to prove three things:
+At the reviewed `dev` tree on 2026-07-09, the current gates were:
 
-1. **Correctness** — the governance proxy enforces the spec faithfully: visibility, envelope integrity, manifest digest, delegation narrowing, hidden-hop detection, per-class budgets, rate limiting, and kill-switch semantics.
-2. **Resilience** — adversarial models cannot bypass policy boundaries through prompt injection, jailbreaking, social engineering, path traversal, multi-turn steering, or chained-tool attacks.
-3. **Real-model integration** — live models routed through the proxy can build substantial software (multi-file applications with tests and documentation) while every tool call flows through governance first.
+| Gate | Verified result |
+|---|---|
+| Python local matrix with the CI coverage flags (Python 3.12) | 1,358 passed, 32 skipped, 85% coverage |
+| Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
+| Go CI | Tests, vet, lint, and vulnerability scan passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E passed |
+| Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
-### Unit & Integration Suite
+These gates verify the checked-in runtime and its configured integration
+paths: policy evaluation, fail-closed error handling, signed/hash-linked
+receipts, delegation, package contracts, and the explicitly gated Linux
+enforcement harnesses. They do **not** prove that Ardur observes calls that
+bypass an adapter, provider-hidden actions, every effect below a tool call, or
+production readiness on every platform.
 
-| Suite | Passed | Skipped | Failed |
-|-------|--------|---------|--------|
-| Core governance (proxy, passport, mission, receipts) | 581 | 21 | 0 |
-
-Covers the Delegation-Core, MIC-State, and MIC-Evidence conformance profiles — all 4 verifier-contract gaps closed as of the hardening round ending 2026-05-14. Includes visibility checks (§6.4), envelope signature verification (§9.5), manifest digest comparison (§9.6), hidden-hop detection (§9.1), and `last_seen_receipts` tracking (§5.7).
-
-### Comprehensive Protocol Composition
-
-Single end-to-end test exercising all protocol layers over real TLS with SPIFFE identity, Biscuit attenuation, JWT delegation, and policy backends.
-
-| Scenario | Duration | What it proves |
-|----------|----------|---------------|
-| Health & baseline | 0.02s | Server responds correctly, content-type negotiation works |
-| JWT session lifecycle | 0.07s | Start → evaluate → attest → end produces verifiable receipts |
-| Biscuit + SPIFFE binding | 0.13s | Biscuit bearer token bound to SPIFFE SVID holder |
-| **Ollama multi-turn build** | **106.6s** | Live cloud model builds a complete journal API across 20 turns — write_file, read_file, list_directory — all through the proxy |
-| JWT delegation chain | 0.11s | Parent → child → grandchild narrowing: tools and budget strictly contract |
-| Biscuit attenuation chain | 0.13s | Root → child → grandchild: each hop narrows authority, escalation blocked |
-| Kill switch mid-session | 0.08s | Activate blocks /evaluate (503), deactivate restores, health stays available |
-| Rate limit flooding | 0.31s | Burst beyond 50 requests triggers 429 with Retry-After header |
-| Metrics verification | 0.03s | Prometheus text format, all 6 required metric families present |
-| Receipt chain integrity | 0.01s | Multi-trace receipts form independently verifiable hash-linked chains |
-| ForbidRules composition | 0.05s | Regex-based forbid-rules backend denies while native permits |
-| Three-backend composition | 0.07s | Native + ForbidRules + Cedar: each backend can independently deny |
-| Integrity hash enforcement | 0.03s | policy_sha256 mismatch → DENY (fail-closed) |
-
-**13/13 passed. Total: 118.3s.**
-
-### Ollama Integration
-
-| Suite | Passed | Failed |
-|-------|--------|--------|
-| Connectivity (model listing, chat, tool calling) | 3 | 0 |
-| Governance integration (proxy routing, denial, multi-turn, delegation) | 8 | 0 |
-| Security headers | 2 | 0 |
-| Concurrency | 1 | 0 |
-| Model capabilities (denial understanding, self-description, constraint respect) | 3 | 0 |
-
-**17/17 passed. Total: 26.1s.**
-
-### Phase 1 — Adversarial Boundary Testing
-
-10 hostile scenarios across 5 cloud models spanning multiple providers. Every scenario is designed to trigger a DENY — models attempt direct forbidden-tool use, mid-execution prompt injection, DAN-style jailbreaking, social engineering, resource-scope violations, path traversal, budget exhaustion, obfuscated command injection, multi-turn gradual steering toward forbidden actions, and chained tool attacks (write script → execute). The public redaction keeps the aggregate result here and omits raw per-model fixture artifacts from the repository.
-
-| Metric | Value |
-|--------|-------|
-| Tool calls evaluated | 143 |
-| PERMIT | 63 |
-| DENY | 106 |
-| **BYPASS** | **0** |
-
-**Zero bypasses.** Proxy boundaries held across all 5 models, all 10 attack vectors. The proxy denied 106 violation attempts. Models that refused before calling tools (ethical refusal) were counted as passes — the scenario's goal is exercising the proxy's enforcement boundary, and a model-level refusal means the attack didn't reach the runtime.
-
-### Phase 2 — Advanced Enforcement Checks
-
-22 programmatic checks verifying specific enforcement points — no model in the loop. Direct API calls against the proxy exercising edge cases:
-
-| Category | Checks | Highlights |
-|----------|--------|-----------|
-| Approval policy | 2 | operator_id required, fatigue threshold exceeded |
-| Delegation | 1 | child tool escalation beyond parent scope rejected |
-| Memory governance | 2 | FIX-8: private key material rejected on memory write/read |
-| Token replay | 1 | JTI replay on session start rejected |
-| Kill switch | 2 | /evaluate and /session/start both return 503 |
-| Per-class budget | 2 | internal_write budget exhaustion, side_effect_class not in allowlist |
-| CWD confinement | 2 | absolute path escape and path traversal escape from CWD both blocked |
-| Policy backends | 1 | ForbidRules backend blocks targeted tool |
-| Tool scope | 1 | forbidden tool directly denied |
-| Resource scope | 1 | write outside resource_scope denied |
-| Budget | 1 | main budget exhausted after max_tool_calls |
-| Session lifecycle | 2 | ended session rejects, multiple sessions coexist |
-| Token validation | 2 | invalid JWT rejected, nonexistent session_id rejected |
-| Input sanitization | 1 | null-byte and unicode dot-confusable traversal paths rejected (U+2024/U+FE52/U+FF0E folded to ASCII '.', and U+2025/U+FE30 caught via NFKC-form backstop, so a tool that NFKC-normalizes before opening cannot escape scope) |
-| Infrastructure | 1 | health endpoint returns ok |
-
-**22/22 passed. Total: <1s.**
-
-### Go AAT — Credential Attenuation Engine
-
-The Go `pkg/aat` package implements 13 constraint types, token serialization, delegation-chain verification, and constraint subsumption. All tests pass with zero failures.
-
-### Aggregate
-
-| Suite | Count | Status |
-|-------|-------|--------|
-| Python unit + integration | 581 + 21 skipped | All passing |
-| Comprehensive protocol composition | 13 scenarios | All passing |
-| Ollama integration | 17 | All passing |
-| Phase 1 adversarial (5 models) | 10 scenarios × 5 models | 0 bypasses |
-| Phase 2 advanced enforcement | 22 checks | All passing |
-| Go AAT | full suite | All passing |
-| MIC conformance (new) | 29 | All passing |
-
-[Python test suite →](https://github.com/ArdurAI/ardur/tree/__ARDUR_SOURCE_REF__/python/tests) · Aggregate report: `python/tests/comprehensive_test_report.json` · [Proof & evidence site →](/__ardur_internal__/source/site/readme/)
+The numeric Python result is a dated snapshot, not a permanent badge; the
+workflow files under [`.github/workflows/`](/__ardur_internal__/source/github/workflows/) are the current
+source of truth. Historical model/adversarial aggregates remain at
+`python/tests/comprehensive_test_report.json`, but they are not presented here
+as evidence for the current tree.
 
 ## First-Run Paths
 
@@ -203,8 +129,9 @@ After a run, use the
 handoff: tested commit, `bundle.redacted.json`, optional live-Claude report, and
 the exact claims the artifacts do and do not support.
 
-> **Capture boundary today (v0.1):** Ardur signs every Claude Code tool-call
-> invocation. Side effects below the tool boundary — subprocess trees,
+> **Capture boundary today (v0.1):** Ardur signs the Claude Code tool-call
+> events delivered to its installed hooks. Side effects below the tool
+> boundary — subprocess trees,
 > kernel events, network connections initiated by tool-spawned processes —
 > are not yet captured; the roadmap closes that gap in v0.2 (filesystem
 > snapshots), v0.5 (Linux eBPF), and v1.0 (macOS Endpoint Security
@@ -213,9 +140,10 @@ the exact claims the artifacts do and do not support.
 
 ## Why Ardur
 
-Many agent stacks can log what happened. Fewer can stop an out-of-scope action
-before it executes. Fewer still can prove later, with verifier-backed evidence,
-what the runtime allowed, denied, or left unknown.
+Many agent stacks can log what happened. A configured Ardur adapter can stop an
+out-of-scope tool request before that adapter dispatches it. Its receipts let a
+reviewer verify the issuer signature and hash linkage later, including what the
+runtime allowed, denied, or left unknown.
 
 Ardur is being built to do all three:
 
@@ -240,7 +168,7 @@ This repo currently includes:
 - a short research-informed positioning summary
 - current status and what is still being resolved
 - public v0.1 specs for mission declarations, execution receipts, verifier contracts, conformance profiles, and related protocol surfaces
-- Python governance runtime under `python/`; Go eBPF/K8s packages and a complete AAT credential-attenuation engine under `go/`
+- Python governance runtime under `python/`; Go eBPF/K8s packages and a JWT AAT credential-attenuation implementation under `go/` (CWT integer-key mapping remains incomplete)
 - the Ardur Personal Hub service and CLI under `python/vibap/` (`ardur hub`, `ardur setup`, `ardur status`, `ardur protect claude-code`, `ardur profile init`, `ardur doctor-claude-code`)
 - the Claude Code plugin under `plugins/claude-code/` with `PreToolUse`, `PostToolUse`, `SubagentStart`, and `SubagentStop` hooks emitting signed receipts
 - runnable framework adapters under `examples/`: LangChain, LangGraph, AutoGen, browser extension, desktop-observe, native-host, and offline/no-key OpenAI Agents SDK and Google ADK fixtures. JSON mission examples remain in `examples/missions/`
@@ -274,7 +202,7 @@ Ardur sits between an AI agent and the tools it calls — so the integration sto
 |----------------------|-------------|---------------------------------|
 | **Agent framework**  | JSON mission examples; Claude Code plugin; runnable LangChain, LangGraph, AutoGen, browser, desktop-observe, native-host, and offline/no-key OpenAI Agents SDK and Google ADK fixture examples | live-provider wrappers and more runnable framework adapters |
 | **Model provider**   | provider-agnostic tool boundary in the runtime design | local Ollama quickstarts and live-provider examples |
-| **Policy engine**    | native checks, forbid-rules, Cedar bridge, AAT constraint engine (13 types) | OPA and broader Biscuit datalog examples |
+| **Policy engine**    | native checks, forbid-rules, Cedar bridge, JWT AAT constraint engine (13 types) | AAT CWT integer-key mapping, OPA, and broader Biscuit datalog examples |
 | **Identity**         | SPIFFE / SPIRE-oriented code and docs | full cluster deployment walkthrough |
 | **Receipts sink**    | local JSON / stdout-oriented receipt surfaces | OTel emitters and durable storage examples |
 

--- a/site/content/source/STATUS.md
+++ b/site/content/source/STATUS.md
@@ -1,8 +1,8 @@
 ---
 title: "Status"
-description: "Today, Ardur captures every Claude Code tool-call invocation — file reads"
+description: "Today, an installed Ardur Claude Code hook records the tool-call events Claude"
 source_path: "STATUS.md"
-source_sha256: "be10312316c8cd5c75a295f170c0930899af329236951194816ca986738168fe"
+source_sha256: "e90f86aac2a3755d8a2856d9ac7c3e398360ed123cb5ed2bb85cc78fda5368e1"
 weight: 100
 maturity: ["in-progress", "public-now"]
 claim_types: ["status"]
@@ -19,10 +19,12 @@ This page is generated from the public repository source file. Edit the source f
 
 ## Capture Boundary
 
-Today, Ardur captures every Claude Code tool-call invocation — file reads
-(`Read`), file writes (`Edit`/`Write`), shell command invocations (`Bash`),
-web access (`WebFetch`/`WebSearch`), and subagent dispatches (`Task`). Each
-invocation is signed (ES256) and chained (SHA-256).
+Today, an installed Ardur Claude Code hook records the tool-call events Claude
+Code delivers to that hook — file reads (`Read`), file writes (`Edit`/`Write`),
+shell command invocations (`Bash`), web access (`WebFetch`/`WebSearch`), and
+subagent dispatches (`Task`). Each observed invocation is signed (ES256) and
+chained (SHA-256). Ardur does not claim visibility into calls that bypass the
+hook or provider-hidden actions.
 
 What we do **not** yet capture:
 
@@ -50,7 +52,7 @@ caveat list, and [`ROADMAP.md`](/__ardur_internal__/source/roadmap/) for the pha
 - curated Python runtime files and tests are present under `python/`, including the Ardur Personal Hub service (`personal_hub.py`), Claude Code hook (`claude_code_hook.py`), Claude telemetry/reporting (`claude_code_telemetry.py`, `claude_code_report.py`), Gemini CLI local-only hook fixture/reporting (`gemini_cli_hook.py`), Codex app-server local host-event fixture/reporting (`codex_app_server_fixture.py`), native-messaging host (`ardur_personal_native_host.py`), and `ARDUR.md` profile compiler (`ardur_profile.py`)
 - the `ardur` CLI ships subcommands for the protocol path (`issue`, `verify`, `attest`, `start`) and the Personal path (`hub`, `setup`, `status`, `doctor`, `doctor-claude-code`, `uninstall`, `run`, `desktop-observe`, `personal-native-host`, `personal-native-manifest`, `profile init`, `protect claude-code`, `claude-code-hook`, `claude-code-report`, `gemini-cli-fixture`, `gemini-cli-hook`, `gemini-cli-report`, `codex-app-server-fixture`, `codex-app-server-event`, `codex-app-server-report`)
 - the Claude Code plugin is present under `plugins/claude-code/` with `PreToolUse`, `PostToolUse`, `SubagentStart`, and `SubagentStop` hooks plus a smoke script
-- curated Go runtime, governance, and operator files are present under `go/` (the AAT package remains a fail-closed skeleton by design and is documented as such in `go/README.md`)
+- curated Go runtime, governance, and operator files are present under `go/`; the AAT package implements the JWT issuance, derivation, proof-of-possession, constraint, and chain-verification path, while CWT integer-key mapping remains incomplete
 - runnable framework examples are present under `examples/`: LangChain, LangGraph, and AutoGen quickstarts; the Ardur Personal browser extension; the Ardur Personal desktop-observe adapter; the Ardur Personal native-messaging host; the Claude Code plugin pointer; and offline/no-key OpenAI Agents SDK and Google ADK fixtures. JSON mission examples remain in `examples/missions/`
 - dedicated Python (3.10 + 3.13) and Go CI workflows run on every push and PR (`.github/workflows/tests.yml`), including the offline examples-smoke regression in `python/tests/test_examples_smoke.py`, alongside CodeQL, link-check, secret-scan, format validation, and the Hugo site build
 - the Hugo public evidence-site source tree is present under `site/`, with start-here / build / evidence sections that link each public claim back to the source file backing it

--- a/site/content/source/docs/known-limitations.md
+++ b/site/content/source/docs/known-limitations.md
@@ -2,7 +2,7 @@
 title: "Known Limitations"
 description: "This page distinguishes documented product boundaries from implementation bugs."
 source_path: "docs/known-limitations.md"
-source_sha256: "24fdbe4177983e88108c940ab7a0ea8109f8a4fdcb5dd6a0038069052b7ce542"
+source_sha256: "be8acf73817e13ea683601d3ae32b76282c4c84c624fef3c060d445131f83c21"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["limitation"]
@@ -42,11 +42,19 @@ evidence, Ardur must classify the result as `insufficient_evidence` (resulting
 in an `unknown` verdict at the session/verifier level) rather than safe. See
 [`coverage-map.md`](/__ardur_internal__/source/docs/coverage-map/) for the receipt-level evidence taxonomy.
 
+Ardur's current first-run proof is a configured tool-boundary proof. It can
+verify the issuer signature and hash linkage on receipts for calls observed by
+the adapter or proxy. It does not prove that every host or provider action was
+observed, and it does not add an independent third-party witness to a
+self-issued receipt. Transparency anchoring and receiver co-signing are
+separate roadmap work.
+
 ## Product limits
 
 Ardur is not:
 
 - a sandbox by itself
+- a universal discovery layer for calls that bypass its configured adapter
 - a universal semantic-safety engine
 - a replacement for identity, workload isolation, or network controls
 

--- a/site/content/source/go/README.md
+++ b/site/content/source/go/README.md
@@ -2,7 +2,7 @@
 title: "Ardur — Go Runtime"
 description: "Go handles the parts of Ardur where Python falls short: Linux eBPF kernel"
 source_path: "go/README.md"
-source_sha256: "a30a71d23cfc78f1d1da3eb0eb204580f34cb390a912251d9af12717ac911da9"
+source_sha256: "a7f0c68d430ba3ee0989ede6b936108329febe051cbb2254fc0ab5970f66c456"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -42,7 +42,7 @@ go test -race ./...
 
 | Path | What lives here |
 |---|---|
-| `pkg/aat` | AAT credential-attenuation engine — constraint checks, subsumption, JWT issuance/derivation, PoP binding, and full chain verification per AAT §3-7 |
+| `pkg/aat` | AAT JWT credential-attenuation engine — constraint checks, subsumption, JWT issuance/derivation, PoP binding, and chain verification per AAT sections 3-7 |
 | `pkg/api/v1alpha1` | CRD types for the Kubernetes operator (`AgentPassport`, etc.) |
 | `pkg/credential` | Mission credential issuance + verification (SD-JWT-VC types for the K8s operator) |
 | `pkg/issuer` | Mission Declaration issuer + signing-key management |
@@ -59,8 +59,8 @@ go test -race ./...
 
 ## AAT Package
 
-The `pkg/aat` package implements the full Attenuating Authorization Token
-specification:
+The `pkg/aat` package implements the JWT path of the Attenuating Authorization
+Token profile:
 
 - **Constraint engine** — 13 constraint types (Exact, Pattern, Range, OneOf,
   NotOneOf, Contains, Subset, Regex, Wildcard, All, Any, Not, CEL) with
@@ -76,9 +76,12 @@ specification:
   §7: structural validation → root verification (3a-3n) → link
   verification (4a-4s) → depth match → leaf constraint check → PoP
   verification → verdict.
-- **49 tests** covering constraint checks, subsumption cross-types,
-  issuance, derivation, PoP round-trips, and full chain verification
-  scenarios.
+- **Tests** covering constraint checks, subsumption cross-types, issuance,
+  derivation, PoP round-trips, and full chain verification scenarios.
+
+The companion CWT integer claim-key mapping is still pending. This package is
+therefore substantial and runnable, but it is not a claim of complete support
+for every AAT serialization profile.
 
 ```bash
 cd go && go test ./pkg/aat/... -v   # full AAT test suite

--- a/site/content/what-works-now.md
+++ b/site/content/what-works-now.md
@@ -15,7 +15,7 @@ Ardur is pre-release, but the public repo is code-bearing today.
 
 | Surface | Current state | Primary source |
 |---|---|---|
-| Runtime governance | Python and Go runtime imports, mission passport issuance, verification, receipt paths, governance checks, AAT credential-attenuation engine (constraints, derivation, PoP, chain verification) | {{< repo-link "python/README.md" "Python" >}}, {{< repo-link "go/README.md" "Go" >}} |
+| Runtime governance | Configured Python proxy and adapter paths for mission passport issuance, policy decisions, and issuer-signed/hash-linked receipts; Go JWT AAT constraints, derivation, PoP, and chain verification with CWT mapping still pending | {{< repo-link "python/README.md" "Python" >}}, {{< repo-link "go/README.md" "Go" >}} |
 | CLI | Protocol and Personal commands including `issue`, `verify`, `attest`, `start`, `hub`, `setup`, `status`, `doctor`, `doctor-claude-code`, `run`, `profile init`, `protect claude-code`, `claude-code-hook`, and `claude-code-report` | {{< repo-link "docs/reference/cli.md" "CLI reference" >}} |
 | Ardur Personal | Local Hub service, browser extension, desktop observe adapter, native messaging host | {{< repo-link "docs/guides/ardur-personal-hub.md" "Personal Hub guide" >}} |
 | Claude Code | Plugin and hooks for `PreToolUse`, `PostToolUse`, `SubagentStart`, `SubagentStop`; source-checkout MVP quickstart with no-key harness, demo packet, evidence-bundle reader, and live-Claude path | {{< repo-link "docs/guides/claude-code-mvp-quickstart.md" "MVP quickstart" >}}, {{< repo-link "docs/guides/phase1-demo-packet.md" "Demo packet" >}}, {{< repo-link "docs/guides/read-phase1-evidence-bundle.md" "Evidence bundle guide" >}}, {{< repo-link "plugins/claude-code/README.md" "Plugin README" >}} |
@@ -23,6 +23,11 @@ Ardur is pre-release, but the public repo is code-bearing today.
 | Protocol docs | Mission Declaration, Delegation Grant, Execution Receipt, EAT profile, Verifier Contract, conformance profiles, IDM extension, revocation | {{< repo-link "docs/specs/README.md" "Specs index" >}} |
 | Cloud model tests | Real-world governance harnesses for live LLM tool calls through the Ardur proxy; raw per-model fixtures are not shipped in the redacted public tree. Aggregate report path: `python/tests/comprehensive_test_report.json` | {{< repo-link "python/tests/run_cloud_model_test.py" "Run harness" >}} |
 | CI and public hygiene | Python 3.10 and 3.13, Go, CodeQL, link-check, secret-scan, format validation, Hugo build | {{< repo-link ".github/workflows/tests.yml" "Tests workflow" >}} |
+
+These are configured-boundary claims. They do not imply visibility into calls
+that bypass an adapter, provider-hidden behavior, or side effects below a tool
+request. Receipt verification proves the configured issuer signature and hash
+linkage; independent third-party witnessing remains roadmap work.
 
 ## Bounded Or In Progress
 
@@ -36,6 +41,12 @@ evidence path is the no-key JSON bundle, not these archival casts.
 {{< proof-status state="hold" label="Not a packaged production release" source="STATUS.md" >}}
 PyPI/Homebrew/OCI distribution, broader cluster deployment material, and
 rerunnable public proof media are still being hardened.
+{{< /proof-status >}}
+
+{{< proof-status state="hold" label="Linux enforcement is a gated development surface" source="docs/coverage-map.md" >}}
+The repository contains privileged Linux BPF-LSM and seccomp proof harnesses
+with live CI. They are not the cross-platform first-run claim, a production
+kernel agent, or evidence that macOS and Windows have equivalent enforcement.
 {{< /proof-status >}}
 
 Primary status source: {{< repo-link "STATUS.md" >}}.

--- a/site/data/claims.json
+++ b/site/data/claims.json
@@ -1,6 +1,29 @@
 {
   "claims": [
     {
+      "id": "configured-tool-boundary",
+      "title": "Ardur governs calls observed at a configured tool boundary",
+      "body": "When a supported adapter or proxy routes a tool request through Ardur, the runtime evaluates the request before that integration dispatches it and emits an issuer-signed, hash-linked receipt. This is a configured-boundary claim: it does not establish universal capture, third-party witnessing, provider-hidden behavior, or side effects below the tool call.",
+      "evidence_level": "code-and-doc",
+      "maturity": "public-now",
+      "claim_type": "runtime-boundary",
+      "surface": ["docs", "python", "scripts"],
+      "framework": ["framework-agnostic", "claude-code"],
+      "source_paths": [
+        "README.md",
+        "STATUS.md",
+        "docs/coverage-map.md",
+        "docs/known-limitations.md",
+        "docs/guides/claude-code-mvp-quickstart.md",
+        "scripts/run-claude-deny-demo.py",
+        "python/vibap/claude_code_hook.py",
+        "python/vibap/proxy.py",
+        "python/vibap/receipt.py",
+        "python/tests/test_claude_deny_demo.py",
+        "python/tests/test_claude_code_hook.py"
+      ]
+    },
+    {
       "id": "mission-boundary",
       "title": "Mission boundaries are the product center",
       "body": "Ardur binds agent sessions to declared missions and makes runtime decisions over tools, resources, flat runtime budgets, and delegation reservations. Mission-declared lineage_budgets are a v0.1 protocol goal, not a current runtime claim: non-empty lineage_budgets fail closed at compile/issue time until compiler/verifier support lands.",

--- a/site/scripts/validate_claims.py
+++ b/site/scripts/validate_claims.py
@@ -14,6 +14,28 @@ SITE_ROOT = REPO_ROOT / "site"
 CLAIMS_PATH = SITE_ROOT / "data" / "claims.json"
 CONTENT_ROOT = SITE_ROOT / "content"
 
+REQUIRED_BOUNDARY_CLAIM_ID = "configured-tool-boundary"
+PUBLIC_FRAMING_PATHS = (
+    Path("README.md"),
+    Path("STATUS.md"),
+    Path("go/README.md"),
+    Path("site/content/_index.md"),
+    Path("site/content/build/python-go.md"),
+    Path("site/content/get-started.md"),
+    Path("site/content/how-it-works.md"),
+    Path("site/content/proof.md"),
+)
+FORBIDDEN_PUBLIC_PHRASES = (
+    "blocks anything outside that boundary",
+    "proof of every decision",
+    "no bypass, no direct access",
+    "the agent never touches resources it shouldn't",
+    "captures every claude code tool-call invocation",
+    "complete implementation of the attenuating authorization token",
+    "every single tool call went through ardur first",
+    "every `permit` was correct",
+)
+
 REQUIRED_FIELDS = {
     "id",
     "title",
@@ -23,7 +45,7 @@ REQUIRED_FIELDS = {
     "claim_type",
     "surface",
     "framework",
-    "source_paths"
+    "source_paths",
 }
 
 ALLOWED_MATURITY = {"public-now", "in-progress", "not-public-yet"}
@@ -32,7 +54,7 @@ ALLOWED_EVIDENCE_LEVEL = {
     "code-and-doc",
     "doc-and-manifest",
     "limitation-backed",
-    "spec"
+    "spec",
 }
 
 
@@ -60,7 +82,9 @@ def validate_claim(claim: dict[str, object], seen: set[str]) -> str:
         fail(f"claim is missing required fields: {', '.join(missing)}")
 
     claim_id = claim["id"]
-    if not isinstance(claim_id, str) or not re.fullmatch(r"[a-z0-9][a-z0-9-]+", claim_id):
+    if not isinstance(claim_id, str) or not re.fullmatch(
+        r"[a-z0-9][a-z0-9-]+", claim_id
+    ):
         fail(f"invalid claim id: {claim_id!r}")
     if claim_id in seen:
         fail(f"duplicate claim id: {claim_id}")
@@ -100,6 +124,17 @@ def validate_claim(claim: dict[str, object], seen: set[str]) -> str:
     return claim_id
 
 
+def validate_public_framing(seen: set[str]) -> None:
+    if REQUIRED_BOUNDARY_CLAIM_ID not in seen:
+        fail(f"missing required boundary claim: {REQUIRED_BOUNDARY_CLAIM_ID}")
+
+    for relative_path in PUBLIC_FRAMING_PATHS:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8").lower()
+        for phrase in FORBIDDEN_PUBLIC_PHRASES:
+            if phrase in text:
+                fail(f"{relative_path}: forbidden public overclaim phrase: {phrase!r}")
+
+
 def main() -> int:
     seen: set[str] = set()
     claims = load_claims()
@@ -107,6 +142,7 @@ def main() -> int:
         if not isinstance(claim, dict):
             fail("every claim entry must be an object")
         validate_claim(claim, seen)
+    validate_public_framing(seen)
 
     print(f"validated {len(claims)} public-site claims")
     return 0


### PR DESCRIPTION
## Summary

- scope first-screen governance claims to tool requests observed through configured Ardur adapters or proxies
- distinguish issuer-signature/hash-link verification from independent third-party witnessing and below-boundary process/kernel evidence
- replace the stale README test/model snapshot with the reviewed current verification matrix
- reconcile the Go AAT status as a substantial JWT implementation with CWT integer-key mapping still pending
- add a source-backed configured-boundary claim and fail the site validator if known overclaim phrases return

## Key corrections

- removed universal “blocks anything / proof of every decision / no bypass” language
- replaced the stale 581-test and unverifiable historical model-result presentation
- replaced the stale site API quickstart with the tested no-key demo
- updated the Proof page to current rerunnable local and CI evidence
- corrected contradictory AAT “complete” versus “skeleton” descriptions

## Validation

- focused public-path tests: 10 passed
- Go AAT package: passed; current JSON stream reports 57 passing test cases
- public claims: 10 validated
- claim-validator negative control: forbidden phrase rejected with exit 1
- source-backed docs: 87 Hugo pages and 46 mirrored artifacts verified
- Hugo 0.161.1: 246 pages built
- rendered documentation links and source provenance: passed
- Ruff check/format: passed

## Boundary

This PR changes documentation and claim validation only. Runtime enforcement behavior is unchanged. The safe public claim is configured local tool-boundary governance with issuer-signed evidence, not universal capture, third-party attestation, or production cross-platform kernel enforcement.

Closes #149
Closes #150