### PR TITLE
fix(run-bridge): keep health response identifier-free

### DIFF
--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -17,6 +17,7 @@ import socket
 import sys
 import tempfile
 import threading
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -204,6 +205,30 @@ def _live_kernel_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, sockdir: P
     socket_path = sockdir / "daemon.sock"
     monkeypatch.setenv(kc.DAEMON_SOCKET_ENV, str(socket_path))
     return socket_path
+
+
+def test_embedded_server_health_does_not_disclose_session_id() -> None:
+    server = run_bridge._build_embedded_server(
+        proxy=object(),
+        session_id="sensitive-session-id",
+        api_token="api-token",
+        private_key=object(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+
+    try:
+        for path in ("/health", "/healthz"):
+            with urllib.request.urlopen(  # noqa: S310 - loopback test server
+                f"http://{host}:{port}{path}", timeout=2
+            ) as response:
+                assert response.status == 200
+                assert json.load(response) == {"status": "ok"}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 def test_ardur_run_governs_launched_agent_zero_setup(

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -286,7 +286,7 @@ def _build_embedded_server(
 
         def do_GET(self) -> None:  # noqa: N802
             if self.path.split("?", 1)[0] in {"/health", "/healthz"}:
-                self._send(200, {"status": "ok", "session_id": session_id})
+                self._send(200, {"status": "ok"})
                 return
             self._send(404, {"error": "not found"})
 


### PR DESCRIPTION
## Summary
- remove the governance session identifier from unauthenticated `/health` and `/healthz` responses
- preserve the minimal status-only liveness contract used by the launcher
- cover both health aliases through the real loopback HTTP handler

Closes #87

## Validation
- `1364 passed, 32 skipped` (`python/tests/`)
- `53 passed` (`python/tests/test_run_bridge.py`)
- focused Ruff check on the changed test
- `git diff --check`
- source-tree cleanliness verified with `git status --porcelain --untracked-files=all`

## Notes
- Full-file Ruff also reports the pre-existing undefined forward reference `MissionPassport` at `python/vibap/run_bridge.py:626`; this PR does not alter that line.