### PR TITLE
test: keep Python suite out of source tree

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,21 @@ jobs:
         timeout-minutes: 15
         env:
           PYTHONFAULTHANDLER: "1"
-        run: python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml
+          COVERAGE_FILE: ${{ runner.temp }}/ardur-coverage
+        run: python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml:${{ runner.temp }}/ardur-coverage-report.xml
+
+      - name: Require pytest to leave the checkout clean
+        run: |
+          worktree_status="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$worktree_status" ]; then
+            printf '%s\n' "$worktree_status"
+            exit 1
+          fi
 
       - name: Show coverage summary
         working-directory: python
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/ardur-coverage
         run: |
           python -m coverage report --fail-under=0
           echo "::notice:: Aspirational targets: vibap=80%%, cli=60%%, integrations=70%%"
@@ -93,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-coverage-${{ matrix.python-version }}
-          path: python/coverage.xml
+          path: ${{ runner.temp }}/ardur-coverage-report.xml
           if-no-files-found: warn
           retention-days: 14
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,10 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
   tree, it includes `python/tests/test_examples_smoke.py` for the offline,
   no-key examples smoke. That test covers checked-in mission fixtures and the
   examples claim ledger; it does **not** prove live-provider framework demos.
+  The job then fails if pytest changed tracked files or left untracked files in
+  the checkout; runtime keys, tokens, hooks, and reports belong in pytest temp
+  directories unless a test explicitly directs output elsewhere. Coverage data
+  and the uploaded XML report are written to the GitHub runner temp directory.
 - **Go job**: runs `go test -count=1 ./...` and `go vet ./...` from `go/`.
 - **Demo stack smoke**: starts the exact `make demo` target from fresh Compose
   volumes in detached/wait mode, then runs `scripts/verify-mvp.sh`. The job

--- a/python/tests/test_ardur_comprehensive_integration.py
+++ b/python/tests/test_ardur_comprehensive_integration.py
@@ -45,13 +45,6 @@ from vibap.tls import generate_self_signed_cert
 CLOUD_MODEL = os.environ.get("ARDUR_OLLAMA_CLOUD_MODEL", "")
 API_KEY = os.environ.get("ARDUR_OLLAMA_API_KEY", "")
 
-TEST_REPORT_PATH = Path(
-    os.environ.get(
-        "ARDUR_COMPREHENSIVE_REPORT",
-        str(Path(__file__).resolve().parent / "comprehensive_test_report.json"),
-    )
-)
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
@@ -299,6 +292,12 @@ class TestArdurComprehensive:
     def test_full_ardur_protocol_composition(
         self, module_keys, tls_material, biscuit_keypair, tmp_path
     ):
+        report_path = Path(
+            os.environ.get(
+                "ARDUR_COMPREHENSIVE_REPORT",
+                str(tmp_path / "comprehensive_test_report.json"),
+            )
+        )
         private_key, public_key, keys_dir = module_keys
         tls_key, tls_cert, tls_fingerprint = tls_material
         report = ScenarioReport()
@@ -414,8 +413,8 @@ class TestArdurComprehensive:
 
         finally:
             report_data = report.finalize(env_info)
-            TEST_REPORT_PATH.write_text(json.dumps(report_data, indent=2), encoding="utf-8")
-            print(f"\nComprehensive report → {TEST_REPORT_PATH}")
+            report_path.write_text(json.dumps(report_data, indent=2), encoding="utf-8")
+            print(f"\nComprehensive report → {report_path}")
 
         failed = [s for s in report_data["scenarios"] if not s["passed"]]
         assert not failed, (

--- a/python/tests/test_cli_failure_json.py
+++ b/python/tests/test_cli_failure_json.py
@@ -1889,13 +1889,18 @@ def test_protect_claude_code_empty_home_returns_invalid(tmp_path, capsys, home):
         assert str(tmp_path) not in step.get("detail", "")
 
 
-def test_protect_claude_code_explicit_dot_home_still_succeeds(tmp_path, capsys):
+def test_protect_claude_code_explicit_dot_home_still_succeeds(
+    tmp_path, capsys, monkeypatch
+):
     """Explicit ``--home .`` (current working directory) remains valid and must
     not be rejected by the empty/whitespace guard. Only empty/whitespace-only
     strings are rejected; an explicit ``.`` is a deliberate CWD choice.
     """
     project = tmp_path / "project"
     project.mkdir()
+    runtime_dir = tmp_path / "runtime-cwd"
+    runtime_dir.mkdir()
+    monkeypatch.chdir(runtime_dir)
     rc, payload = _run_cli_and_read_json(
         [
             "protect",
@@ -1913,6 +1918,10 @@ def test_protect_claude_code_explicit_dot_home_still_succeeds(tmp_path, capsys):
 
     assert rc == 0
     assert payload["ok"] is True
+    assert (runtime_dir / "active_mission.jwt").is_file()
+    assert (runtime_dir / "claude-code-pre_tool_use").is_file()
+    assert (runtime_dir / "keys" / "passport_private.pem").is_file()
+    assert (runtime_dir / "keys" / "passport_public.pem").is_file()
 
 
 def test_protect_claude_code_home_regular_file_returns_invalid(tmp_path, capsys):

--- a/site/content/source/docs/TESTING.md
+++ b/site/content/source/docs/TESTING.md
@@ -2,7 +2,7 @@
 title: "Testing"
 description: "The public tree includes curated Python and Go runtime code under `python/`"
 source_path: "docs/TESTING.md"
-source_sha256: "0664ec87f2290202a1767be4b669ec0ffa53bcc389b5086e5a21e4cf3f9e52c4"
+source_sha256: "0f744eb35d40c00e2cc5802804cf0425e4d7ff9a77049a4d032a2ffeee1a58b4"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -69,6 +69,10 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
   tree, it includes `python/tests/test_examples_smoke.py` for the offline,
   no-key examples smoke. That test covers checked-in mission fixtures and the
   examples claim ledger; it does **not** prove live-provider framework demos.
+  The job then fails if pytest changed tracked files or left untracked files in
+  the checkout; runtime keys, tokens, hooks, and reports belong in pytest temp
+  directories unless a test explicitly directs output elsewhere. Coverage data
+  and the uploaded XML report are written to the GitHub runner temp directory.
 - **Go job**: runs `go test -count=1 ./...` and `go vet ./...` from `go/`.
 - **Demo stack smoke**: starts the exact `make demo` target from fresh Compose
   volumes in detached/wait mode, then runs `scripts/verify-mvp.sh`. The job

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -80,10 +80,21 @@ jobs:
         timeout-minutes: 15
         env:
           PYTHONFAULTHANDLER: "1"
-        run: python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml
+          COVERAGE_FILE: ${{ runner.temp }}/ardur-coverage
+        run: python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml:${{ runner.temp }}/ardur-coverage-report.xml
+
+      - name: Require pytest to leave the checkout clean
+        run: |
+          worktree_status="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$worktree_status" ]; then
+            printf '%s\n' "$worktree_status"
+            exit 1
+          fi
 
       - name: Show coverage summary
         working-directory: python
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/ardur-coverage
         run: |
           python -m coverage report --fail-under=0
           echo "::notice:: Aspirational targets: vibap=80%%, cli=60%%, integrations=70%%"
@@ -93,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-coverage-${{ matrix.python-version }}
-          path: python/coverage.xml
+          path: ${{ runner.temp }}/ardur-coverage-report.xml
           if-no-files-found: warn
           retention-days: 14
 


### PR DESCRIPTION
## Summary

- isolate the explicit `--home .` protect test in a pytest temporary working directory while asserting its expected JWT, hook, and key artifacts
- write the comprehensive integration report to `tmp_path` by default while preserving the explicit `ARDUR_COMPREHENSIVE_REPORT` override
- move coverage data/XML to runner temp storage and fail the Python job when pytest leaves tracked or untracked checkout changes
- keep the published workflow mirror and testing documentation in sync

## Verification

- `python -m pytest tests/ -q --tb=short --durations=20 --cov=vibap --cov-report=term --cov-report=xml:<tmp>/ardur-coverage-report.xml`: 1,363 passed, 32 skipped, 85% coverage
- focused writer and comprehensive tests: 2 passed
- workflow mirror contract: passed
- canonical and mirrored workflow YAML: parsed successfully
- exact post-test `git status --porcelain --untracked-files=all` gate: clean in bash and zsh
- `python/tests/comprehensive_test_report.json`: unchanged

Closes #215