### PR TITLE
perf(daemon): shard lifecycle event routing

### DIFF
--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -8,8 +8,10 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
@@ -61,6 +63,7 @@ func newTestDaemon(t *testing.T) *daemon {
 		cgroupIndex:               make(map[uint64]string),
 		treeScopes:                make(map[string]*kernelcapture.ProcessTreeScope),
 		correlators:               make(map[string]*kernelcapture.Correlator),
+		routeIndex:                make(map[string]*sessionRoute),
 		enforceChains:             make(map[string]*kernelcapture.EnforceReceiptChain),
 		enforceSummaries:          make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
 		enforceOrphanChain:        kernelcapture.NewEnforceReceiptChain(),
@@ -434,6 +437,143 @@ func TestRouteEvent_NoMatch(t *testing.T) {
 	}
 	if corr != nil {
 		t.Error("routeEvent no-match: expected nil correlator")
+	}
+}
+
+func TestRouteEventFallbackIndexContainsOnlyZeroCgroupScopes(t *testing.T) {
+	d := newTestDaemon(t)
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "registered-cgroup", RootPID: 100, CgroupID: 42,
+	}, "registered-cgroup")
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "fallback-scope", RootPID: 200,
+	}, "fallback-scope")
+
+	d.mu.RLock()
+	fallbackCount := len(d.fallbackRoutes)
+	routeCount := len(d.routeIndex)
+	d.mu.RUnlock()
+	if fallbackCount != 1 || routeCount != 2 {
+		t.Fatalf("route indexes = fallback:%d all:%d, want fallback:1 all:2", fallbackCount, routeCount)
+	}
+
+	evt := kernelcapture.ProcessEvent{PID: 200, CgroupID: 999, Type: kernelcapture.ProcessEventExec}
+	if sid, correlator := d.routeEvent(&evt); sid != "fallback-scope" || correlator == nil {
+		t.Fatalf("zero-cgroup fallback = (%q, %v), want (fallback-scope, non-nil)", sid, correlator)
+	}
+}
+
+func TestSessionRouteRetirementWaitsForMatchedEvent(t *testing.T) {
+	d := newTestDaemon(t)
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: "retirement-session", RootPID: 100, CgroupID: 42,
+	}, "retirement-session")
+
+	evt := kernelcapture.ProcessEvent{PID: 100, CgroupID: 42, Type: kernelcapture.ProcessEventExec}
+	route := d.lockRouteEvent(&evt)
+	if route == nil {
+		t.Fatal("lockRouteEvent returned nil for registered session")
+	}
+	ended := make(chan struct{})
+	go func() {
+		d.onSessionEnded("retirement-session")
+		close(ended)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for d.mu.TryRLock() {
+		d.mu.RUnlock()
+		if time.Now().After(deadline) {
+			route.unlock()
+			t.Fatal("session retirement did not reach the route lease")
+		}
+		runtime.Gosched()
+	}
+	select {
+	case <-ended:
+		route.unlock()
+		t.Fatal("session retirement completed while a matched route lease was held")
+	default:
+	}
+	route.unlock()
+	select {
+	case <-ended:
+	case <-time.After(time.Second):
+		t.Fatal("session retirement did not complete after route lease release")
+	}
+
+	probe := kernelcapture.ProcessEvent{PID: 100, CgroupID: 42, Type: kernelcapture.ProcessEventExec}
+	if sid, correlator := d.routeEvent(&probe); sid != "" || correlator != nil {
+		t.Fatalf("retired route matched as (%q, %v)", sid, correlator)
+	}
+}
+
+func TestProcessKernelEventReleasesRouteWithNilCorrelator(t *testing.T) {
+	d := newTestDaemon(t)
+	scope := kernelcapture.NewProcessTreeScope(100, 42)
+	scope.SessionID = "nil-correlator-session"
+	route := newSessionRoute("nil-correlator-session", &scope, nil)
+	d.mu.Lock()
+	d.cgroupIndex[42] = route.sessionID
+	d.treeScopes[route.sessionID] = &scope
+	d.publishSessionRouteLocked(route)
+	d.mu.Unlock()
+
+	d.processKernelEvent(kernelcapture.ProcessEvent{PID: 100, CgroupID: 42, Type: kernelcapture.ProcessEventExec})
+	if !route.mu.TryLock() {
+		t.Fatal("nil-correlator event leaked its route lease")
+	}
+	route.mu.Unlock()
+}
+
+func TestRouteEventConcurrentRoutingAndRetirement(t *testing.T) {
+	d := newTestDaemon(t)
+	const sessionCount = 32
+	for index := 0; index < sessionCount; index++ {
+		sessionID := benchmarkRouteSessionID(index)
+		evt := benchmarkRouteEvent(index)
+		d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+			SessionID: sessionID, RootPID: evt.PID, CgroupID: evt.CgroupID,
+		}, sessionID)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for index := 0; index < sessionCount; index++ {
+		index := index
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 500 {
+				evt := benchmarkRouteEvent(index)
+				d.routeEvent(&evt)
+			}
+		}()
+		if index%2 == 0 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				d.onSessionEnded(benchmarkRouteSessionID(index))
+			}()
+		}
+	}
+	close(start)
+	wg.Wait()
+
+	for index := 0; index < sessionCount; index++ {
+		evt := benchmarkRouteEvent(index)
+		sid, correlator := d.routeEvent(&evt)
+		if index%2 == 0 {
+			if sid != "" || correlator != nil {
+				t.Fatalf("retired session %d still routed as %q", index, sid)
+			}
+			continue
+		}
+		if want := benchmarkRouteSessionID(index); sid != want || correlator == nil {
+			t.Fatalf("active session %d routed as (%q, %v), want (%q, non-nil)", index, sid, correlator, want)
+		}
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -67,6 +67,46 @@ type KernelReceiptEntry struct {
 	Receipt       kernelcapture.SyntheticKernelReceipt `json:"receipt"`
 }
 
+// sessionRoute owns mutable process-tree routing state for one session. Its
+// identity and correlator are immutable after publication. A successful
+// lockIfMatches leaves mu locked so the caller can hold a route lease through
+// correlation and evidence append; callers must invoke unlock afterward.
+type sessionRoute struct {
+	mu         sync.Mutex
+	sessionID  string
+	scope      *kernelcapture.ProcessTreeScope
+	correlator *kernelcapture.Correlator
+	active     bool
+}
+
+func newSessionRoute(sessionID string, scope *kernelcapture.ProcessTreeScope, correlator *kernelcapture.Correlator) *sessionRoute {
+	return &sessionRoute{
+		sessionID:  sessionID,
+		scope:      scope,
+		correlator: correlator,
+		active:     true,
+	}
+}
+
+func (r *sessionRoute) lockIfMatches(evt *kernelcapture.ProcessEvent) bool {
+	if r == nil || evt == nil {
+		return false
+	}
+	r.mu.Lock()
+	if !r.active || r.scope == nil || !r.scope.MatchesAndTrack(*evt) {
+		r.mu.Unlock()
+		return false
+	}
+	evt.SessionID = r.sessionID
+	return true
+}
+
+func (r *sessionRoute) unlock() {
+	if r != nil {
+		r.mu.Unlock()
+	}
+}
+
 // daemon holds all shared state for the running daemon process.
 type daemon struct {
 	log         *slog.Logger
@@ -75,12 +115,17 @@ type daemon struct {
 	peerPolicy  kernelcapture.DaemonPeerAuthorizationPolicy
 	evidenceDir string
 
-	// Routing index: cgroup_id → session_id, maintained under mu.
-	// Populated on register_session, removed on end_session / expiry.
-	mu          sync.RWMutex
-	cgroupIndex map[uint64]string
-	treeScopes  map[string]*kernelcapture.ProcessTreeScope
-	correlators map[string]*kernelcapture.Correlator
+	// Routing indexes are published under mu. routeIndex resolves immutable
+	// route pointers; mutable ProcessTreeScope state is protected by each
+	// route's own mutex. fallbackRoutes is copy-on-write and contains only
+	// zero-cgroup test/replay scopes, since nonzero scopes reject cgroup escape.
+	// Lock order is lifecycleDropMu -> mu -> sessionRoute.mu.
+	mu             sync.RWMutex
+	cgroupIndex    map[uint64]string
+	treeScopes     map[string]*kernelcapture.ProcessTreeScope
+	correlators    map[string]*kernelcapture.Correlator
+	routeIndex     map[string]*sessionRoute
+	fallbackRoutes []*sessionRoute
 
 	// enforce_events state, maintained under mu (session-scoped) plus two
 	// daemon-lifetime singletons for events that cannot be attributed to any
@@ -230,6 +275,7 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 		cgroupIndex:               make(map[uint64]string),
 		treeScopes:                make(map[string]*kernelcapture.ProcessTreeScope),
 		correlators:               make(map[string]*kernelcapture.Correlator),
+		routeIndex:                make(map[string]*sessionRoute),
 		enforceChains:             make(map[string]*kernelcapture.EnforceReceiptChain),
 		enforceSummaries:          make(map[string]*kernelcapture.EnforceEventSummaryAccumulator),
 		enforceOrphanChain:        kernelcapture.NewEnforceReceiptChain(),
@@ -797,12 +843,14 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 	scope.SessionID = sessionID
 	d.treeScopes[sessionID] = &scope
 
-	d.correlators[sessionID] = kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{
+	correlator := kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{
 		Platform:         "linux",
 		CaptureBackend:   "linux_ebpf",
 		CorrelationGrace: 5 * time.Second,
 		RestartGrace:     3 * time.Second,
 	})
+	d.correlators[sessionID] = correlator
+	d.publishSessionRouteLocked(newSessionRoute(sessionID, &scope, correlator))
 	d.enforceChains[sessionID] = kernelcapture.NewEnforceReceiptChain()
 	summary := kernelcapture.NewEnforceEventSummaryAccumulator()
 	lastTamperSeq, _ := d.tamperChain.Head()
@@ -844,6 +892,7 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	d.applyMu.Lock()
 	defer d.applyMu.Unlock()
 	d.mu.Lock()
+	d.retireSessionRouteLocked(sessionID)
 
 	// Best-effort: remove enforcement state from BPF maps — op_policy + managed
 	// gate (keyed by the routing scope's cgroup), then the (non-double-buffered)
@@ -886,33 +935,95 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	d.log.Info("session ended", "session_id", sessionID)
 }
 
-// routeEvent finds the session for a raw kernel event, runs process-tree
-// tracking, and returns the session_id + correlator. Returns ("", nil) if the
-// event belongs to no registered session.
-func (d *daemon) routeEvent(evt *kernelcapture.ProcessEvent) (string, *kernelcapture.Correlator) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+// publishSessionRouteLocked publishes route while d.mu is held. The fallback
+// snapshot is copy-on-write so event readers can use an old slice after
+// releasing d.mu without racing registration or retirement.
+func (d *daemon) publishSessionRouteLocked(route *sessionRoute) {
+	if route == nil || route.sessionID == "" {
+		return
+	}
+	d.retireSessionRouteLocked(route.sessionID)
+	if d.routeIndex == nil {
+		d.routeIndex = make(map[string]*sessionRoute)
+	}
+	d.routeIndex[route.sessionID] = route
+	if route.scope != nil && route.scope.CgroupID == 0 {
+		next := make([]*sessionRoute, len(d.fallbackRoutes)+1)
+		copy(next, d.fallbackRoutes)
+		next[len(d.fallbackRoutes)] = route
+		d.fallbackRoutes = next
+	}
+}
 
-	// Fast path: cgroup match.
+// retireSessionRouteLocked marks one route inactive and removes it from future
+// lookups while d.mu is held. Taking route.mu waits for an already-matched
+// event to finish correlation and evidence append before teardown continues.
+func (d *daemon) retireSessionRouteLocked(sessionID string) {
+	route := d.routeIndex[sessionID]
+	if route == nil {
+		return
+	}
+	route.mu.Lock()
+	route.active = false
+	isFallback := route.scope != nil && route.scope.CgroupID == 0
+	route.mu.Unlock()
+	delete(d.routeIndex, sessionID)
+	if !isFallback {
+		return
+	}
+	next := make([]*sessionRoute, 0, len(d.fallbackRoutes)-1)
+	for _, candidate := range d.fallbackRoutes {
+		if candidate != route {
+			next = append(next, candidate)
+		}
+	}
+	d.fallbackRoutes = next
+}
+
+// lockRouteEvent finds and locks the route for evt. A non-nil result owns the
+// route mutex; the caller must invoke route.unlock().
+func (d *daemon) lockRouteEvent(evt *kernelcapture.ProcessEvent) *sessionRoute {
+	if evt == nil {
+		return nil
+	}
+	d.mu.RLock()
+	var fastRoute *sessionRoute
 	if evt.CgroupID != 0 {
-		if sid, ok := d.cgroupIndex[evt.CgroupID]; ok {
-			scope := d.treeScopes[sid]
-			if scope != nil && scope.MatchesAndTrack(*evt) {
-				evt.SessionID = sid
-				return sid, d.correlators[sid]
-			}
+		if sessionID, ok := d.cgroupIndex[evt.CgroupID]; ok {
+			fastRoute = d.routeIndex[sessionID]
 		}
 	}
-	// Slow path: walk all sessions and check process tree membership.
-	// This handles subtree events where the child has escaped to a new cgroup
-	// (uncommon but possible).
-	for sid, scope := range d.treeScopes {
-		if scope.MatchesAndTrack(*evt) {
-			evt.SessionID = sid
-			return sid, d.correlators[sid]
+	fallbackRoutes := d.fallbackRoutes
+	d.mu.RUnlock()
+
+	if fastRoute != nil && fastRoute.lockIfMatches(evt) {
+		return fastRoute
+	}
+	// Only zero-cgroup test/replay scopes can match outside the cgroup index.
+	// Nonzero production scopes enforce exact cgroup equality in MatchesAndTrack.
+	start := 0
+	if len(fallbackRoutes) > 0 {
+		start = int(evt.PID % uint32(len(fallbackRoutes)))
+	}
+	for offset := range fallbackRoutes {
+		route := fallbackRoutes[(start+offset)%len(fallbackRoutes)]
+		if route != fastRoute && route.lockIfMatches(evt) {
+			return route
 		}
 	}
-	return "", nil
+	return nil
+}
+
+// routeEvent is the lookup-only test seam. Production event processing uses
+// lockRouteEvent directly and holds the route lease through evidence append.
+func (d *daemon) routeEvent(evt *kernelcapture.ProcessEvent) (string, *kernelcapture.Correlator) {
+	route := d.lockRouteEvent(evt)
+	if route == nil {
+		return "", nil
+	}
+	sessionID, correlator := route.sessionID, route.correlator
+	route.unlock()
+	return sessionID, correlator
 }
 
 // appendKernelReceipt writes one KernelReceiptEntry as a JSONL line to
@@ -1046,10 +1157,15 @@ func (d *daemon) appendAndPersistTamperEntryLocked(entry kernelcapture.TamperRec
 // processKernelEvent is called by the platform-specific event loop for each
 // event that arrives from the eBPF ringbuf.
 func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent) {
-	sid, correlator := d.routeEvent(&evt)
-	if sid == "" || correlator == nil {
+	route := d.lockRouteEvent(&evt)
+	if route == nil {
 		return
 	}
+	defer route.unlock()
+	if route.correlator == nil {
+		return
+	}
+	sid, correlator := route.sessionID, route.correlator
 
 	receipt := correlator.Correlate(evt, kernelcapture.EventContext{})
 
@@ -1236,6 +1352,7 @@ func (d *daemon) pruneExpiredSessions() {
 	var expiredPolicies []expiredPolicy
 	for sid, scope := range d.treeScopes {
 		if _, err := d.registry.ActiveSession(sid); err != nil {
+			d.retireSessionRouteLocked(sid)
 			if scope.CgroupID != 0 {
 				delete(d.cgroupIndex, scope.CgroupID)
 				ep := expiredPolicy{cgroupID: scope.CgroupID}

--- a/go/cmd/ardur-kernelcaptured/route_benchmark_test.go
+++ b/go/cmd/ardur-kernelcaptured/route_benchmark_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+var benchmarkRouteSessionCounts = []int{1, 8, 64, 256}
+
+func BenchmarkRouteEventFastPathParallel(b *testing.B) {
+	for _, sessionCount := range benchmarkRouteSessionCounts {
+		b.Run(fmt.Sprintf("sessions-%d", sessionCount), func(b *testing.B) {
+			d := newBenchmarkRouteDaemon(sessionCount)
+			assertBenchmarkRouteMatch(b, d, 0)
+			var next atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					index := int(next.Add(1)-1) % sessionCount
+					evt := benchmarkRouteEvent(index)
+					d.routeEvent(&evt)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkRouteEventUnownedParallel(b *testing.B) {
+	for _, sessionCount := range benchmarkRouteSessionCounts {
+		b.Run(fmt.Sprintf("sessions-%d", sessionCount), func(b *testing.B) {
+			d := newBenchmarkRouteDaemon(sessionCount)
+			evt := kernelcapture.ProcessEvent{PID: 1, CgroupID: ^uint64(0), Type: kernelcapture.ProcessEventExec}
+			if sid, correlator := d.routeEvent(&evt); sid != "" || correlator != nil {
+				b.Fatalf("unowned probe routed to session %q", sid)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					probe := evt
+					d.routeEvent(&probe)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkRouteEventFallbackParallel(b *testing.B) {
+	for _, sessionCount := range benchmarkRouteSessionCounts {
+		b.Run(fmt.Sprintf("sessions-%d", sessionCount), func(b *testing.B) {
+			d := newBenchmarkFallbackRouteDaemon(sessionCount)
+			var next atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					index := int(next.Add(1)-1) % sessionCount
+					evt := benchmarkFallbackRouteEvent(index)
+					d.routeEvent(&evt)
+				}
+			})
+		})
+	}
+}
+
+func newBenchmarkRouteDaemon(sessionCount int) *daemon {
+	d := &daemon{
+		log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cgroupIndex: make(map[uint64]string, sessionCount),
+		treeScopes:  make(map[string]*kernelcapture.ProcessTreeScope, sessionCount),
+		correlators: make(map[string]*kernelcapture.Correlator, sessionCount),
+		routeIndex:  make(map[string]*sessionRoute, sessionCount),
+	}
+	for index := 0; index < sessionCount; index++ {
+		sessionID := benchmarkRouteSessionID(index)
+		evt := benchmarkRouteEvent(index)
+		scope := kernelcapture.NewProcessTreeScope(evt.PID, evt.CgroupID)
+		scope.SessionID = sessionID
+		d.cgroupIndex[evt.CgroupID] = sessionID
+		d.treeScopes[sessionID] = &scope
+		correlator := kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{})
+		d.correlators[sessionID] = correlator
+		d.publishSessionRouteLocked(newSessionRoute(sessionID, &scope, correlator))
+	}
+	return d
+}
+
+func newBenchmarkFallbackRouteDaemon(sessionCount int) *daemon {
+	d := newBenchmarkRouteDaemon(0)
+	for index := 0; index < sessionCount; index++ {
+		sessionID := benchmarkRouteSessionID(index)
+		evt := benchmarkFallbackRouteEvent(index)
+		scope := kernelcapture.NewProcessTreeScope(evt.PID, 0)
+		scope.SessionID = sessionID
+		d.treeScopes[sessionID] = &scope
+		correlator := kernelcapture.NewCorrelator(kernelcapture.CorrelatorOptions{})
+		d.correlators[sessionID] = correlator
+		d.publishSessionRouteLocked(newSessionRoute(sessionID, &scope, correlator))
+	}
+	return d
+}
+
+func assertBenchmarkRouteMatch(b *testing.B, d *daemon, index int) {
+	b.Helper()
+	evt := benchmarkRouteEvent(index)
+	want := benchmarkRouteSessionID(index)
+	if sid, correlator := d.routeEvent(&evt); sid != want || correlator == nil {
+		b.Fatalf("fast-path probe = (%q, %v), want (%q, non-nil)", sid, correlator, want)
+	}
+}
+
+func benchmarkRouteEvent(index int) kernelcapture.ProcessEvent {
+	return kernelcapture.ProcessEvent{
+		PID:      uint32(1_000 + index),
+		CgroupID: uint64(10_000 + index),
+		Type:     kernelcapture.ProcessEventExec,
+	}
+}
+
+func benchmarkFallbackRouteEvent(index int) kernelcapture.ProcessEvent {
+	return kernelcapture.ProcessEvent{
+		PID:  uint32(1_000 + index),
+		Type: kernelcapture.ProcessEventExec,
+	}
+}
+
+func benchmarkRouteSessionID(index int) string {
+	return fmt.Sprintf("benchmark-session-%d", index)
+}


### PR DESCRIPTION
## Summary

- replace the daemon-wide write lock in lifecycle routing with immutable route publication and per-session route leases
- keep mutable `ProcessTreeScope` maps under the owning route mutex
- restrict fallback scans to zero-cgroup test/replay scopes, the only scopes whose match contract permits cross-cgroup lookup
- hold matched production leases through correlation/evidence append so session retirement invalidates stale snapshots and waits for prior work
- add permanent fast, unowned, and fallback parallel benchmarks plus concurrent retirement race tests

## Correctness boundaries

- lock order is `lifecycleDropMu -> d.mu -> sessionRoute.mu`; lifecycle processing never reacquires `d.mu` while holding a route lease
- fallback snapshots are copy-on-write, so readers use immutable backing arrays after releasing `d.mu`
- route identity is pointer-generation based: retired snapshots remain reachable but fail closed on `active=false`
- this PR does **not** claim kernel-side cgroup filtering; production filter-map ownership/restart behavior is tracked in #226

## Benchmark results

Apple M4 Max, darwin/arm64, `-cpu=8 -benchtime=300ms -count=5`, median ns/op, zero allocations throughout:

| Path | Sessions | Before | After | Result |
|---|---:|---:|---:|---:|
| registered fast hit | 1 | 122.2 | 176.7 | 45% slower |
| registered fast hit | 8 | 152.4 | 112.1 | 26% faster |
| registered fast hit | 64 | 193.8 | 107.7 | 44% faster |
| registered fast hit | 256 | 219.8 | 109.5 | 50% faster |
| production unowned miss | 1 | 125.3 | 75.8 | 40% faster |
| production unowned miss | 8 | 199.3 | 76.3 | 62% faster |
| production unowned miss | 64 | 769.3 | 77.3 | 90% faster |
| production unowned miss | 256 | 2845 | 79.0 | 36x faster |

The one-session fast-path tradeoff is about 55 ns and remains sub-200 ns. Valid zero-cgroup fallback is faster at 1/8/256 sessions; the 64-session replay-only point is about 15% slower (686 -> 788 ns).

## Validation

- `go test -race ./cmd/ardur-kernelcaptured`
- `go test ./...`
- `go vet ./...`
- Linux arm64 cross-build: `GOOS=linux GOARCH=arm64 go build ./...`
- benchmark suite above, repeated before/after with zero allocations

Fixes #88