### PR TITLE
fix(run-bridge): gate target exec on kernel registration

### DIFF
--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 from argparse import Namespace
 import json
+import os
 import shutil
 import socket
+import subprocess
 import sys
 import tempfile
 import threading
@@ -567,6 +569,132 @@ def test_wrap_command_with_seccomp_shim_builds_expected_argv(monkeypatch: pytest
         "claude",
         "--foo",
     ]
+
+
+def test_wrap_command_with_launch_gate_builds_expected_argv() -> None:
+    assert run_bridge._wrap_command_with_launch_gate(["agent", "--flag"], ready_fd=17) == [
+        sys.executable,
+        "-I",
+        str(Path(run_bridge.__file__).with_name("launch_gate.py")),
+        "--ready-fd",
+        "17",
+        "--",
+        "agent",
+        "--flag",
+    ]
+
+
+def test_launch_gate_fails_closed_when_parent_does_not_release(tmp_path: Path) -> None:
+    marker = tmp_path / "target-ran"
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        run_bridge._wrap_command_with_launch_gate(
+            [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"],
+            ready_fd=read_fd,
+        ),
+        pass_fds=(read_fd,),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    os.close(read_fd)
+    os.close(write_fd)
+
+    _stdout, stderr = proc.communicate(timeout=5)
+    assert proc.returncode == 125
+    assert b"parent exited before releasing target" in stderr
+    assert not marker.exists()
+
+
+def test_launch_gate_ignores_project_local_module_shadow(tmp_path: Path) -> None:
+    shadow_marker = tmp_path / "shadow-ran"
+    target_marker = tmp_path / "target-ran"
+    shadow_package = tmp_path / "vibap"
+    shadow_package.mkdir()
+    (shadow_package / "__init__.py").write_text("", encoding="utf-8")
+    (shadow_package / "launch_gate.py").write_text(
+        f"from pathlib import Path\nPath({str(shadow_marker)!r}).touch()\n",
+        encoding="utf-8",
+    )
+
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        run_bridge._wrap_command_with_launch_gate(
+            [sys.executable, "-c", f"from pathlib import Path; Path({str(target_marker)!r}).touch()"],
+            ready_fd=read_fd,
+        ),
+        cwd=tmp_path,
+        pass_fds=(read_fd,),
+    )
+    os.close(read_fd)
+    os.write(write_fd, b"\x01")
+    os.close(write_fd)
+
+    assert proc.wait(timeout=5) == 0
+    assert target_marker.is_file()
+    assert not shadow_marker.exists()
+
+
+def test_ardur_run_gates_target_through_registration_and_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = tmp_path / "target-ran"
+    target = tmp_path / "target.py"
+    target.write_text(
+        f"import os\nfrom pathlib import Path\nPath({str(marker)!r}).write_text(str(os.getpid()))\n",
+        encoding="utf-8",
+    )
+    cgroup_path = tmp_path / "run-cgroup"
+    cgroup_path.mkdir()
+
+    class FakeCgroup:
+        cgroup_id = 4242
+        path = cgroup_path
+        adopted_pid: int | None = None
+        cleaned = False
+
+        def adopt_pid(self, pid: int) -> None:
+            self.adopted_pid = pid
+
+        def cleanup(self) -> None:
+            self.cleaned = True
+
+    fake_cgroup = FakeCgroup()
+    monkeypatch.setattr(kc, "create_run_cgroup", lambda _session_id: fake_cgroup)
+    monkeypatch.setattr(
+        run_bridge,
+        "_plan_seccomp_shim",
+        lambda *, enabled: SeccompShimPlan(tier=kc.ENFORCEMENT_TIER_BPF_LSM, wrapped=False),
+    )
+
+    def correlate(**kwargs: object) -> kc.CorrelationResult:
+        assert fake_cgroup.adopted_pid == kwargs["pid"]
+        assert not marker.exists(), "target executed before daemon registration completed"
+        return kc.CorrelationResult(
+            available=True,
+            reason="test registration complete",
+            method="test",
+            cgroup_id=fake_cgroup.cgroup_id,
+            cgroup_path=str(fake_cgroup.path),
+        )
+
+    def apply_policy(**_kwargs: object) -> dict[str, object]:
+        assert not marker.exists(), "target executed before BPF policy application completed"
+        return {"applied": True, "reason": "test policy applied"}
+
+    monkeypatch.setattr(run_bridge, "_correlate_launch", correlate)
+    monkeypatch.setattr(run_bridge, "_apply_kernel_policy", apply_policy)
+
+    result = run_governed(
+        command=[sys.executable, str(target)],
+        mission="Gate target exec through kernel registration.",
+        home=tmp_path / "gate-home",
+        via="env",
+    )
+
+    assert result.exit_code == 0
+    assert marker.is_file()
+    assert int(marker.read_text(encoding="utf-8")) == fake_cgroup.adopted_pid
+    assert fake_cgroup.cleaned is True
 
 
 def test_verify_seccomp_listener_attached_true(monkeypatch: pytest.MonkeyPatch, sockdir: Path) -> None:

--- a/python/vibap/launch_gate.py
+++ b/python/vibap/launch_gate.py
@@ -1,0 +1,52 @@
+"""PID-preserving pre-exec gate for ``ardur run`` kernel registration."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+RELEASE_BYTE = b"\x01"
+PARENT_NOT_READY_EXIT = 125
+
+
+def _parse_args(argv: list[str]) -> tuple[int, list[str]]:
+    parser = argparse.ArgumentParser(description="wait for Ardur registration, then exec a command")
+    parser.add_argument("--ready-fd", type=int, required=True, help=argparse.SUPPRESS)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        parser.error("a command is required after --")
+    return args.ready_fd, command
+
+
+def main(argv: list[str] | None = None) -> int:
+    ready_fd, command = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    try:
+        release = os.read(ready_fd, 1)
+    except OSError as exc:
+        print(f"ardur launch gate: parent readiness channel failed: {exc}", file=sys.stderr)
+        return PARENT_NOT_READY_EXIT
+    finally:
+        try:
+            os.close(ready_fd)
+        except OSError:
+            pass
+
+    if release != RELEASE_BYTE:
+        print("ardur launch gate: parent exited before releasing target", file=sys.stderr)
+        return PARENT_NOT_READY_EXIT
+
+    try:
+        os.execvpe(command[0], command, os.environ)
+    except OSError as exc:
+        print(f"ardur launch gate: exec {command[0]!r} failed: {exc}", file=sys.stderr)
+        return 126
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from . import kernel_correlation as kc
+from .launch_gate import RELEASE_BYTE as LAUNCH_GATE_RELEASE_BYTE
 from .package_assets import claude_code_plugin_dir
 
 # Environment-variable contract the bridge exports to the launched agent. The
@@ -582,6 +583,31 @@ def _wrap_command_with_seccomp_shim(
     ]
 
 
+def _wrap_command_with_launch_gate(command: list[str], *, ready_fd: int) -> list[str]:
+    """Block the target exec until cgroup adoption and registration finish.
+
+    The gate process is the child returned by ``Popen``. It retains that PID
+    when it eventually execs ``command``, so the cgroup and daemon registration
+    continue to identify the governed root process after release.
+    """
+    return [
+        sys.executable,
+        "-I",
+        str(Path(__file__).with_name("launch_gate.py")),
+        "--ready-fd",
+        str(ready_fd),
+        "--",
+        *command,
+    ]
+
+
+def _release_launch_gate(ready_fd: int) -> None:
+    try:
+        os.write(ready_fd, LAUNCH_GATE_RELEASE_BYTE)
+    finally:
+        os.close(ready_fd)
+
+
 # Module-level so tests can monkeypatch a short timeout rather than either
 # waiting out the real budget or threading an override through
 # run_governed's public signature for a purely internal verification detail.
@@ -826,6 +852,8 @@ def run_governed(
     # exception is raised before kernel correlation is attempted below.
     correlation = kc.CorrelationResult(available=False, reason="run did not reach kernel correlation")
     seccomp_ready_file: Path | None = None
+    launch_gate_read_fd: int | None = None
+    launch_gate_write_fd: int | None = None
     try:
         _wait_for_health(proxy_url, api_token)
 
@@ -870,14 +898,31 @@ def run_governed(
         if enable_kernel_correlation:
             cgroup_handle = kc.create_run_cgroup(session_id)
 
+        # A child PID does not exist until Popen returns, but an ordinary target
+        # can exec before that PID is adopted into the cgroup and registered
+        # with the daemon. Launch a tiny inherited-FD gate as the child whenever
+        # a cgroup exists; exec preserves its PID after the parent releases it.
+        popen_extra: dict[str, Any] = {}
+        if cgroup_handle is not None:
+            launch_gate_read_fd, launch_gate_write_fd = os.pipe()
+            run_command = _wrap_command_with_launch_gate(run_command, ready_fd=launch_gate_read_fd)
+            popen_extra["pass_fds"] = (launch_gate_read_fd,)
+
         # 5. Launch the agent.
-        proc = subprocess.Popen(
-            run_command,
-            env=run_env,
-            cwd=str(work_dir),
-            stdout=stdout,
-            stderr=stderr,
-        )
+        try:
+            proc = subprocess.Popen(
+                run_command,
+                env=run_env,
+                cwd=str(work_dir),
+                stdout=stdout,
+                stderr=stderr,
+                **popen_extra,
+            )
+        finally:
+            if launch_gate_read_fd is not None:
+                with suppress(OSError):
+                    os.close(launch_gate_read_fd)
+                launch_gate_read_fd = None
 
         if cgroup_handle is not None:
             try:
@@ -906,6 +951,13 @@ def run_governed(
             with suppress(OSError):
                 seccomp_ready_file.touch()
 
+        # The seccomp shim must run before _apply_kernel_policy can verify its
+        # listener handoff. Other tiers stay gated through policy application,
+        # eliminating both the registration race and a target-vs-policy race.
+        if seccomp_plan.wrapped and launch_gate_write_fd is not None:
+            _release_launch_gate(launch_gate_write_fd)
+            launch_gate_write_fd = None
+
         # 5b. Push the mission's lowered BPF policy to the daemon now that the
         # cgroup is registered. Under --enforce a failure here kills the agent
         # and aborts the run; under permissive it degrades to a recorded note.
@@ -924,6 +976,10 @@ def run_governed(
             raise
         if not kernel_policy["applied"]:
             notes.append(kernel_policy["reason"])
+
+        if launch_gate_write_fd is not None:
+            _release_launch_gate(launch_gate_write_fd)
+            launch_gate_write_fd = None
 
         # 6. Wait for the agent to exit (bounded by the mission duration budget).
         try:
@@ -957,6 +1013,10 @@ def run_governed(
         if seccomp_ready_file is not None:
             with suppress(OSError):
                 seccomp_ready_file.unlink()
+        for fd in (launch_gate_read_fd, launch_gate_write_fd):
+            if fd is not None:
+                with suppress(OSError):
+                    os.close(fd)
         server.shutdown()
         server.server_close()
 

--- a/scripts/validate-python-distribution.py
+++ b/scripts/validate-python-distribution.py
@@ -38,6 +38,7 @@ PLUGIN_ASSETS = (
     PurePosixPath("hooks/subagent_start"),
     PurePosixPath("hooks/subagent_stop"),
 )
+REQUIRED_RUNTIME_FILES = (PurePosixPath("vibap/launch_gate.py"),)
 
 
 class DistributionValidationError(ValueError):
@@ -167,6 +168,8 @@ def validate_wheel(wheel_path: Path, expected_version: str) -> None:
             PurePosixPath("vibap/_specs/mission_declaration_v01.schema.json") in names,
             "wheel does not contain the embedded mission schema",
         )
+        for runtime_file in REQUIRED_RUNTIME_FILES:
+            require(runtime_file in names, f"wheel is missing runtime file: {runtime_file}")
         expected_plugin_files = plugin_files()
         plugin_root = PurePosixPath("vibap/_plugins/claude-code")
         actual_plugin_files = {
@@ -224,6 +227,12 @@ def validate_sdist(sdist_path: Path, expected_version: str) -> None:
             require(
                 path in names and names[path].isfile(),
                 f"sdist is missing {relative_path}",
+            )
+        for runtime_file in REQUIRED_RUNTIME_FILES:
+            path = root / runtime_file
+            require(
+                path in names and names[path].isfile(),
+                f"sdist is missing runtime file: {runtime_file}",
             )
         require(
             read_required(archive.extractfile(names[root / "LICENSE"]), "sdist LICENSE")


### PR DESCRIPTION
## Summary
- launch cgroup-backed runs through a PID-preserving inherited-pipe gate
- keep the governed target blocked until cgroup adoption and daemon registration complete
- keep BPF-LSM targets blocked through policy application; preserve seccomp shim handoff ordering
- execute the reviewed gate file with isolated Python startup so an untrusted project CWD cannot shadow it
- fail closed when the parent exits without an exact release byte
- require the gate in both wheel and sdist publication validation

Closes #85

## Security/correctness properties
- `Popen` returns the gate PID; `exec` preserves that PID for the target
- no target code runs inside registration or BPF policy-application callbacks
- parent-channel EOF exits 125 without target execution
- project-local `vibap.launch_gate` shadow packages are ignored

## Validation
- clean worktree-local Python 3.13 venv on EXTENDED
- `1368 passed, 32 skipped`, 85% total coverage
- `57 passed` (`tests/test_run_bridge.py`)
- 4 focused launch-gate tests
- real sdist/wheel build and distribution validator
- Ruff on all changed Python surfaces (with the known pre-existing `MissionPassport` F821 excluded only for full `run_bridge.py`)
- `git diff --check` and source-tree cleanliness