### PR TITLE
feat(run-bridge): add explicit resource scope roots

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -427,11 +427,11 @@ Legacy Hub streaming remains the default when no governance selector is supplied
 ardur run [--hub-url URL] [--hub-token TOKEN] [--home DIR] -- <command>
 ```
 
-The zero-setup governance bridge is selected when `--mission`,
-`--allowed-tools`, `--forbidden-tools`, `--max-tool-calls`, or `--via` is
-supplied. It issues a temporary Mission Passport, starts an embedded loopback
-governance proxy, launches the command, then prints a governance summary to
-stderr when the command exits:
+The zero-setup governance bridge is selected when any governance option is
+supplied, including the mission/tool flags, kernel flags, or resource-scope
+flags below. It issues a temporary Mission Passport, starts an embedded
+loopback governance proxy, launches the command, then prints a governance
+summary to stderr when the command exits:
 
 ```text
 ardur run [--home DIR]
@@ -442,6 +442,8 @@ ardur run [--home DIR]
           [--max-duration-s N]
           [--via auto|claude-code|env|intercept]
           [--no-kernel-correlation]
+          [--enforce]
+          [--resource-scope PATH ... | --no-resource-scope]
           -- <command>
 ```
 
@@ -457,7 +459,19 @@ cooperating command through environment variables, and `--via intercept` is only
 a scaffolded transparent-intercept path today; it fails closed rather than
 claiming universal CLI capture. `--no-kernel-correlation` disables the
 best-effort kernel/cgroup correlation attempt that may be available on suitable
-Linux hosts.
+Linux hosts. `--enforce` aborts instead of degrading when kernel policy cannot
+be installed.
+
+By default, a governed run scopes file access to the complete governed working
+directory tree. Repeat `--resource-scope PATH` to narrow that scope to one or
+more roots inside the working directory. Relative roots resolve against the
+governed working directory; symlinks are resolved before the inside-directory
+check. Each canonical root produces exact and subtree proxy patterns and is
+also passed to BPF path lowering; the existing kernel-tier and bounded path
+depth limits still apply. Glob patterns and roots outside the working directory
+are rejected before keys or a passport are created. `--no-resource-scope` is
+mutually exclusive with `--resource-scope`; it removes file scope only for a
+mission that is genuinely network-only and relies on the seccomp fallback.
 
 Safe local example:
 

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -969,6 +969,72 @@ def test_run_governed_rejects_unknown_via(tmp_path: Path, monkeypatch: pytest.Mo
         run_governed(command=["true"], via="bogus", home=tmp_path / "h")
 
 
+def test_resolve_run_resource_scope_narrows_relative_roots(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    source = work_dir / "src"
+    source.mkdir(parents=True)
+
+    patterns = run_bridge._resolve_run_resource_scope(
+        work_dir,
+        resource_scope=["src", str(source)],
+        disabled=False,
+    )
+
+    assert patterns == [str(source), f"{source}/*"]
+
+    from vibap.proxy import _check_resource_scope
+
+    assert _check_resource_scope({"file_path": str(source / "main.py")}, patterns, cwd=str(work_dir))[0] is True
+    assert _check_resource_scope({"file_path": str(work_dir / "README.md")}, patterns, cwd=str(work_dir))[0] is False
+
+    from vibap.bpf_lower import lower_to_bpf_policy_plan
+
+    plan = lower_to_bpf_policy_plan(resource_scope=patterns)
+    assert str(source) in plan.path_allow
+
+
+@pytest.mark.parametrize(
+    ("resource_scope", "disabled", "message"),
+    [
+        (["../outside"], False, "inside the governed cwd"),
+        (["src/*"], False, "not glob patterns"),
+        ([], False, "at least one path root"),
+        (["src"], True, "cannot be combined"),
+    ],
+)
+def test_resolve_run_resource_scope_rejects_unsafe_or_ambiguous_inputs(
+    tmp_path: Path,
+    resource_scope: list[str],
+    disabled: bool,
+    message: str,
+) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    with pytest.raises(ValueError, match=message):
+        run_bridge._resolve_run_resource_scope(
+            work_dir,
+            resource_scope=resource_scope,
+            disabled=disabled,
+        )
+
+
+def test_run_governed_rejects_invalid_resource_scope_before_artifacts(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    home = tmp_path / "ardur-home"
+
+    with pytest.raises(ValueError, match="inside the governed cwd"):
+        run_governed(
+            command=["true"],
+            mission="Reject scope escape before setup.",
+            resource_scope=["../outside"],
+            cwd=work_dir,
+            home=home,
+        )
+
+    assert not home.exists()
+
+
 class _FakeSessionStatusDaemon:
     """A one-shot AF_UNIX server that replays a canned session_status response."""
 
@@ -1147,6 +1213,42 @@ def test_run_governed_cli_coerces_unset_numeric_budgets(
     assert captured["max_duration_s"] == (
         DEFAULT_MAX_DURATION_S if unset_field == "max_duration_s" else 123
     )
+
+
+def test_run_governed_cli_passes_explicit_resource_scope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    class Stop(Exception):
+        pass
+
+    def fake_run_governed(**kwargs: object) -> None:
+        captured.update(kwargs)
+        raise Stop
+
+    monkeypatch.setattr("vibap.run_bridge.run_governed", fake_run_governed)
+
+    with pytest.raises(Stop):
+        run_governed_cli(
+            Namespace(
+                command=["--", "true"],
+                mission="scope override smoke",
+                allowed_tools=["Read"],
+                forbidden_tools=None,
+                max_tool_calls=7,
+                max_duration_s=123,
+                home=tmp_path / "h",
+                via="env",
+                no_kernel_correlation=True,
+                enforce=False,
+                resource_scope=["src", "tests"],
+                no_resource_scope=False,
+            )
+        )
+
+    assert captured["resource_scope"] == ["src", "tests"]
+    assert captured["no_resource_scope"] is False
 
 
 @pytest.mark.parametrize("command", ([], ["--"]))
@@ -1368,10 +1470,19 @@ def test_run_dispatch_legacy_vs_governance() -> None:
         ["run", "--mission", "x", "--", "echo"],
         ["run", "--allowed-tools", "Read", "--", "echo"],
         ["run", "--max-tool-calls", "5", "--", "echo"],
+        ["run", "--max-duration-s", "60", "--", "echo"],
         ["run", "--via", "env", "--", "echo"],
+        ["run", "--no-kernel-correlation", "--", "echo"],
+        ["run", "--resource-scope", "src", "--", "echo"],
+        ["run", "--no-resource-scope", "--", "echo"],
     ):
         args = parser.parse_args(argv)
         assert _run_has_governance_intent(args) is True, argv
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["run", "--resource-scope", "src", "--no-resource-scope", "--", "echo"]
+        )
 
 
 # ── run governance budget validation ────────────────────────────────────────────

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -2231,8 +2231,21 @@ def _run_has_governance_intent(args: argparse.Namespace) -> bool:
     """
     return any(
         getattr(args, name, None) not in (None, False)
-        for name in ("mission", "allowed_tools", "forbidden_tools", "via", "govern", "enforce")
-    ) or getattr(args, "max_tool_calls", None) is not None
+        for name in (
+            "mission",
+            "allowed_tools",
+            "forbidden_tools",
+            "via",
+            "govern",
+            "enforce",
+            "no_kernel_correlation",
+            "resource_scope",
+            "no_resource_scope",
+        )
+    ) or any(
+        getattr(args, name, None) is not None
+        for name in ("max_tool_calls", "max_duration_s")
+    )
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -4006,7 +4019,7 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--max-duration-s",
         type=int,
-        default=86400,
+        default=None,
         help="wall-clock budget for the governed run in seconds",
     )
     run.add_argument(
@@ -4026,7 +4039,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="abort the run if kernel-level BPF policy enforcement cannot be installed "
         "(default: permissive — degrade to hook/proxy governance with a recorded note)",
     )
-    run.add_argument(
+    resource_scope_group = run.add_mutually_exclusive_group()
+    resource_scope_group.add_argument(
+        "--resource-scope",
+        action="append",
+        metavar="PATH",
+        help="narrow file access to a path root inside the governed cwd (repeatable; "
+        "relative paths resolve against cwd)",
+    )
+    resource_scope_group.add_argument(
         "--no-resource-scope",
         action="store_true",
         help="skip the default cwd-based file resource_scope (path_allow); use for a "

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -749,6 +749,47 @@ def _apply_kernel_policy(
 # ── main entry ─────────────────────────────────────────────────────────────────
 
 
+def _resolve_run_resource_scope(
+    work_dir: Path,
+    *,
+    resource_scope: list[str] | None,
+    disabled: bool,
+) -> list[str]:
+    """Return exact + subtree patterns for validated roots inside ``work_dir``."""
+    if disabled and resource_scope is not None:
+        raise ValueError("resource_scope cannot be combined with no_resource_scope")
+    if disabled:
+        return []
+
+    raw_roots = [str(work_dir)] if resource_scope is None else resource_scope
+    if not raw_roots:
+        raise ValueError("resource_scope must contain at least one path root")
+
+    roots: list[Path] = []
+    for raw_root in raw_roots:
+        if not isinstance(raw_root, str) or not raw_root.strip():
+            raise ValueError("resource_scope entries must be non-empty path roots")
+        if any(char in raw_root for char in "*?[]"):
+            raise ValueError("resource_scope entries must be path roots, not glob patterns")
+        candidate = Path(raw_root).expanduser()
+        if not candidate.is_absolute():
+            candidate = work_dir / candidate
+        try:
+            root = candidate.resolve()
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"invalid resource_scope path root: {exc}") from exc
+        if root != work_dir and not root.is_relative_to(work_dir):
+            raise ValueError("resource_scope path roots must stay inside the governed cwd")
+        if root not in roots:
+            roots.append(root)
+
+    patterns: list[str] = []
+    for root in roots:
+        root_text = str(root)
+        patterns.extend((root_text, "/*" if root_text == "/" else f"{root_text}/*"))
+    return patterns
+
+
 def run_governed(
     *,
     command: list[str],
@@ -763,6 +804,7 @@ def run_governed(
     env: dict[str, str] | None = None,
     enable_kernel_correlation: bool = True,
     enforce: bool = False,
+    resource_scope: list[str] | None = None,
     no_resource_scope: bool = False,
     cwd: Path | None = None,
     stdout: Any | None = None,
@@ -776,6 +818,12 @@ def run_governed(
     :class:`KernelPolicyEnforcementError` when ``enforce=True`` and
     kernel-level BPF policy enforcement could not be installed — the launched
     agent is killed before the error propagates.
+
+    ``resource_scope`` narrows the default cwd-based file scope to one or more
+    path roots inside ``cwd``. Relative roots resolve against ``cwd``; each is
+    represented as exact + recursive patterns for proxy enforcement and as an
+    absolute path prefix for BPF lowering. It cannot be combined with
+    ``no_resource_scope``.
 
     ``no_resource_scope`` skips the default cwd-based file resource_scope
     (``path_allow``/``OP_FILE_READ``+``OP_FILE_WRITE``), which every mission
@@ -797,6 +845,11 @@ def run_governed(
         raise ValueError(f"unknown --via mode: {via!r} (choose from {', '.join(VALID_VIA_MODES)})")
 
     work_dir = Path(cwd).expanduser().resolve() if cwd else Path.cwd()
+    scope_patterns = _resolve_run_resource_scope(
+        work_dir,
+        resource_scope=resource_scope,
+        disabled=no_resource_scope,
+    )
 
     ephemeral = home is None
     if ephemeral:
@@ -815,7 +868,7 @@ def run_governed(
         mission=mission_text,
         allowed_tools=list(allowed_tools or []),
         forbidden_tools=list(forbidden_tools or []),
-        resource_scope=[] if no_resource_scope else [str(work_dir), f"{work_dir}/*"],
+        resource_scope=scope_patterns,
         cwd=str(work_dir),
         max_tool_calls=max_tool_calls,
         max_duration_s=max_duration_s,
@@ -1341,6 +1394,7 @@ def run_governed_cli(args: Any) -> int:
             via=getattr(args, "via", None) or "auto",
             enable_kernel_correlation=not getattr(args, "no_kernel_correlation", False),
             enforce=bool(getattr(args, "enforce", False)),
+            resource_scope=getattr(args, "resource_scope", None),
             no_resource_scope=bool(getattr(args, "no_resource_scope", False)),
         )
     except NotImplementedError as exc:

--- a/site/content/source/docs/reference/cli.md
+++ b/site/content/source/docs/reference/cli.md
@@ -2,7 +2,7 @@
 title: "ardur` CLI Reference"
 description: "The `ardur` console entry point ships with the Python package. After"
 source_path: "docs/reference/cli.md"
-source_sha256: "23f4e7f438053d1628c2a67e426d8196b6e8b74a874e4a1f0eaa79782e23277f"
+source_sha256: "89b36cf0a9eea41a39410935c14bcccd1964fc29cc090d973e384ed999731544"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -444,11 +444,11 @@ Legacy Hub streaming remains the default when no governance selector is supplied
 ardur run [--hub-url URL] [--hub-token TOKEN] [--home DIR] -- <command>
 ```
 
-The zero-setup governance bridge is selected when `--mission`,
-`--allowed-tools`, `--forbidden-tools`, `--max-tool-calls`, or `--via` is
-supplied. It issues a temporary Mission Passport, starts an embedded loopback
-governance proxy, launches the command, then prints a governance summary to
-stderr when the command exits:
+The zero-setup governance bridge is selected when any governance option is
+supplied, including the mission/tool flags, kernel flags, or resource-scope
+flags below. It issues a temporary Mission Passport, starts an embedded
+loopback governance proxy, launches the command, then prints a governance
+summary to stderr when the command exits:
 
 ```text
 ardur run [--home DIR]
@@ -459,6 +459,8 @@ ardur run [--home DIR]
           [--max-duration-s N]
           [--via auto|claude-code|env|intercept]
           [--no-kernel-correlation]
+          [--enforce]
+          [--resource-scope PATH ... | --no-resource-scope]
           -- <command>
 ```
 
@@ -474,7 +476,19 @@ cooperating command through environment variables, and `--via intercept` is only
 a scaffolded transparent-intercept path today; it fails closed rather than
 claiming universal CLI capture. `--no-kernel-correlation` disables the
 best-effort kernel/cgroup correlation attempt that may be available on suitable
-Linux hosts.
+Linux hosts. `--enforce` aborts instead of degrading when kernel policy cannot
+be installed.
+
+By default, a governed run scopes file access to the complete governed working
+directory tree. Repeat `--resource-scope PATH` to narrow that scope to one or
+more roots inside the working directory. Relative roots resolve against the
+governed working directory; symlinks are resolved before the inside-directory
+check. Each canonical root produces exact and subtree proxy patterns and is
+also passed to BPF path lowering; the existing kernel-tier and bounded path
+depth limits still apply. Glob patterns and roots outside the working directory
+are rejected before keys or a passport are created. `--no-resource-scope` is
+mutually exclusive with `--resource-scope`; it removes file scope only for a
+mission that is genuinely network-only and relies on the seccomp fallback.
 
 Safe local example:
 


### PR DESCRIPTION
## Summary
- add repeatable `ardur run --resource-scope PATH` roots that narrow the default CWD scope
- resolve relative roots against governed CWD and reject glob, traversal, symlink escape, outside-CWD, empty, and ambiguous inputs before artifacts
- expand canonical roots to exact + subtree proxy patterns and feed them through existing BPF lowering
- keep the current recursive CWD default for compatibility instead of applying #86’s breaking `[work_dir]` suggestion
- make scope modes argparse-mutually-exclusive
- fix governance dispatch for resource/kernel flags and explicit `--max-duration-s`
- synchronize the public CLI reference and hosted source mirror

Closes #86

## Why the issue design changed
`resource_scope` is now a real enforcement input, not only an attestation claim. `[work_dir]` would name only the directory in proxy glob semantics and break ordinary project file access. An explicit narrowing override solves the policy precision problem without silently changing every existing run.

## Validation
- clean worktree-local Python 3.13 venv on EXTENDED
- `1374 passed, 32 skipped`, 85% total coverage
- 64 run-bridge tests; 11 focused scope/dispatch tests
- installed CLI smoke proves relative `src` becomes canonical exact + subtree signed passport claims
- invalid scope proven to fail before home/key/passport creation
- proxy sibling denial and BPF root lowering parity
- Ruff, source-doc sync, 10 claim checks
- Hugo 0.161.1 build (247 pages) and rendered-link validation
- `git diff --check` and clean source tree