### PR TITLE
fix(kernelcapture): account global lifecycle loss

### DIFF
--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -35,17 +35,24 @@ matching eBPF program. A record that is too short for that ABI, or otherwise
 cannot be decoded, produces a structured warning:
 
 ```text
-malformed ringbuf record drop_count=<n>
+malformed ringbuf record loss_epoch=<n>
 ```
 
-The daemon drops that record and continues reading. `drop_count` is the number
-of malformed records seen since the previous valid lifecycle event. If the next
-valid event correlates to a session, its kernel receipt carries that count as
-`capture_loss.ringbuf_dropped`; correlation then treats the evidence as
-degraded or insufficient rather than claiming a complete event stream. If the
-next valid event is not correlated, the current implementation resets the
-counter without writing it to a session receipt, so daemon logs remain the
-source of truth for the host-wide gap.
+The daemon drops that record and continues reading. `loss_epoch` is a monotonic
+daemon-lifetime identifier for a host-wide lifecycle capture gap. Because the
+malformed record has no trustworthy PID or cgroup, the daemon does not charge
+the gap to whichever session happens to produce the next valid event. Instead,
+every session active when the gap occurs records the same increment in its
+`lifecycle_capture` session-window summary. An uncorrelated valid event cannot
+clear the summary, and a session registered after the gap does not inherit it.
+
+Successful `session_status` and `end_session` responses expose the summary with
+`coverage_status`, `ringbuf_dropped`, `daemon_queue_dropped`, and the first and
+last affected loss epochs. The run bridge fetches this summary before ending a
+normal governed session and folds it into the signed attestation as
+`kernel_enforcement.lifecycle_capture`. The daemon retains the summary for the
+session lifetime and returns it on every status request; individual lifecycle
+receipts do not misrepresent the host-global gap as event-local capture loss.
 
 A malformed record points to a producer/consumer ABI mismatch, truncated
 sample, or corruption in the lifecycle event path. It is not the expected
@@ -58,8 +65,8 @@ startup and are reported by the loader before records can be emitted.
    build or release digest.
 2. Inspect startup logs for load, verifier, attach, or pinned-state reuse
    failures before the first malformed-record warning.
-3. Treat every malformed-record warning or nonzero
-   `capture_loss.ringbuf_dropped` value as an evidence gap; do not use affected
+3. Treat every malformed-record warning or `lifecycle_capture` summary whose
+   `coverage_status` is `degraded` as an evidence gap; do not use affected
    sessions to claim complete kernel observation for that interval.
 4. Restart with a matched daemon and eBPF artifact set. If warnings continue,
    preserve the daemon logs, kernel version, artifact digests, and the first
@@ -67,6 +74,6 @@ startup and are reported by the loader before records can be emitted.
 5. Use `--no-ringbuf` only to isolate the socket control plane. Record that
    capture and enforcement were intentionally unavailable during the test.
 
-The receipt counter is evidence-integrity metadata attached to the next
-correlated event, not a per-session packet-loss metric or a promise that every
-missing kernel event can be reconstructed.
+The summary is evidence-integrity metadata for a session's active time window,
+not a claim that the malformed record belonged to that session or a promise
+that any missing kernel event can be reconstructed.

--- a/go/cmd/ardur-kernelcaptured/daemon_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_linux.go
@@ -98,7 +98,6 @@ func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 	source := kernelcapture.NewRingbufProcessSourceFromRingbufReader(handles.Reader())
 	// No defer source.Close() here: handles.Close() owns the reader.
 
-	var loss kernelcapture.CaptureLoss
 	// Empty scope: all events reach the router (per-session filtering is done
 	// in daemon.routeEvent via the cgroup index and ProcessTreeScope).
 	scope := kernelcapture.SessionScope{}
@@ -116,8 +115,8 @@ func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 				case kernelcapture.RingbufErrorContextCanceled, kernelcapture.RingbufErrorDeadlineExceeded:
 					return ctx.Err()
 				case kernelcapture.RingbufErrorMalformedRecord:
-					loss.RingbufDropped++
-					log.Warn("malformed ringbuf record", "drop_count", loss.RingbufDropped)
+					epoch := d.recordMalformedLifecycleRecord()
+					log.Warn("malformed ringbuf record", "loss_epoch", epoch)
 					continue
 				}
 			}
@@ -127,7 +126,6 @@ func runEBPFConsumer(ctx context.Context, d *daemon, log *slog.Logger) error {
 			continue
 		}
 
-		d.processKernelEvent(evt, loss)
-		loss = kernelcapture.CaptureLoss{} // reset: drops since last good event have been reported
+		d.processKernelEvent(evt)
 	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -55,22 +55,23 @@ func newTestDaemon(t *testing.T) *daemon {
 	t.Helper()
 	tmpDir := t.TempDir()
 	return &daemon{
-		log:                  testLogger(t),
-		registry:             kernelcapture.NewDaemonSessionRegistry(),
-		evidenceDir:          filepath.Join(tmpDir, "evidence"),
-		cgroupIndex:          make(map[uint64]string),
-		treeScopes:           make(map[string]*kernelcapture.ProcessTreeScope),
-		correlators:          make(map[string]*kernelcapture.Correlator),
-		enforceChains:        make(map[string]*kernelcapture.EnforceReceiptChain),
-		enforceSummaries:     make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
-		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
-		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
-		fs:                   osEvidenceFS{},
-		tamperChain:          kernelcapture.NewTamperReceiptChain(),
-		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
-		seccompListeners:     make(map[string]context.CancelFunc),
-		activeTier:           daemonTierNone,
-		appliedAllow:         make(map[string]*appliedAllowRecord),
+		log:                       testLogger(t),
+		registry:                  kernelcapture.NewDaemonSessionRegistry(),
+		evidenceDir:               filepath.Join(tmpDir, "evidence"),
+		cgroupIndex:               make(map[uint64]string),
+		treeScopes:                make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators:               make(map[string]*kernelcapture.Correlator),
+		enforceChains:             make(map[string]*kernelcapture.EnforceReceiptChain),
+		enforceSummaries:          make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
+		enforceOrphanChain:        kernelcapture.NewEnforceReceiptChain(),
+		enforceOrphanSummary:      kernelcapture.NewEnforceEventSummaryAccumulator(),
+		lifecycleCaptureSummaries: make(map[string]*kernelcapture.LifecycleCaptureSummaryAccumulator),
+		fs:                        osEvidenceFS{},
+		tamperChain:               kernelcapture.NewTamperReceiptChain(),
+		seccompPolicy:             kernelcapture.NewSeccompPolicyStore(),
+		seccompListeners:          make(map[string]context.CancelFunc),
+		activeTier:                daemonTierNone,
+		appliedAllow:              make(map[string]*appliedAllowRecord),
 		// No-op cgroup verifier: daemon-flow tests register synthetic PIDs that
 		// aren't real /proc descendants. The real check is covered directly by
 		// daemon_cgroup_verify_linux_test.go.
@@ -436,6 +437,136 @@ func TestRouteEvent_NoMatch(t *testing.T) {
 	}
 }
 
+func TestLifecycleCaptureLossIsSessionWindowedAndNotEventAttributed(t *testing.T) {
+	d := newTestDaemon(t)
+	stub := newStubFS()
+	d.fs = evidenceFS(stub)
+
+	register := func(sessionID string, rootPID uint32, cgroupID uint64) {
+		d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+			SessionID: sessionID, RootPID: rootPID, CgroupID: cgroupID,
+		}, sessionID)
+	}
+	register("session-a", 100, 10)
+	register("session-b", 200, 20)
+
+	if epoch := d.recordMalformedLifecycleRecord(); epoch != 1 {
+		t.Fatalf("first loss epoch = %d, want 1", epoch)
+	}
+	// A valid event outside every registered scope must not erase the gap.
+	d.processKernelEvent(kernelcapture.ProcessEvent{PID: 999, CgroupID: 99, Type: kernelcapture.ProcessEventExec})
+
+	for _, sessionID := range []string{"session-a", "session-b"} {
+		summary, ok := d.lifecycleCaptureSummaryForSession(sessionID)
+		if !ok {
+			t.Fatalf("missing lifecycle capture summary for %s", sessionID)
+		}
+		if summary.CoverageStatus != kernelcapture.LifecycleCaptureCoverageDegraded || summary.RingbufDropped != 1 {
+			t.Fatalf("%s summary after uncorrelated event = %+v", sessionID, summary)
+		}
+		if summary.LossEpochStart != 1 || summary.LossEpochEnd != 1 {
+			t.Fatalf("%s loss epoch = %d..%d, want 1..1", sessionID, summary.LossEpochStart, summary.LossEpochEnd)
+		}
+	}
+
+	// A later correlated event is written without being arbitrarily charged the
+	// host-global gap; the session-level summary remains degraded instead.
+	d.processKernelEvent(kernelcapture.ProcessEvent{PID: 100, CgroupID: 10, Type: kernelcapture.ProcessEventExec})
+	stub.mu.Lock()
+	data := append([]byte(nil), stub.appends[filepath.Join(d.evidenceDir, "session-a", "kernel_receipts.jsonl")]...)
+	stub.mu.Unlock()
+	if len(data) == 0 {
+		t.Fatal("correlated event did not write a kernel receipt")
+	}
+	var entry KernelReceiptEntry
+	if err := json.Unmarshal(data[:len(data)-1], &entry); err != nil {
+		t.Fatalf("decode kernel receipt: %v", err)
+	}
+	if entry.Receipt.CaptureLoss != (kernelcapture.CaptureLoss{}) {
+		t.Fatalf("correlated receipt was arbitrarily charged global loss: %+v", entry.Receipt.CaptureLoss)
+	}
+
+	// A session registered after epoch 1 starts complete, then joins all other
+	// active sessions in epoch 2.
+	register("session-c", 300, 30)
+	if got, _ := d.lifecycleCaptureSummaryForSession("session-c"); got.CoverageStatus != kernelcapture.LifecycleCaptureCoverageComplete || got.RingbufDropped != 0 {
+		t.Fatalf("new session inherited an old capture gap: %+v", got)
+	}
+	d.recordLifecycleCaptureLoss(kernelcapture.CaptureLoss{RingbufDropped: 1})
+
+	for _, tc := range []struct {
+		sessionID string
+		drops     uint64
+		start     uint64
+	}{{"session-a", 2, 1}, {"session-b", 2, 1}, {"session-c", 1, 2}} {
+		got, _ := d.lifecycleCaptureSummaryForSession(tc.sessionID)
+		if got.RingbufDropped != tc.drops || got.LossEpochStart != tc.start || got.LossEpochEnd != 2 {
+			t.Fatalf("%s final summary = %+v", tc.sessionID, got)
+		}
+	}
+}
+
+func TestLifecycleCaptureSummaryIsExposedUntilSessionEnd(t *testing.T) {
+	d := newTestDaemon(t)
+	const startTicks uint64 = 987654
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+		ProcessStartTimeTicks: startTicks,
+		Authorization: kernelcapture.DaemonPeerAuthorization{
+			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+			UID:                   uint32(os.Getuid()),
+			PID:                   uint32(os.Getpid()),
+			ProcessStartTimeTicks: startTicks,
+		},
+	}
+
+	register := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "capture-status-session",
+			RootPID:      123,
+			CgroupID:     456,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   60,
+		},
+	}
+	handshake.Method = register.Method
+	if resp := d.handleAuthorizedRequest(context.Background(), register, handshake); !resp.OK {
+		t.Fatalf("register_session failed: %+v", resp)
+	}
+	d.recordMalformedLifecycleRecord()
+
+	status := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodSessionStatus,
+		SessionStatus:   &kernelcapture.DaemonSessionStatusRequest{SessionID: "capture-status-session"},
+	}
+	handshake.Method = status.Method
+	statusResp := d.handleAuthorizedRequest(context.Background(), status, handshake)
+	if !statusResp.OK || statusResp.LifecycleCapture == nil {
+		t.Fatalf("session_status lifecycle capture = %+v", statusResp)
+	}
+	if got := statusResp.LifecycleCapture; got.CoverageStatus != kernelcapture.LifecycleCaptureCoverageDegraded || got.RingbufDropped != 1 {
+		t.Fatalf("session_status lifecycle capture = %+v", got)
+	}
+
+	end := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodEndSession,
+		EndSession:      &kernelcapture.DaemonEndSessionRequest{SessionID: "capture-status-session"},
+	}
+	handshake.Method = end.Method
+	endResp := d.handleAuthorizedRequest(context.Background(), end, handshake)
+	if !endResp.OK || endResp.LifecycleCapture == nil || endResp.LifecycleCapture.RingbufDropped != 1 {
+		t.Fatalf("end_session lifecycle capture = %+v", endResp)
+	}
+	if _, ok := d.lifecycleCaptureSummaryForSession("capture-status-session"); ok {
+		t.Fatal("ended session retained lifecycle capture state")
+	}
+}
+
 // TestRouteEvent_SlowPathPIDTreeMatch exercises the slow-path PID-tree scan.
 // The session is registered with CgroupID=0 (no cgroup guard) so it does not
 // appear in cgroupIndex. The event carries CgroupID=99 which misses the fast
@@ -670,6 +801,7 @@ func TestPruneExpiredSessions(t *testing.T) {
 	d.treeScopes["phantom-session"] = &scope
 	d.cgroupIndex[88] = "phantom-session"
 	d.correlators["phantom-session"] = kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{})
+	d.lifecycleCaptureSummaries["phantom-session"] = kernelcapture.NewLifecycleCaptureSummaryAccumulator()
 	d.mu.Unlock()
 
 	// pruneExpiredSessions should remove the phantom session because the
@@ -679,6 +811,7 @@ func TestPruneExpiredSessions(t *testing.T) {
 	d.mu.RLock()
 	_, stillInCgroup := d.cgroupIndex[88]
 	_, stillInTree := d.treeScopes["phantom-session"]
+	_, stillInCapture := d.lifecycleCaptureSummaries["phantom-session"]
 	d.mu.RUnlock()
 
 	if stillInCgroup {
@@ -686,6 +819,9 @@ func TestPruneExpiredSessions(t *testing.T) {
 	}
 	if stillInTree {
 		t.Error("phantom session tree scope not pruned")
+	}
+	if stillInCapture {
+		t.Error("phantom session lifecycle capture summary not pruned")
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -89,6 +89,11 @@ type daemon struct {
 	enforceSummaries     map[string]*kernelcapture.EnforceEventSummaryAccumulator
 	enforceOrphanChain   *kernelcapture.EnforceReceiptChain
 	enforceOrphanSummary *kernelcapture.EnforceEventSummaryAccumulator
+	// lifecycleCaptureSummaries retain daemon-global exec/exit capture gaps for
+	// every session that was active when each gap occurred. lossEpoch is a
+	// daemon-lifetime monotonic identifier shared by all affected sessions.
+	lifecycleCaptureSummaries map[string]*kernelcapture.LifecycleCaptureSummaryAccumulator
+	lifecycleCaptureLossEpoch uint64
 
 	// OS filesystem for JSONL append (interface for test injection).
 	fs evidenceFS
@@ -199,25 +204,26 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 	}
 
 	return &daemon{
-		log:                  log,
-		registry:             registry,
-		custodyPlan:          custodyPlan,
-		peerPolicy:           peerPolicy,
-		evidenceDir:          evidenceDir,
-		cgroupIndex:          make(map[uint64]string),
-		treeScopes:           make(map[string]*kernelcapture.ProcessTreeScope),
-		correlators:          make(map[string]*kernelcapture.Correlator),
-		enforceChains:        make(map[string]*kernelcapture.EnforceReceiptChain),
-		enforceSummaries:     make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
-		enforceOrphanChain:   kernelcapture.NewEnforceReceiptChain(),
-		enforceOrphanSummary: kernelcapture.NewEnforceEventSummaryAccumulator(),
-		fs:                   osEvidenceFS{},
-		tamperChain:          kernelcapture.NewTamperReceiptChain(),
-		seccompPolicy:        kernelcapture.NewSeccompPolicyStore(),
-		seccompListeners:     make(map[string]context.CancelFunc),
-		activeTier:           daemonTierNone,
-		appliedAllow:         make(map[string]*appliedAllowRecord),
-		cgroupVerifier:       verifyRegisterSessionCgroup,
+		log:                       log,
+		registry:                  registry,
+		custodyPlan:               custodyPlan,
+		peerPolicy:                peerPolicy,
+		evidenceDir:               evidenceDir,
+		cgroupIndex:               make(map[uint64]string),
+		treeScopes:                make(map[string]*kernelcapture.ProcessTreeScope),
+		correlators:               make(map[string]*kernelcapture.Correlator),
+		enforceChains:             make(map[string]*kernelcapture.EnforceReceiptChain),
+		enforceSummaries:          make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
+		enforceOrphanChain:        kernelcapture.NewEnforceReceiptChain(),
+		enforceOrphanSummary:      kernelcapture.NewEnforceEventSummaryAccumulator(),
+		lifecycleCaptureSummaries: make(map[string]*kernelcapture.LifecycleCaptureSummaryAccumulator),
+		fs:                        osEvidenceFS{},
+		tamperChain:               kernelcapture.NewTamperReceiptChain(),
+		seccompPolicy:             kernelcapture.NewSeccompPolicyStore(),
+		seccompListeners:          make(map[string]context.CancelFunc),
+		activeTier:                daemonTierNone,
+		appliedAllow:              make(map[string]*appliedAllowRecord),
+		cgroupVerifier:            verifyRegisterSessionCgroup,
 	}, nil
 }
 
@@ -321,11 +327,17 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 		}
 	case kernelcapture.DaemonProtocolMethodEndSession:
 		if sessionID := req.EndSession; sessionID != nil {
+			if summary, ok := d.lifecycleCaptureSummaryForSession(sessionID.SessionID); ok {
+				resp.LifecycleCapture = &summary
+			}
 			d.onSessionEnded(sessionID.SessionID)
 		}
 	case kernelcapture.DaemonProtocolMethodSessionStatus:
 		if summary, ok := d.enforceSummaryForScope(resp.SessionID); ok {
 			resp.Enforcement = &summary
+		}
+		if summary, ok := d.lifecycleCaptureSummaryForSession(resp.SessionID); ok {
+			resp.LifecycleCapture = &summary
 		}
 		resp.SeccompListenerAttached = d.seccompListenerAttached(resp.SessionID)
 	case kernelcapture.DaemonProtocolMethodHealth:
@@ -774,6 +786,7 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 	lastTamperSeq, _ := d.tamperChain.Head()
 	summary.InitializeTamperWindow(lastTamperSeq+1, d.expectedKillSwitchEngaged)
 	d.enforceSummaries[sessionID] = summary
+	d.lifecycleCaptureSummaries[sessionID] = kernelcapture.NewLifecycleCaptureSummaryAccumulator()
 
 	d.log.Info("session registered",
 		"session_id", sessionID,
@@ -820,6 +833,7 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	delete(d.correlators, sessionID)
 	delete(d.enforceChains, sessionID)
 	delete(d.enforceSummaries, sessionID)
+	delete(d.lifecycleCaptureSummaries, sessionID)
 	// Grab (and forget) the seccomp listener's cancel func here, under the
 	// same lock as the map deletes above; call it below, outside the lock,
 	// since the supervisor goroutine it stops may itself try to touch
@@ -995,16 +1009,13 @@ func (d *daemon) appendAndPersistTamperEntryLocked(entry kernelcapture.TamperRec
 
 // processKernelEvent is called by the platform-specific event loop for each
 // event that arrives from the eBPF ringbuf.
-func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent, loss kernelcapture.CaptureLoss) {
+func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent) {
 	sid, correlator := d.routeEvent(&evt)
 	if sid == "" || correlator == nil {
 		return
 	}
 
-	ctx := kernelcapture.EventContext{
-		CaptureLoss: loss,
-	}
-	receipt := correlator.Correlate(evt, ctx)
+	receipt := correlator.Correlate(evt, kernelcapture.EventContext{})
 
 	d.log.Debug("kernel event",
 		"session_id", sid,
@@ -1016,6 +1027,40 @@ func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent, loss kernelc
 		"verdict", receipt.Verdict,
 	)
 	d.appendKernelReceipt(sid, evt, receipt)
+}
+
+// recordLifecycleCaptureLoss records one daemon-global process lifecycle loss
+// epoch against every session active at that instant. It deliberately does not
+// attach the loss to a later event: the malformed record has no trustworthy
+// cgroup or PID, so event-based attribution would be arbitrary. The summaries
+// remain available for every session_status response until the session ends.
+func (d *daemon) recordLifecycleCaptureLoss(loss kernelcapture.CaptureLoss) uint64 {
+	if loss.RingbufDropped == 0 && loss.DaemonQueueDropped == 0 {
+		return 0
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lifecycleCaptureLossEpoch++
+	epoch := d.lifecycleCaptureLossEpoch
+	for _, summary := range d.lifecycleCaptureSummaries {
+		summary.RecordLoss(loss, epoch)
+	}
+	return epoch
+}
+
+func (d *daemon) recordMalformedLifecycleRecord() uint64 {
+	return d.recordLifecycleCaptureLoss(kernelcapture.CaptureLoss{RingbufDropped: 1})
+}
+
+func (d *daemon) lifecycleCaptureSummaryForSession(sessionID string) (kernelcapture.LifecycleCaptureSummary, bool) {
+	d.mu.RLock()
+	summary, ok := d.lifecycleCaptureSummaries[sessionID]
+	d.mu.RUnlock()
+	if !ok || summary == nil {
+		return kernelcapture.LifecycleCaptureSummary{}, false
+	}
+	return summary.Snapshot(), true
 }
 
 // pruneExpiredSessions removes sessions that the registry has expired so the
@@ -1046,6 +1091,7 @@ func (d *daemon) pruneExpiredSessions() {
 			delete(d.correlators, sid)
 			delete(d.enforceChains, sid)
 			delete(d.enforceSummaries, sid)
+			delete(d.lifecycleCaptureSummaries, sid)
 			if cancel, ok := d.seccompListeners[sid]; ok {
 				expiredSeccompCancels = append(expiredSeccompCancels, cancel)
 				delete(d.seccompListeners, sid)

--- a/go/pkg/kernelcapture/README.md
+++ b/go/pkg/kernelcapture/README.md
@@ -10,6 +10,10 @@ This package is the Ardur Linux proof harness for process-exec capture with pair
   - `correlation_confidence`
   - `coverage_status`
   - `capture_loss`
+- Exposes a session-window `lifecycle_capture` summary on daemon
+  `session_status` / `end_session` responses. Daemon-global malformed-record
+  loss degrades every session active during the same monotonic loss epoch and
+  is never charged to whichever session produces the next valid event.
 - Enforces honesty behavior:
   - ambiguous attribution => `insufficient_evidence`
   - degraded/unknown coverage => `insufficient_evidence`
@@ -130,8 +134,8 @@ This package is the Ardur Linux proof harness for process-exec capture with pair
    - Rejects `session_status` and `end_session` attempts from the same UID/GID/PID when the daemon-observed process-start identity differs, so PID reuse cannot satisfy ownership by PID alone.
    - Exposes `ActiveSession`, `BuildActiveSessionHandoffPlan`, and `HandleAuthorizedSessionStatusSnapshot` so internal daemon status/handoff code can reuse the same active-session lookup before projecting a no-mutation handoff plan from daemon-owned custody paths.
    - Adds `DaemonSessionStatusSnapshotSink` and `DaemonSessionStatusSnapshotHandler` so a bounded local socket handler can retain detached daemon-internal status snapshots in memory while returning only a narrow protocol response.
-   - Adds `SendDaemonSessionStatusRequest`, a narrow local Unix-socket client proof for `session_status` responses that decodes only `DaemonProtocolResponse` and rejects response expansion.
-   - Keeps daemon-internal status snapshots out of the client-visible JSON-line protocol response: `session_status` still returns only the narrow status envelope.
+   - Adds `SendDaemonSessionStatusRequest`, a narrow local Unix-socket client proof for `session_status` responses that decodes only the bounded `DaemonProtocolResponse` schema and rejects unknown response fields.
+   - Keeps daemon-internal status snapshots out of the client-visible JSON-line protocol response: the runtime daemon may add reviewed `enforcement` and `lifecycle_capture` evidence summaries, but not custody paths, handoff plans, raw process metadata, or internal snapshot state.
    - Does not persist state across daemon restarts, install/start a service, create/assign cgroups, pin maps, execute commands, or perform live kernel enforcement.
 
 12. `BuildDaemonSessionStatusEvidenceLogPlan` (no-write evidence-log plan)

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -126,6 +126,12 @@ type DaemonProtocolResponse struct {
 	// directories are root-0700, so this is the only channel a non-root client
 	// has to learn what kernel-level enforcement happened.
 	Enforcement *EnforceEventSummary `json:"enforcement,omitempty"`
+	// LifecycleCapture reports daemon-global process exec/exit capture loss that
+	// occurred while this session was active. It is populated on successful
+	// session_status and end_session responses. Loss is summarized independently
+	// for every concurrently active session because a malformed host-level record
+	// cannot be attributed to whichever session produces the next valid event.
+	LifecycleCapture *LifecycleCaptureSummary `json:"lifecycle_capture,omitempty"`
 	// EnforcementTier carries which kernel enforcement tier is currently
 	// active — EnforcementTierBPFLSM, EnforcementTierSeccomp, or
 	// EnforcementTierNone — on successful health responses. The daemon

--- a/go/pkg/kernelcapture/daemon_protocol_test.go
+++ b/go/pkg/kernelcapture/daemon_protocol_test.go
@@ -117,6 +117,40 @@ func TestDaemonProtocolResponseDecodeRejectsInternalExpansion(t *testing.T) {
 	}
 }
 
+func TestDaemonProtocolResponseLifecycleCaptureRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := LifecycleCaptureSummary{
+		CoverageStatus:     LifecycleCaptureCoverageDegraded,
+		RingbufDropped:     2,
+		DaemonQueueDropped: 1,
+		LossEpochStart:     4,
+		LossEpochEnd:       6,
+	}
+	encoded, err := EncodeDaemonProtocolResponse(DaemonProtocolResponse{
+		ProtocolVersion:  DaemonProtocolVersion,
+		OK:               true,
+		Method:           DaemonProtocolMethodSessionStatus,
+		SessionID:        "session-1",
+		Status:           DaemonSessionStatusActive,
+		LifecycleCapture: &want,
+	})
+	if err != nil {
+		t.Fatalf("EncodeDaemonProtocolResponse returned error: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte(`"lifecycle_capture":{"coverage_status":"degraded","ringbuf_dropped":2,"daemon_queue_dropped":1,"loss_epoch_start":4,"loss_epoch_end":6}`)) {
+		t.Fatalf("encoded lifecycle_capture = %s", encoded)
+	}
+
+	decoded, err := DecodeDaemonProtocolResponse(encoded)
+	if err != nil {
+		t.Fatalf("DecodeDaemonProtocolResponse returned error: %v", err)
+	}
+	if decoded.LifecycleCapture == nil || *decoded.LifecycleCapture != want {
+		t.Fatalf("decoded lifecycle_capture = %#v, want %#v", decoded.LifecycleCapture, want)
+	}
+}
+
 func TestDaemonProtocolValidationRejectsInvalidRequests(t *testing.T) {
 	t.Parallel()
 

--- a/go/pkg/kernelcapture/lifecycle_capture_summary.go
+++ b/go/pkg/kernelcapture/lifecycle_capture_summary.go
@@ -1,0 +1,61 @@
+package kernelcapture
+
+import "sync"
+
+const (
+	LifecycleCaptureCoverageComplete = "complete"
+	LifecycleCaptureCoverageDegraded = "degraded"
+)
+
+// LifecycleCaptureSummary reports daemon-global process lifecycle loss that
+// occurred while one session was active. The loss cannot be attributed to a
+// particular session, so every session active during the same loss epoch sees
+// the same increment in its own session-window summary.
+type LifecycleCaptureSummary struct {
+	CoverageStatus     string `json:"coverage_status"`
+	RingbufDropped     uint64 `json:"ringbuf_dropped"`
+	DaemonQueueDropped uint64 `json:"daemon_queue_dropped"`
+	LossEpochStart     uint64 `json:"loss_epoch_start,omitempty"`
+	LossEpochEnd       uint64 `json:"loss_epoch_end,omitempty"`
+}
+
+// LifecycleCaptureSummaryAccumulator builds a concurrent session-window
+// LifecycleCaptureSummary.
+type LifecycleCaptureSummaryAccumulator struct {
+	mu      sync.Mutex
+	summary LifecycleCaptureSummary
+}
+
+// NewLifecycleCaptureSummaryAccumulator returns a complete, loss-free summary.
+func NewLifecycleCaptureSummaryAccumulator() *LifecycleCaptureSummaryAccumulator {
+	return &LifecycleCaptureSummaryAccumulator{
+		summary: LifecycleCaptureSummary{CoverageStatus: LifecycleCaptureCoverageComplete},
+	}
+}
+
+// RecordLoss adds daemon-global loss observed while this session was active.
+// epoch is a daemon-lifetime monotonic identifier for one observed loss window.
+func (a *LifecycleCaptureSummaryAccumulator) RecordLoss(loss CaptureLoss, epoch uint64) {
+	if loss.RingbufDropped == 0 && loss.DaemonQueueDropped == 0 {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.summary.CoverageStatus = LifecycleCaptureCoverageDegraded
+	a.summary.RingbufDropped += loss.RingbufDropped
+	a.summary.DaemonQueueDropped += loss.DaemonQueueDropped
+	if a.summary.LossEpochStart == 0 || epoch < a.summary.LossEpochStart {
+		a.summary.LossEpochStart = epoch
+	}
+	if epoch > a.summary.LossEpochEnd {
+		a.summary.LossEpochEnd = epoch
+	}
+}
+
+// Snapshot returns a detached point-in-time summary.
+func (a *LifecycleCaptureSummaryAccumulator) Snapshot() LifecycleCaptureSummary {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.summary
+}

--- a/go/pkg/kernelcapture/lifecycle_capture_summary_test.go
+++ b/go/pkg/kernelcapture/lifecycle_capture_summary_test.go
@@ -1,0 +1,25 @@
+package kernelcapture
+
+import "testing"
+
+func TestLifecycleCaptureSummaryAccumulator(t *testing.T) {
+	acc := NewLifecycleCaptureSummaryAccumulator()
+	if got := acc.Snapshot(); got.CoverageStatus != LifecycleCaptureCoverageComplete {
+		t.Fatalf("initial coverage_status = %q, want complete", got.CoverageStatus)
+	}
+
+	acc.RecordLoss(CaptureLoss{}, 1)
+	acc.RecordLoss(CaptureLoss{RingbufDropped: 2}, 4)
+	acc.RecordLoss(CaptureLoss{DaemonQueueDropped: 3}, 7)
+
+	got := acc.Snapshot()
+	if got.CoverageStatus != LifecycleCaptureCoverageDegraded {
+		t.Fatalf("coverage_status = %q, want degraded", got.CoverageStatus)
+	}
+	if got.RingbufDropped != 2 || got.DaemonQueueDropped != 3 {
+		t.Fatalf("loss counters = %+v, want ringbuf=2 queue=3", got)
+	}
+	if got.LossEpochStart != 4 || got.LossEpochEnd != 7 {
+		t.Fatalf("loss epoch = %d..%d, want 4..7", got.LossEpochStart, got.LossEpochEnd)
+	}
+}

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -1106,6 +1106,13 @@ class TestKernelEnforcementClaim:
                         "kill_switch_engaged_during_session": True,
                         "kill_switch_evidence_gap": False,
                     },
+                    "lifecycle_capture": {
+                        "coverage_status": "degraded",
+                        "ringbuf_dropped": 2,
+                        "daemon_queue_dropped": 0,
+                        "loss_epoch_start": 4,
+                        "loss_epoch_end": 5,
+                    },
                 },
             )
             try:
@@ -1127,6 +1134,13 @@ class TestKernelEnforcementClaim:
             "kill_switch_change_count": 2,
             "kill_switch_engaged_during_session": True,
             "kill_switch_evidence_gap": False,
+            "lifecycle_capture": {
+                "coverage_status": "degraded",
+                "ringbuf_dropped": 2,
+                "daemon_queue_dropped": 0,
+                "loss_epoch_start": 4,
+                "loss_epoch_end": 5,
+            },
         }
         assert daemon.received is not None
         assert daemon.received["method"] == "session_status"

--- a/python/vibap/kernel_correlation.py
+++ b/python/vibap/kernel_correlation.py
@@ -303,8 +303,8 @@ class KernelCaptureClient:
 
     def session_status(self, *, session_id: str) -> dict[str, Any]:
         """Fetch the daemon's status snapshot for a session, including its
-        kernel-enforcement rollup (``"enforcement"``) when the daemon has
-        processed enforce_events for it.
+        kernel-enforcement rollup (``"enforcement"``) and process-lifecycle
+        capture health (``"lifecycle_capture"``).
 
         Evidence-log directories are root-0700, so this socket round-trip is
         the only way a non-root caller can learn what kernel enforcement

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -469,7 +469,7 @@ def _kernel_enforcement_claim(
     session_id: str,
     correlation: kc.CorrelationResult,
 ) -> dict[str, Any] | None:
-    """Fetch the daemon's kernel-enforcement rollup for a correlated session.
+    """Fetch the daemon's signed kernel evidence rollup for a session.
 
     Returns ``None`` (never raises) when correlation was never established or
     the daemon cannot be reached — kernel enforcement data is an enhancement
@@ -485,9 +485,13 @@ def _kernel_enforcement_claim(
     except (kc.DaemonUnavailable, kc.DaemonProtocolError, ValueError):
         return None
     enforcement = response.get("enforcement")
-    if not isinstance(enforcement, dict):
+    lifecycle_capture = response.get("lifecycle_capture")
+    if not isinstance(enforcement, dict) and not isinstance(lifecycle_capture, dict):
         return None
-    return enforcement
+    claim = dict(enforcement) if isinstance(enforcement, dict) else {}
+    if isinstance(lifecycle_capture, dict):
+        claim["lifecycle_capture"] = lifecycle_capture
+    return claim
 
 
 @dataclass

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "03acee461d41945a8d9f66ec2d3eb304f36910c11f0bf99e9801599b694461e2"
+source_sha256: "dbd5d5546e499bba786cb6c126932fa7cf6843773dcd29014b35b5fd4d6df3de"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -52,17 +52,24 @@ matching eBPF program. A record that is too short for that ABI, or otherwise
 cannot be decoded, produces a structured warning:
 
 ```text
-malformed ringbuf record drop_count=<n>
+malformed ringbuf record loss_epoch=<n>
 ```
 
-The daemon drops that record and continues reading. `drop_count` is the number
-of malformed records seen since the previous valid lifecycle event. If the next
-valid event correlates to a session, its kernel receipt carries that count as
-`capture_loss.ringbuf_dropped`; correlation then treats the evidence as
-degraded or insufficient rather than claiming a complete event stream. If the
-next valid event is not correlated, the current implementation resets the
-counter without writing it to a session receipt, so daemon logs remain the
-source of truth for the host-wide gap.
+The daemon drops that record and continues reading. `loss_epoch` is a monotonic
+daemon-lifetime identifier for a host-wide lifecycle capture gap. Because the
+malformed record has no trustworthy PID or cgroup, the daemon does not charge
+the gap to whichever session happens to produce the next valid event. Instead,
+every session active when the gap occurs records the same increment in its
+`lifecycle_capture` session-window summary. An uncorrelated valid event cannot
+clear the summary, and a session registered after the gap does not inherit it.
+
+Successful `session_status` and `end_session` responses expose the summary with
+`coverage_status`, `ringbuf_dropped`, `daemon_queue_dropped`, and the first and
+last affected loss epochs. The run bridge fetches this summary before ending a
+normal governed session and folds it into the signed attestation as
+`kernel_enforcement.lifecycle_capture`. The daemon retains the summary for the
+session lifetime and returns it on every status request; individual lifecycle
+receipts do not misrepresent the host-global gap as event-local capture loss.
 
 A malformed record points to a producer/consumer ABI mismatch, truncated
 sample, or corruption in the lifecycle event path. It is not the expected
@@ -75,8 +82,8 @@ startup and are reported by the loader before records can be emitted.
    build or release digest.
 2. Inspect startup logs for load, verifier, attach, or pinned-state reuse
    failures before the first malformed-record warning.
-3. Treat every malformed-record warning or nonzero
-   `capture_loss.ringbuf_dropped` value as an evidence gap; do not use affected
+3. Treat every malformed-record warning or `lifecycle_capture` summary whose
+   `coverage_status` is `degraded` as an evidence gap; do not use affected
    sessions to claim complete kernel observation for that interval.
 4. Restart with a matched daemon and eBPF artifact set. If warnings continue,
    preserve the daemon logs, kernel version, artifact digests, and the first
@@ -84,6 +91,6 @@ startup and are reported by the loader before records can be emitted.
 5. Use `--no-ringbuf` only to isolate the socket control plane. Record that
    capture and enforcement were intentionally unavailable during the test.
 
-The receipt counter is evidence-integrity metadata attached to the next
-correlated event, not a per-session packet-loss metric or a promise that every
-missing kernel event can be reconstructed.
+The summary is evidence-integrity metadata for a session's active time window,
+not a claim that the malformed record belonged to that session or a promise
+that any missing kernel event can be reconstructed.

--- a/site/content/source/go/pkg/kernelcapture/README.md
+++ b/site/content/source/go/pkg/kernelcapture/README.md
@@ -2,7 +2,7 @@
 title: "kernelcapture proof harness"
 description: "This package is the Ardur Linux proof harness for process-exec capture with paired process-exit lifecycle metadata and kernel-effect synthetic receipts."
 source_path: "go/pkg/kernelcapture/README.md"
-source_sha256: "c8e604d6880ec26c6c93a5502c1435b99790e7a80586b5b1a207b1ef64807571"
+source_sha256: "f3ef13e19867d08f9f10ebc9d6c2fb66e8f67f232d06befbb4e603bfd7d12952"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -27,6 +27,10 @@ This package is the Ardur Linux proof harness for process-exec capture with pair
   - `correlation_confidence`
   - `coverage_status`
   - `capture_loss`
+- Exposes a session-window `lifecycle_capture` summary on daemon
+  `session_status` / `end_session` responses. Daemon-global malformed-record
+  loss degrades every session active during the same monotonic loss epoch and
+  is never charged to whichever session produces the next valid event.
 - Enforces honesty behavior:
   - ambiguous attribution => `insufficient_evidence`
   - degraded/unknown coverage => `insufficient_evidence`
@@ -147,8 +151,8 @@ This package is the Ardur Linux proof harness for process-exec capture with pair
    - Rejects `session_status` and `end_session` attempts from the same UID/GID/PID when the daemon-observed process-start identity differs, so PID reuse cannot satisfy ownership by PID alone.
    - Exposes `ActiveSession`, `BuildActiveSessionHandoffPlan`, and `HandleAuthorizedSessionStatusSnapshot` so internal daemon status/handoff code can reuse the same active-session lookup before projecting a no-mutation handoff plan from daemon-owned custody paths.
    - Adds `DaemonSessionStatusSnapshotSink` and `DaemonSessionStatusSnapshotHandler` so a bounded local socket handler can retain detached daemon-internal status snapshots in memory while returning only a narrow protocol response.
-   - Adds `SendDaemonSessionStatusRequest`, a narrow local Unix-socket client proof for `session_status` responses that decodes only `DaemonProtocolResponse` and rejects response expansion.
-   - Keeps daemon-internal status snapshots out of the client-visible JSON-line protocol response: `session_status` still returns only the narrow status envelope.
+   - Adds `SendDaemonSessionStatusRequest`, a narrow local Unix-socket client proof for `session_status` responses that decodes only the bounded `DaemonProtocolResponse` schema and rejects unknown response fields.
+   - Keeps daemon-internal status snapshots out of the client-visible JSON-line protocol response: the runtime daemon may add reviewed `enforcement` and `lifecycle_capture` evidence summaries, but not custody paths, handoff plans, raw process metadata, or internal snapshot state.
    - Does not persist state across daemon restarts, install/start a service, create/assign cgroups, pin maps, execute commands, or perform live kernel enforcement.
 
 12. `BuildDaemonSessionStatusEvidenceLogPlan` (no-write evidence-log plan)


### PR DESCRIPTION
## Summary
- replace next-valid-event attribution with monotonic daemon lifecycle loss epochs
- apply each host-global malformed-record gap to every session active in that window
- expose lifecycle capture health through session status/end responses and signed run attestations
- document the final operator and protocol contract

## Correctness contract
- unrelated valid events cannot erase a pending gap
- correlated events are not arbitrarily charged host-global loss
- overlapping sessions receive the same gap; later sessions do not inherit it
- status remains degraded for the session lifetime and is returned before state retirement

## Validation
- `go test -race ./pkg/kernelcapture ./cmd/ardur-kernelcaptured`
- `go test -count=1 -timeout 120s ./...`
- Linux arm64 test-binary cross-compile
- `pytest tests -q`: 1375 passed, 32 skipped
- `pytest tests/test_run_bridge.py -q`: 64 passed
- `go vet ./...`
- source-doc sync/claims validation
- Hugo production build: 247 pages

Closes #219