### PR TITLE
fix(codeql): document intentional retry and cleanup paths

### DIFF
--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -13,7 +13,6 @@ import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
-import vibap.claude_code_hook as claude_code_hook
 from vibap.claude_code_hook import (
     ChainState,
     append_receipt,
@@ -201,7 +200,9 @@ def test_empty_vibap_home_falls_back_to_default_home(tmp_path, monkeypatch):
     monkeypatch.setenv("VIBAP_HOME", "")  # explicit empty string
     # Other tests may materialize the process-level default under the repo
     # CWD. Give this fallback assertion an empty default home of its own.
-    monkeypatch.setattr(claude_code_hook, "DEFAULT_HOME", tmp_path / "default-home")
+    monkeypatch.setattr(
+        "vibap.claude_code_hook.DEFAULT_HOME", tmp_path / "default-home"
+    )
 
     with pytest.raises(MissionLoadError) as exc_info:
         load_active_passport(keys_dir=tmp_path)

--- a/python/vibap/claude_code_daemon.py
+++ b/python/vibap/claude_code_daemon.py
@@ -678,6 +678,7 @@ def _copy_to_destination_staging_file(
             try:
                 staged.unlink()
             except FileNotFoundError:
+                # Another cleanup path already established the desired absence.
                 pass
         raise
 
@@ -706,6 +707,7 @@ def _remove_staging_file(path: Path | None) -> None:
     try:
         path.unlink()
     except FileNotFoundError:
+        # Staging cleanup is intentionally idempotent.
         pass
 
 
@@ -716,6 +718,7 @@ def _restore_destination(path: Path, *, existed: bool, backup: Path | None) -> N
         try:
             path.unlink()
         except FileNotFoundError:
+            # A missing destination already matches the pre-transaction state.
             pass
 
 

--- a/scripts/run-no-key-mvp-demo.py
+++ b/scripts/run-no-key-mvp-demo.py
@@ -128,6 +128,7 @@ def wait_for_health(
                 if response.status == 200 and payload.get("status") == "ok":
                     return
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+            # Startup races are expected; the bounded loop raises at the deadline.
             pass
         time.sleep(0.1)
     raise DemoError(


### PR DESCRIPTION
## Summary

- remove the duplicate `import` / `from import` pattern for `vibap.claude_code_hook`
- document the bounded startup retry in the no-key demo
- document three idempotent native-hook staging cleanup handlers where missing files already satisfy the intended state
- preserve runtime behavior while making intentional exception handling reviewable

## Live alerts

Targets current `dev` CodeQL alerts:

- [#243](https://github.com/ArdurAI/ardur/security/code-scanning/243) - `py/import-and-import-from`
- [#244](https://github.com/ArdurAI/ardur/security/code-scanning/244) - bounded health retry
- [#245](https://github.com/ArdurAI/ardur/security/code-scanning/245) - transactional staging cleanup
- [#246](https://github.com/ArdurAI/ardur/security/code-scanning/246) - idempotent staging removal
- [#247](https://github.com/ArdurAI/ardur/security/code-scanning/247) - rollback to an absent destination

## Validation

- focused no-key demo, native daemon install, and complete Claude hook tests: 68 passed
- Ruff 0.13.0 checks pass on both production files
- Ruff check passes on the modified test with unrelated pre-existing E741 excluded
- quick shell, JSON, YAML, schema, public-term, and model-name checks pass
- `git diff --check` passes

## Scope

No user-facing behavior changes, so README does not require an update. Existing whole-file formatter drift reproduces on untouched HEAD versions of the daemon and large hook test; this PR avoids a broad unrelated reformat.