### PR TITLE
fix(seccomp): preserve governance control-plane access

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ claim.
 
 ## Verification Snapshot
 
-At the reviewed `dev` tree on 2026-07-09, the current gates were:
+At the reviewed `dev` tree on 2026-07-10, the current gates were:
 
 | Gate | Verified result |
 |---|---|
-| Python local matrix (Python 3.13) | 1,600 passed, 32 skipped; CI separately enforces its coverage threshold |
+| Python local matrix (Python 3.13) | 1,601 passed, 32 skipped; CI separately enforces its coverage threshold |
 | Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
 | Go CI | Tests, vet, lint, and vulnerability scan passed |
-| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
 | Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
 These gates verify the checked-in runtime and its configured integration

--- a/docs/demo/enforce-e2e.md
+++ b/docs/demo/enforce-e2e.md
@@ -76,6 +76,45 @@ The image builds `ardur-kernelcaptured` and the `enforce-verify` tool from
 source (the committed `processguard_bpfel.o` is used as-is — no clang needed)
 and installs the `ardur` CLI.
 
+## Run — seccomp fallback control-plane proof
+
+The seccomp path is an independent full `ardur run` E2E and does not require
+`bpf` in the active LSM list. The demo forces `-disable-bpf-lsm`, then runs a
+network-deny mission through the seccomp listener:
+
+```console
+$ docker run --rm --privileged --pid=host \
+    -v /tmp/ardur-demo-out:/out \
+    ardur-enforce-demo \
+    bash /opt/ardur/demo/run-seccomp.sh enforce
+```
+
+The agent first completes an authenticated `/evaluate` call and produces a
+signed governance receipt. It then deliberately attempts a separate
+`127.0.0.3:19999` connection so the kernel tier is tested independently of the
+proxy decision. The script requires the governance decision, a non-zero
+evaluated-call and receipt count, `DENIED_EPERM`, an exact denied data-plane
+event, no control-plane event, an intact evidence chain, and an attestation
+digest match. Every assertion is fail-fast.
+
+The governance exception is one daemon-stored IP-and-port tuple, not loopback
+or CIDR allowlisting. The supervisor connects a `pidfd_getfd(2)` duplicate of
+the target socket using trusted tuple bytes and returns success without
+`SECCOMP_USER_NOTIF_FLAG_CONTINUE`; see
+[Kernel Capture Daemon Operations](../reference/kernel-capture-daemon.md#seccomp-governance-endpoint)
+for the Linux 5.6 and ptrace-permission requirements and the remaining tier
+boundary.
+
+The paired permissive control uses the same governance call and data-plane
+target but expects `ECONNREFUSED` and zero denied verdicts:
+
+```console
+$ docker run --rm --privileged --pid=host \
+    -v /tmp/ardur-demo-out:/out \
+    ardur-enforce-demo \
+    bash /opt/ardur/demo/run-seccomp.sh permissive
+```
+
 ---
 
 ## Run — enforce (known bootstrap failure)

--- a/docs/demo/enforce-e2e/agent_seccomp.py
+++ b/docs/demo/enforce-e2e/agent_seccomp.py
@@ -8,13 +8,18 @@ contract as agent.py: sleep first so ardur-exec-shim's handoff to the daemon
 has landed before the probe runs (register_session/apply_policy/handoff all
 race the agent's own startup, same as the BPF-LSM path's apply_policy race).
 
-Under --enforce (OP_NET_CONNECT deny, seccomp tier active) the kernel refuses
-the connect with EPERM; under permissive the same op is logged but allowed.
+The agent first performs a real authenticated /evaluate request against the
+embedded governance bridge. Under --enforce (OP_NET_CONNECT deny, seccomp tier
+active) that exact daemon-owned control-plane tuple remains reachable, while
+the later unrelated loopback connect is refused with EPERM. Under permissive
+the same data-plane op is logged but allowed.
 """
 import errno
+import json
 import os
 import socket
 import time
+import urllib.request
 
 DELAY = float(os.environ.get("AGENT_DELAY", "4"))
 TARGET_HOST = os.environ.get("AGENT_CONNECT_HOST", "127.0.0.3")
@@ -29,6 +34,25 @@ print(f"AGENT: pid={os.getpid()} cgroup={cgline}", flush=True)
 
 print(f"AGENT: sleeping {DELAY}s for the seccomp handoff to land...", flush=True)
 time.sleep(DELAY)
+
+request = urllib.request.Request(
+    os.environ["ARDUR_PROXY_URL"] + "/evaluate",
+    data=json.dumps(
+        {
+            "session_id": os.environ["ARDUR_SESSION_ID"],
+            "tool_name": "fetch",
+            "arguments": {"url": f"http://{TARGET_HOST}:{TARGET_PORT}/probe"},
+        }
+    ).encode(),
+    method="POST",
+    headers={
+        "Authorization": "Bearer " + os.environ["ARDUR_API_TOKEN"],
+        "Content-Type": "application/json",
+    },
+)
+with urllib.request.urlopen(request, timeout=5) as response:
+    governance = json.loads(response.read())
+print(f"AGENT: governance decision={governance['decision']} before connect", flush=True)
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 try:

--- a/docs/demo/enforce-e2e/run-seccomp.sh
+++ b/docs/demo/enforce-e2e/run-seccomp.sh
@@ -7,10 +7,24 @@
 # even on a host (like this image's kernel) where BPF-LSM would otherwise win
 # tier selection.
 #   Usage: run-seccomp.sh <enforce|permissive>
-set -u
+set -euo pipefail
 MODE="${1:-enforce}"
 OUT="/out/seccomp-${MODE}"; mkdir -p "$OUT"
 DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+DPID=""
+
+cleanup() {
+  if [ -n "$DPID" ]; then
+    kill "$DPID" 2>/dev/null || true
+    wait "$DPID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+case "$MODE" in
+  enforce|permissive) ;;
+  *) echo "usage: $0 <enforce|permissive>" >&2; exit 2 ;;
+esac
 
 echo "============ ardur run seccomp-tier demo — mode=${MODE} ============"
 
@@ -32,11 +46,20 @@ for _ in $(seq 1 40); do
   kill -0 $DPID 2>/dev/null || { echo "daemon died:"; cat "$OUT/daemon.log"; exit 1; }
   sleep 0.25
 done
-grep -q "seccomp handoff socket listening" "$OUT/daemon.log" \
-  && echo "daemon: seccomp tier active, handoff socket listening ✓" \
-  || { echo "daemon: seccomp handoff socket never came up"; tail -5 "$OUT/daemon.log"; kill $DPID; exit 1; }
-grep -q "\"tier\":\"seccomp\"" "$OUT/daemon.log" \
-  && echo "daemon: enforcement_tier=seccomp confirmed (BPF-LSM was disabled, not just unavailable) ✓"
+if grep -q "seccomp handoff socket listening" "$OUT/daemon.log"; then
+  echo "daemon: seccomp tier active, handoff socket listening ✓"
+else
+  echo "daemon: seccomp handoff socket never came up"
+  tail -5 "$OUT/daemon.log"
+  exit 1
+fi
+if grep -q "\"tier\":\"seccomp\"" "$OUT/daemon.log"; then
+  echo "daemon: enforcement_tier=seccomp confirmed (BPF-LSM was disabled, not just unavailable) ✓"
+else
+  echo "daemon: expected seccomp tier was not selected"
+  tail -10 "$OUT/daemon.log"
+  exit 1
+fi
 
 # 2. ardur run a benign agent under a mission that forbids network access.
 #    --no-resource-scope: skip the default cwd file allowlist, which the
@@ -55,12 +78,38 @@ ardur run \
   $ENF \
   -- python3 "$DEMO_DIR/agent_seccomp.py" 2>&1 | tee "$OUT/ardur-run.log" | grep -E "AGENT:|kernel policy|kernel link|attestation|agent exit|ardur-exec-shim|ardur run:"
 
+grep -q "AGENT: governance decision=DENY before connect" "$OUT/ardur-run.log"
+grep -Eq "tool calls[[:space:]]+[1-9][0-9]* evaluated" "$OUT/ardur-run.log"
+grep -Eq "receipts[[:space:]]+[1-9][0-9]* signed" "$OUT/ardur-run.log"
+grep -Eq "agent exit[[:space:]]+0$" "$OUT/ardur-run.log"
+if [ "$MODE" = "enforce" ]; then
+  grep -q "AGENT: RESULT=DENIED_EPERM" "$OUT/ardur-run.log"
+else
+  grep -q "AGENT: RESULT=DENIED_ECONNREFUSED" "$OUT/ardur-run.log"
+fi
+
 # 3. offline evidence verification: hash-chain integrity + attestation linkage.
 #    Same enforce_events.jsonl format and same enforce-verify tool as the
 #    BPF-LSM demo — the E3 evidence pipeline is shared across both tiers.
-EVID=$(find /var/lib/ardur/kernelcapture/evidence -name enforce_events.jsonl 2>/dev/null | head -1)
+EVID=$(find /var/lib/ardur/kernelcapture/evidence -name enforce_events.jsonl -print -quit 2>/dev/null)
 if [ -n "$EVID" ]; then
   cp "$EVID" "$OUT/enforce_events.jsonl"
+  python3 - "$OUT/enforce_events.jsonl" "$MODE" <<'PY'
+import json
+import sys
+
+path, mode = sys.argv[1:]
+entries = [json.loads(line) for line in open(path, encoding="utf-8") if line.strip()]
+targets = [(entry.get("event") or {}).get("Path", "") for entry in entries]
+if "127.0.0.3:19999" not in targets:
+    raise SystemExit(f"FAIL: exact data-plane target missing from evidence: {targets}")
+if any(target.startswith("127.0.0.1:") for target in targets):
+    raise SystemExit(f"FAIL: control-plane exemption emitted as mission evidence: {targets}")
+denied = sum(entry.get("verdict") == "denied" for entry in entries)
+if mode == "enforce" and denied < 1:
+    raise SystemExit("FAIL: enforce mode produced no denied data-plane verdict")
+print(f"seccomp evidence exact data-plane target = 127.0.0.3:19999; denied verdicts = {denied}")
+PY
   DIGEST=$(python3 - "/out/home-seccomp-${MODE}" <<'PY'
 import base64, glob, json, os, sys
 home = sys.argv[1]
@@ -80,12 +129,14 @@ PY
 )
   echo "------ offline verification (no kernel, no daemon, no root) ------"
   echo "attestation kernel_enforcement.chain_digest = ${DIGEST:-<none>}"
-  enforce-verify "$OUT/enforce_events.jsonl" ${DIGEST:+$DIGEST}
-  echo "enforce-verify exit: $?"
+  [ -n "$DIGEST" ] || { echo "FAIL: attestation has no kernel-enforcement chain digest"; exit 1; }
+  enforce-verify "$OUT/enforce_events.jsonl" "$DIGEST"
+  echo "enforce-verify exit: 0"
 else
-  echo "no enforce_events.jsonl produced — nothing to verify"
-  [ "$MODE" = "enforce" ] && { echo "FAIL: enforce mode must produce evidence of the denial"; kill $DPID 2>/dev/null; exit 1; }
+  echo "FAIL: no enforce_events.jsonl produced for the data-plane probe"
+  exit 1
 fi
 
-kill $DPID 2>/dev/null; wait $DPID 2>/dev/null
+cleanup
+DPID=""
 echo "== seccomp demo (${MODE}) done =="

--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -28,6 +28,45 @@ consumer. A healthy socket in this mode proves control-plane liveness only; it
 does not prove that a governed process is observed or constrained below the
 tool-call boundary.
 
+## Seccomp governance endpoint
+
+On a seccomp-tier `ardur run`, the network policy also traps the agent's TCP
+connection to the run's embedded governance proxy. The authenticated,
+session-owning parent includes that proxy's exact literal loopback IP and port
+in `apply_policy`. The daemon validates the tuple and stores it separately from
+the mission's `net_allow`; hostnames, non-loopback addresses, port zero, an
+endpoint without `OP_NET_CONNECT`, and broad `127/8` or `::1` CIDR exceptions
+are not accepted.
+
+For that exact tuple only, the daemon does not resume the tracee's original
+`connect(2)` with `SECCOMP_USER_NOTIF_FLAG_CONTINUE`. Another target thread
+could rewrite a pointer argument after inspection. Instead, the supervisor
+uses `pidfd_open(2)` and `pidfd_getfd(2)` to duplicate the target socket,
+connects the shared socket using the daemon-stored tuple, revalidates the
+notification, and returns synthetic success with no continue flag. Any lookup,
+permission, duplication, connect, or notification-validity failure returns
+`EPERM`. The control connection is transport plumbing and does not emit a
+mission enforcement event; unrelated loopback connections still follow the
+mission policy and remain visible in evidence.
+
+This emulation requires Linux 5.6 or newer and permission for the daemon to
+perform the kernel's `PTRACE_MODE_ATTACH_REALCREDS` check for the target. A
+production daemon normally satisfies that through its privileged service
+identity; restrictive capability, Yama, LSM, or container settings can still
+deny it, in which case the connection fails closed. See the Linux kernel
+[seccomp user-notification documentation](https://docs.kernel.org/userspace-api/seccomp_filter.html),
+[`seccomp_unotify(2)`](https://www.man7.org/linux/man-pages/man2/seccomp_unotify.2.html),
+and [`pidfd_getfd(2)`](https://www.man7.org/linux/man-pages/man2/pidfd_getfd.2.html).
+The shipped systemd unit includes `CAP_SYS_PTRACE` in both its ambient and
+bounding sets and explicitly permits `pidfd_open` and `pidfd_getfd`; custom
+units must preserve those three requirements for the seccomp endpoint path.
+
+Ordinary seccomp mission-policy allows still use `CONTINUE` and retain the
+documented weaker-than-BPF-LSM race boundary. The BPF-LSM tier does not use the
+endpoint field or this emulation path. Its full enforce-mode launch bootstrap
+remains tracked separately in
+[#241](https://github.com/ArdurAI/ardur/issues/241).
+
 ## Process lifecycle cgroup filter
 
 The production lifecycle consumer pins `filter_control` and `allowed_cgroups`

--- a/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"testing"
@@ -76,6 +77,43 @@ func TestHandleApplyPolicy_ForeignPeerRejected(t *testing.T) {
 	respOwner := d.handleApplyPolicy(applyPolicyReqFor("ses-owned", kernelcapture.BpfEnforceModePermissive), owner)
 	if strings.Contains(respOwner.Error, "owned by a different peer") {
 		t.Fatalf("owning peer apply_policy was wrongly rejected for ownership: %+v", respOwner)
+	}
+}
+
+func TestHandleApplyPolicy_ForeignPeerCannotInstallControlPlaneEndpoint(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	d.activeTier = daemonTierSeccomp
+	registerTestSession(t, d, "ses-control-owned", 4201)
+
+	req := applyNetConnectPolicyReqFor(
+		"ses-control-owned", kernelcapture.BpfActionDeny, kernelcapture.BpfEnforceModeEnforce,
+	)
+	req.ApplyPolicy.ControlPlaneEndpoint = &kernelcapture.DaemonControlPlaneEndpoint{
+		IP: "127.0.0.1", Port: 43210,
+	}
+
+	foreign := testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodApplyPolicy, 501)
+	foreign.Authorization.PID = 9999
+	foreign.ProcessStartTimeTicks = 123456
+	foreign.Authorization.ProcessStartTimeTicks = 123456
+	if resp := d.handleApplyPolicy(req, foreign); resp.OK {
+		t.Fatalf("foreign peer installed control-plane endpoint: %+v", resp)
+	}
+	if _, _, ok := kernelcapture.MatchSeccompControlPlaneEndpoint(
+		d.seccompPolicy, "ses-control-owned", net.ParseIP("127.0.0.1"), 43210,
+	); ok {
+		t.Fatal("foreign peer rejection still mutated the seccomp control-plane store")
+	}
+
+	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
+	if resp := d.handleApplyPolicy(req, owner); !resp.OK {
+		t.Fatalf("session-owning peer could not install control-plane endpoint: %+v", resp)
+	}
+	if _, _, ok := kernelcapture.MatchSeccompControlPlaneEndpoint(
+		d.seccompPolicy, "ses-control-owned", net.ParseIP("127.0.0.1"), 43210,
+	); !ok {
+		t.Fatal("session-owning peer did not install the exact control-plane endpoint")
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
@@ -274,6 +274,20 @@ func (d *daemon) handleSeccompConnectNotif(listenerFD int, notif kernelcapture.S
 		return
 	}
 
+	if trustedIP, trustedPort, controlPlane := kernelcapture.MatchSeccompControlPlaneEndpoint(
+		d.seccompPolicy, sessionID, ip, port,
+	); controlPlane {
+		if err := kernelcapture.EmulateSeccompControlPlaneConnect(listenerFD, notif, trustedIP, trustedPort); err != nil {
+			d.respondSeccompControlPlaneFailClosed(listenerFD, notif, sessionID, log, err)
+			return
+		}
+		if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, 0, 0, false); err != nil {
+			log.Warn("seccomp notif send (control-plane emulated success)", "session_id", sessionID, "error", err)
+		}
+		log.Debug("seccomp control-plane connect emulated", "session_id", sessionID, "pid", notif.PID, "endpoint", fmt.Sprintf("%s:%d", trustedIP, trustedPort))
+		return
+	}
+
 	decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, sessionID, ip)
 	if !decision.HasPolicy {
 		// No OP_NET_CONNECT rule for this session: pass through untouched
@@ -304,6 +318,13 @@ func (d *daemon) handleSeccompConnectNotif(listenerFD int, notif kernelcapture.S
 		actionTaken = kernelcapture.BpfActionAllow
 	}
 	d.emitSeccompConnectEvent(cgroupID, notif.PID, actionTaken, decision.EnforceMode, ip, port, log)
+}
+
+func (d *daemon) respondSeccompControlPlaneFailClosed(listenerFD int, notif kernelcapture.SeccompNotif, sessionID string, log *slog.Logger, cause error) {
+	log.Warn("seccomp control-plane connect denied: emulation failed", "session_id", sessionID, "pid", notif.PID, "error", cause)
+	if err := kernelcapture.SendSeccompNotifResp(listenerFD, notif.ID, -1, int32(unix.EPERM), false); err != nil {
+		log.Warn("seccomp notif send (control-plane fail-closed deny)", "session_id", sessionID, "error", err)
+	}
 }
 
 // respondSeccompFailClosed answers a notification with EPERM and logs why,

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 )
 
@@ -77,12 +78,22 @@ type DaemonSetKillSwitchRequest struct {
 // apply for this session.  The BPF program uses the generation to detect stale
 // map entries left over from a prior policy cycle.
 type DaemonApplyPolicyRequest struct {
-	SessionID   string              `json:"session_id"`
-	OpPolicies  []DaemonOpPolicy    `json:"op_policies"`
-	PathAllow   []string            `json:"path_allow,omitempty"`
-	NetAllow    []string            `json:"net_allow,omitempty"` // CIDR strings (IPv4 or IPv6)
-	Generation  BpfPolicyGeneration `json:"generation"`
-	EnforceMode BpfEnforceMode      `json:"enforce_mode"` // default mode for no-rule ops
+	SessionID            string                      `json:"session_id"`
+	OpPolicies           []DaemonOpPolicy            `json:"op_policies"`
+	PathAllow            []string                    `json:"path_allow,omitempty"`
+	NetAllow             []string                    `json:"net_allow,omitempty"` // CIDR strings (IPv4 or IPv6)
+	Generation           BpfPolicyGeneration         `json:"generation"`
+	EnforceMode          BpfEnforceMode              `json:"enforce_mode"` // default mode for no-rule ops
+	ControlPlaneEndpoint *DaemonControlPlaneEndpoint `json:"control_plane_endpoint,omitempty"`
+}
+
+// DaemonControlPlaneEndpoint is the exact loopback listener owned by the
+// authenticated ardur-run bridge. It is deliberately separate from NetAllow:
+// the seccomp supervisor may emulate a connect to this one tuple, but it must
+// never turn into a mission-controlled CIDR or wildcard exception.
+type DaemonControlPlaneEndpoint struct {
+	IP   string `json:"ip"`
+	Port uint16 `json:"port"`
 }
 
 // DaemonOpPolicy is one (op, action, enforce_mode) triple in an apply_policy
@@ -365,12 +376,41 @@ func validateDaemonApplyPolicy(req DaemonApplyPolicyRequest) error {
 			return fmt.Errorf("%w: apply_policy path_allow[%d]: path %q must be absolute", ErrDaemonProtocol, i, p)
 		}
 	}
+	if req.ControlPlaneEndpoint != nil {
+		if _, ok := seenOps[BpfOpNetConnect]; !ok {
+			return fmt.Errorf("%w: apply_policy control_plane_endpoint requires OP_NET_CONNECT", ErrDaemonProtocol)
+		}
+		if _, err := parseDaemonControlPlaneEndpoint(*req.ControlPlaneEndpoint); err != nil {
+			return fmt.Errorf("%w: apply_policy control_plane_endpoint: %v", ErrDaemonProtocol, err)
+		}
+	}
 	switch req.EnforceMode {
 	case BpfEnforceModePermissive, BpfEnforceModeEnforce:
 	default:
 		return fmt.Errorf("%w: apply_policy unknown enforce_mode %d", ErrDaemonProtocol, req.EnforceMode)
 	}
 	return nil
+}
+
+func parseDaemonControlPlaneEndpoint(endpoint DaemonControlPlaneEndpoint) (net.IP, error) {
+	if endpoint.Port == 0 {
+		return nil, fmt.Errorf("port must be non-zero")
+	}
+	ipText := strings.TrimSpace(endpoint.IP)
+	if ipText != endpoint.IP || ipText == "" {
+		return nil, fmt.Errorf("ip must be a non-empty literal without surrounding whitespace")
+	}
+	ip := net.ParseIP(ipText)
+	if ip == nil {
+		return nil, fmt.Errorf("ip %q must be a literal address", endpoint.IP)
+	}
+	if !ip.IsLoopback() {
+		return nil, fmt.Errorf("ip %q must be loopback", endpoint.IP)
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return append(net.IP(nil), ip4...), nil
+	}
+	return append(net.IP(nil), ip.To16()...), nil
 }
 
 func validateDaemonRegisterSession(req DaemonRegisterSessionRequest) error {

--- a/go/pkg/kernelcapture/daemon_protocol_test.go
+++ b/go/pkg/kernelcapture/daemon_protocol_test.go
@@ -211,6 +211,55 @@ func TestDaemonProtocolDecodeRejectsRegisterSessionWithoutRootPID(t *testing.T) 
 	}
 }
 
+func TestDaemonApplyPolicyControlPlaneEndpointValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := DaemonApplyPolicyRequest{
+		SessionID: "session-1",
+		OpPolicies: []DaemonOpPolicy{{
+			Op:          BpfOpNetConnect,
+			Action:      BpfActionDeny,
+			EnforceMode: BpfEnforceModeEnforce,
+		}},
+		Generation:  1,
+		EnforceMode: BpfEnforceModeEnforce,
+		ControlPlaneEndpoint: &DaemonControlPlaneEndpoint{
+			IP:   "127.0.0.1",
+			Port: 43210,
+		},
+	}
+	if err := validateDaemonApplyPolicy(valid); err != nil {
+		t.Fatalf("valid exact loopback endpoint rejected: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		endpoint DaemonControlPlaneEndpoint
+	}{
+		{name: "remote IPv4", endpoint: DaemonControlPlaneEndpoint{IP: "192.0.2.10", Port: 43210}},
+		{name: "remote IPv6", endpoint: DaemonControlPlaneEndpoint{IP: "2001:db8::1", Port: 43210}},
+		{name: "hostname", endpoint: DaemonControlPlaneEndpoint{IP: "localhost", Port: 43210}},
+		{name: "unspecified IPv4", endpoint: DaemonControlPlaneEndpoint{IP: "0.0.0.0", Port: 43210}},
+		{name: "zero port", endpoint: DaemonControlPlaneEndpoint{IP: "127.0.0.1", Port: 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := valid
+			req.ControlPlaneEndpoint = &tc.endpoint
+			if err := validateDaemonApplyPolicy(req); err == nil || !errors.Is(err, ErrDaemonProtocol) {
+				t.Fatalf("validate endpoint %#v error = %v, want ErrDaemonProtocol", tc.endpoint, err)
+			}
+		})
+	}
+
+	withoutNetPolicy := valid
+	withoutNetPolicy.OpPolicies = []DaemonOpPolicy{{
+		Op: BpfOpExec, Action: BpfActionDeny, EnforceMode: BpfEnforceModeEnforce,
+	}}
+	if err := validateDaemonApplyPolicy(withoutNetPolicy); err == nil || !errors.Is(err, ErrDaemonProtocol) {
+		t.Fatalf("endpoint without OP_NET_CONNECT error = %v, want ErrDaemonProtocol", err)
+	}
+}
+
 func TestDaemonProtocolValidationRejectsForbiddenHandoffMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/go/pkg/kernelcapture/seccomp_notify_linux.go
+++ b/go/pkg/kernelcapture/seccomp_notify_linux.go
@@ -22,8 +22,10 @@ package kernelcapture
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"runtime"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -61,9 +63,9 @@ const (
 	// syscall proceed with whatever arguments are in the tracee's registers
 	// *at the moment the kernel resumes it* — not necessarily the ones the
 	// supervisor read via NOTIF_RECV. It is only ever set on a
-	// confirmed-safe ALLOW decision in seccomp_supervisor_linux.go, never as
-	// a default — see that file's decide function for the fail-closed
-	// contract.
+	// confirmed mission-policy ALLOW decision in
+	// daemon_seccomp_linux.go, never for the exact governance control-plane
+	// exemption and never as a default.
 	seccompUserNotifFlagContinue = 1 << 0
 
 	seccompRetAllow       = 0x7fff0000 // SECCOMP_RET_ALLOW
@@ -299,6 +301,138 @@ func buildSeccompNotifResp(id uint64, val int64, errno int32, continueSyscall bo
 func SeccompNotifIDValid(listenerFD int, id uint64) bool {
 	localID := id
 	return seccompIoctl(listenerFD, seccompIoctlNotifIDValid, unsafe.Pointer(&localID)) == nil
+}
+
+// EmulateSeccompControlPlaneConnect connects the tracee's socket to one
+// daemon-validated loopback tuple without resuming the original connect(2).
+// pidfd_getfd returns a duplicate that shares the socket's open file
+// description with the tracee, so connecting the duplicate connects the
+// socket on which the blocked target thread is waiting. The caller must then
+// answer the notification with synthetic success and continueSyscall=false.
+//
+// This path exists specifically to avoid SECCOMP_USER_NOTIF_FLAG_CONTINUE's
+// pointer-argument race: the destination passed to unix.Connect is built from
+// daemon-owned bytes, not from the tracee's mutable sockaddr memory.
+func EmulateSeccompControlPlaneConnect(listenerFD int, notif SeccompNotif, ip net.IP, port uint16) error {
+	if notif.PID == 0 {
+		return fmt.Errorf("kernelcapture: seccomp control-plane connect target pid is 0")
+	}
+	targetFD := notif.Args[0]
+	if targetFD > uint64(^uint(0)>>1) {
+		return fmt.Errorf("kernelcapture: seccomp control-plane connect target fd %d overflows int", targetFD)
+	}
+	destination, err := trustedSeccompControlPlaneSockaddr(ip, port)
+	if err != nil {
+		return err
+	}
+	if !SeccompNotifIDValid(listenerFD, notif.ID) {
+		return fmt.Errorf("kernelcapture: notification %d no longer valid before socket duplication", notif.ID)
+	}
+
+	pidfd, err := unix.PidfdOpen(int(notif.PID), 0)
+	if err != nil {
+		return fmt.Errorf("kernelcapture: pidfd_open(%d): %w", notif.PID, err)
+	}
+	defer unix.Close(pidfd)
+
+	dupFD, err := unix.PidfdGetfd(pidfd, int(targetFD), 0)
+	if err != nil {
+		return fmt.Errorf("kernelcapture: pidfd_getfd(pid=%d, fd=%d): %w", notif.PID, targetFD, err)
+	}
+	defer unix.Close(dupFD)
+
+	if err := connectTrustedSeccompSocket(dupFD, destination, ip, port); err != nil {
+		return err
+	}
+	if !SeccompNotifIDValid(listenerFD, notif.ID) {
+		return fmt.Errorf("kernelcapture: notification %d no longer valid after socket connect", notif.ID)
+	}
+	return nil
+}
+
+const seccompControlPlaneConnectTimeoutMS = 5000
+
+func connectTrustedSeccompSocket(fd int, destination unix.Sockaddr, trustedIP net.IP, trustedPort uint16) error {
+	err := unix.Connect(fd, destination)
+	switch err {
+	case nil, unix.EISCONN:
+		// Verify the peer below. EISCONN is safe only if the socket is already
+		// connected to the exact daemon-owned tuple.
+	case unix.EINPROGRESS, unix.EALREADY, unix.EINTR:
+		if fd > int(^uint32(0)>>1) {
+			return fmt.Errorf("kernelcapture: duplicated target fd %d overflows poll fd", fd)
+		}
+		pollFDs := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}
+		deadline := time.Now().Add(seccompControlPlaneConnectTimeoutMS * time.Millisecond)
+		for {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return fmt.Errorf("kernelcapture: duplicated control-plane socket connect timed out")
+			}
+			timeoutMS := int((remaining + time.Millisecond - 1) / time.Millisecond)
+			n, pollErr := unix.Poll(pollFDs, timeoutMS)
+			if pollErr == unix.EINTR {
+				continue
+			}
+			if pollErr != nil {
+				return fmt.Errorf("kernelcapture: poll duplicated control-plane socket: %w", pollErr)
+			}
+			if n == 0 {
+				return fmt.Errorf("kernelcapture: duplicated control-plane socket connect timed out")
+			}
+			break
+		}
+		socketErr, getErr := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ERROR)
+		if getErr != nil {
+			return fmt.Errorf("kernelcapture: read duplicated control-plane socket SO_ERROR: %w", getErr)
+		}
+		if socketErr != 0 {
+			return fmt.Errorf("kernelcapture: asynchronous duplicated control-plane socket connect: %w", unix.Errno(socketErr))
+		}
+	default:
+		return fmt.Errorf("kernelcapture: connect duplicated target socket to trusted control plane: %w", err)
+	}
+
+	peer, err := unix.Getpeername(fd)
+	if err != nil {
+		return fmt.Errorf("kernelcapture: getpeername duplicated control-plane socket: %w", err)
+	}
+	if !seccompSockaddrMatchesEndpoint(peer, trustedIP, trustedPort) {
+		return fmt.Errorf("kernelcapture: duplicated socket peer does not match trusted control-plane endpoint")
+	}
+	return nil
+}
+
+func seccompSockaddrMatchesEndpoint(sockaddr unix.Sockaddr, ip net.IP, port uint16) bool {
+	switch addr := sockaddr.(type) {
+	case *unix.SockaddrInet4:
+		return addr.Port == int(port) && ip.To4() != nil && net.IP(addr.Addr[:]).Equal(ip)
+	case *unix.SockaddrInet6:
+		return addr.Port == int(port) && ip.To4() == nil && net.IP(addr.Addr[:]).Equal(ip)
+	default:
+		return false
+	}
+}
+
+func trustedSeccompControlPlaneSockaddr(ip net.IP, port uint16) (unix.Sockaddr, error) {
+	if port == 0 {
+		return nil, fmt.Errorf("kernelcapture: seccomp control-plane port must be non-zero")
+	}
+	if ip == nil || !ip.IsLoopback() {
+		return nil, fmt.Errorf("kernelcapture: seccomp control-plane IP must be loopback")
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		addr := &unix.SockaddrInet4{Port: int(port)}
+		copy(addr.Addr[:], ip4)
+		return addr, nil
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return nil, fmt.Errorf("kernelcapture: invalid seccomp control-plane IP")
+	}
+	addr := &unix.SockaddrInet6{Port: int(port)}
+	copy(addr.Addr[:], ip16)
+	return addr, nil
 }
 
 // maxReadableSockaddrLen caps how many bytes ReadTargetSockaddr will read

--- a/go/pkg/kernelcapture/seccomp_notify_linux_test.go
+++ b/go/pkg/kernelcapture/seccomp_notify_linux_test.go
@@ -18,13 +18,116 @@ package kernelcapture
 
 import (
 	"encoding/binary"
+	"net"
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
+
+func TestTrustedSeccompControlPlaneSockaddr(t *testing.T) {
+	t.Parallel()
+
+	v4, err := trustedSeccompControlPlaneSockaddr(net.ParseIP("127.0.0.1"), 43210)
+	if err != nil {
+		t.Fatalf("IPv4 sockaddr: %v", err)
+	}
+	v4addr, ok := v4.(*unix.SockaddrInet4)
+	if !ok || v4addr.Port != 43210 || v4addr.Addr != [4]byte{127, 0, 0, 1} {
+		t.Fatalf("IPv4 sockaddr = %#v, want 127.0.0.1:43210", v4)
+	}
+
+	v6, err := trustedSeccompControlPlaneSockaddr(net.ParseIP("::1"), 43211)
+	if err != nil {
+		t.Fatalf("IPv6 sockaddr: %v", err)
+	}
+	v6addr, ok := v6.(*unix.SockaddrInet6)
+	wantV6 := [16]byte{}
+	wantV6[15] = 1
+	if !ok || v6addr.Port != 43211 || v6addr.Addr != wantV6 {
+		t.Fatalf("IPv6 sockaddr = %#v, want [::1]:43211", v6)
+	}
+}
+
+func TestTrustedSeccompControlPlaneSockaddrRejectsWidenedTargets(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		ip   net.IP
+		port uint16
+	}{
+		{name: "remote IPv4", ip: net.ParseIP("192.0.2.10"), port: 443},
+		{name: "unspecified IPv4", ip: net.ParseIP("0.0.0.0"), port: 443},
+		{name: "nil IP", ip: nil, port: 443},
+		{name: "zero port", ip: net.ParseIP("127.0.0.1"), port: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := trustedSeccompControlPlaneSockaddr(tc.ip, tc.port); err == nil {
+				t.Fatal("expected invalid control-plane tuple to be rejected")
+			}
+		})
+	}
+}
+
+func TestSeccompSockaddrMatchesEndpointRequiresExactIPAndPort(t *testing.T) {
+	t.Parallel()
+
+	v4 := &unix.SockaddrInet4{Port: 43210, Addr: [4]byte{127, 0, 0, 1}}
+	if !seccompSockaddrMatchesEndpoint(v4, net.ParseIP("127.0.0.1"), 43210) {
+		t.Fatal("exact IPv4 endpoint did not match")
+	}
+	if seccompSockaddrMatchesEndpoint(v4, net.ParseIP("127.0.0.1"), 43211) {
+		t.Fatal("adjacent IPv4 port matched")
+	}
+	if seccompSockaddrMatchesEndpoint(v4, net.ParseIP("127.0.0.2"), 43210) {
+		t.Fatal("adjacent IPv4 address matched")
+	}
+
+	v6 := &unix.SockaddrInet6{Port: 43211}
+	v6.Addr[15] = 1
+	if !seccompSockaddrMatchesEndpoint(v6, net.ParseIP("::1"), 43211) {
+		t.Fatal("exact IPv6 endpoint did not match")
+	}
+	if seccompSockaddrMatchesEndpoint(v6, net.ParseIP("127.0.0.1"), 43211) {
+		t.Fatal("IPv4 endpoint matched an IPv6 peer")
+	}
+}
+
+func TestConnectTrustedSeccompSocketCompletesNonblockingConnect(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM|unix.SOCK_NONBLOCK|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create nonblocking socket: %v", err)
+	}
+	defer unix.Close(fd)
+	destination, err := trustedSeccompControlPlaneSockaddr(tcpAddr.IP, uint16(tcpAddr.Port))
+	if err != nil {
+		t.Fatalf("trusted sockaddr: %v", err)
+	}
+	if err := connectTrustedSeccompSocket(fd, destination, tcpAddr.IP, uint16(tcpAddr.Port)); err != nil {
+		t.Fatalf("connect nonblocking trusted socket: %v", err)
+	}
+
+	tcpListener := listener.(*net.TCPListener)
+	if err := tcpListener.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set accept deadline: %v", err)
+	}
+	conn, err := tcpListener.Accept()
+	if err != nil {
+		t.Fatalf("accept emulated connection: %v", err)
+	}
+	conn.Close()
+}
 
 // TestSeccompIoctlNumbers pins the three ioctl request values this file
 // computes via iocEncode against the same numbers every other

--- a/go/pkg/kernelcapture/seccomp_policy.go
+++ b/go/pkg/kernelcapture/seccomp_policy.go
@@ -25,17 +25,14 @@ package kernelcapture
 //
 // Claim boundary (state up front, not just in the PR description): seccomp
 // user-notify is weaker than an in-kernel LSM against a racing multithreaded
-// adversary. The supervisor observes syscall arguments and reads target
-// memory across a window bounded by SECCOMP_IOCTL_NOTIF_ID_VALID checks (see
-// seccomp_notify_linux.go), but a sufficiently fast concurrent thread in the
-// target process can still rewrite the sockaddr bytes between the kernel
-// capturing the syscall arguments and this store's decision being enforced,
-// in ways a kernel-resident LSM hook (which runs synchronously in the
-// syscalling thread's own context, with no supervisor round-trip) is not
-// exposed to. This tier is a real, load-bearing enforcement mechanism for
-// single-threaded or cooperative targets — which describes the overwhelming
-// majority of AI-agent subprocess trees this project governs — not a
-// theoretically-airtight one against an adversarial multithreaded target.
+// adversary. Ordinary mission-policy ALLOW decisions resume connect(2) with
+// SECCOMP_USER_NOTIF_FLAG_CONTINUE, so a sufficiently fast concurrent thread
+// can still rewrite sockaddr bytes after inspection. The bridge-owned
+// control-plane endpoint is intentionally stronger: the supervisor duplicates
+// the target socket with pidfd_getfd, connects it using daemon-owned address
+// bytes, and returns synthetic success without CONTINUE. That closes argument
+// mutation for this one exact tuple; it does not upgrade the wider seccomp
+// tier into an in-kernel-LSM-equivalent claim.
 
 import (
 	"fmt"
@@ -51,9 +48,15 @@ type SeccompPolicyStore struct {
 }
 
 type seccompSessionPolicy struct {
-	action      BpfAction
-	enforceMode BpfEnforceMode
-	allow       []*net.IPNet
+	action       BpfAction
+	enforceMode  BpfEnforceMode
+	allow        []*net.IPNet
+	controlPlane *seccompControlPlaneEndpoint
+}
+
+type seccompControlPlaneEndpoint struct {
+	ip   net.IP
+	port uint16
 }
 
 // NewSeccompPolicyStore returns an empty store.
@@ -79,10 +82,22 @@ func ApplySeccompPolicy(store *SeccompPolicyStore, sessionID string, req DaemonA
 		}
 	}
 	if netPolicy == nil {
+		if req.ControlPlaneEndpoint != nil {
+			return fmt.Errorf("kernelcapture: seccomp control-plane endpoint requires OP_NET_CONNECT")
+		}
 		store.mu.Lock()
 		delete(store.sessions, sessionID)
 		store.mu.Unlock()
 		return nil
+	}
+
+	var controlPlane *seccompControlPlaneEndpoint
+	if req.ControlPlaneEndpoint != nil {
+		ip, err := parseDaemonControlPlaneEndpoint(*req.ControlPlaneEndpoint)
+		if err != nil {
+			return fmt.Errorf("kernelcapture: seccomp control-plane endpoint: %w", err)
+		}
+		controlPlane = &seccompControlPlaneEndpoint{ip: ip, port: req.ControlPlaneEndpoint.Port}
 	}
 
 	allow := make([]*net.IPNet, 0, len(req.NetAllow))
@@ -96,12 +111,33 @@ func ApplySeccompPolicy(store *SeccompPolicyStore, sessionID string, req DaemonA
 
 	store.mu.Lock()
 	store.sessions[sessionID] = seccompSessionPolicy{
-		action:      netPolicy.Action,
-		enforceMode: netPolicy.EnforceMode,
-		allow:       allow,
+		action:       netPolicy.Action,
+		enforceMode:  netPolicy.EnforceMode,
+		allow:        allow,
+		controlPlane: controlPlane,
 	}
 	store.mu.Unlock()
 	return nil
+}
+
+// MatchSeccompControlPlaneEndpoint returns a copy of the daemon-owned endpoint
+// only when the tracee requested that exact IP and port. The returned tuple,
+// not the tracee's mutable sockaddr bytes, is what the Linux supervisor uses
+// for socket-connect emulation.
+func MatchSeccompControlPlaneEndpoint(store *SeccompPolicyStore, sessionID string, ip net.IP, port uint16) (net.IP, uint16, bool) {
+	if store == nil || ip == nil {
+		return nil, 0, false
+	}
+	store.mu.RLock()
+	policy, ok := store.sessions[sessionID]
+	if !ok || policy.controlPlane == nil || port != policy.controlPlane.port || !policy.controlPlane.ip.Equal(ip) {
+		store.mu.RUnlock()
+		return nil, 0, false
+	}
+	trustedIP := append(net.IP(nil), policy.controlPlane.ip...)
+	trustedPort := policy.controlPlane.port
+	store.mu.RUnlock()
+	return trustedIP, trustedPort, true
 }
 
 // RemoveSeccompPolicy clears sessionID's policy, mirroring RemovePolicyMaps'

--- a/go/pkg/kernelcapture/seccomp_policy_test.go
+++ b/go/pkg/kernelcapture/seccomp_policy_test.go
@@ -166,6 +166,53 @@ func TestApplySeccompPolicy_InvalidNetAllowEntryErrorsAndLeavesPriorPolicyIntact
 	}
 }
 
+func TestSeccompControlPlaneEndpointMatchesExactTupleOnly(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	req := netConnectRequest("s1", BpfActionDeny, BpfEnforceModeEnforce)
+	req.ControlPlaneEndpoint = &DaemonControlPlaneEndpoint{IP: "127.0.0.1", Port: 43210}
+	if err := ApplySeccompPolicy(store, "s1", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	ip, port, ok := MatchSeccompControlPlaneEndpoint(store, "s1", net.ParseIP("127.0.0.1"), 43210)
+	if !ok || !ip.Equal(net.ParseIP("127.0.0.1")) || port != 43210 {
+		t.Fatalf("exact endpoint match = (%v, %d, %v), want (127.0.0.1, 43210, true)", ip, port, ok)
+	}
+	for _, target := range []struct {
+		ip   string
+		port uint16
+	}{
+		{ip: "127.0.0.1", port: 43211},
+		{ip: "127.0.0.2", port: 43210},
+		{ip: "::1", port: 43210},
+	} {
+		if _, _, matched := MatchSeccompControlPlaneEndpoint(store, "s1", net.ParseIP(target.ip), target.port); matched {
+			t.Errorf("unrelated loopback tuple %s:%d matched the control-plane endpoint", target.ip, target.port)
+		}
+	}
+}
+
+func TestApplySeccompPolicy_InvalidControlEndpointLeavesPriorPolicyIntact(t *testing.T) {
+	store := NewSeccompPolicyStore()
+	good := netConnectRequest("s1", BpfActionDeny, BpfEnforceModeEnforce)
+	good.ControlPlaneEndpoint = &DaemonControlPlaneEndpoint{IP: "127.0.0.1", Port: 43210}
+	if err := ApplySeccompPolicy(store, "s1", good); err != nil {
+		t.Fatalf("apply good policy: %v", err)
+	}
+
+	bad := netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)
+	bad.ControlPlaneEndpoint = &DaemonControlPlaneEndpoint{IP: "192.0.2.10", Port: 443}
+	if err := ApplySeccompPolicy(store, "s1", bad); err == nil {
+		t.Fatal("expected non-loopback control endpoint to be rejected")
+	}
+	if _, _, ok := MatchSeccompControlPlaneEndpoint(store, "s1", net.ParseIP("127.0.0.1"), 43210); !ok {
+		t.Fatal("rejected apply replaced the prior control-plane endpoint")
+	}
+	if d := EvaluateSeccompConnect(store, "s1", net.ParseIP("203.0.113.9")); d.Allowed {
+		t.Fatalf("rejected apply replaced the prior deny policy: %+v", d)
+	}
+}
+
 func TestApplySeccompPolicy_NoNetConnectOpClearsPriorPolicy(t *testing.T) {
 	store := NewSeccompPolicyStore()
 	if err := ApplySeccompPolicy(store, "s1", netConnectRequest("s1", BpfActionAllow, BpfEnforceModeEnforce)); err != nil {

--- a/packaging/systemd/ardur-kernelcaptured.service
+++ b/packaging/systemd/ardur-kernelcaptured.service
@@ -43,8 +43,10 @@ LogsDirectoryMode=0700
 # CAP_SYS_ADMIN: attach tracepoints and pin BPF objects on bpffs.
 # CAP_NET_ADMIN: manage network-related BPF hooks (future).
 # CAP_PERFMON: access perf_event_open for eBPF tracepoints (kernel ≥5.8).
-AmbientCapabilities=CAP_BPF CAP_SYS_ADMIN CAP_NET_ADMIN CAP_PERFMON
-CapabilityBoundingSet=CAP_BPF CAP_SYS_ADMIN CAP_NET_ADMIN CAP_PERFMON
+# CAP_SYS_PTRACE: duplicate a seccomp target socket with pidfd_getfd after
+#                 the session-owner and exact control-plane tuple checks.
+AmbientCapabilities=CAP_BPF CAP_SYS_ADMIN CAP_NET_ADMIN CAP_PERFMON CAP_SYS_PTRACE
+CapabilityBoundingSet=CAP_BPF CAP_SYS_ADMIN CAP_NET_ADMIN CAP_PERFMON CAP_SYS_PTRACE
 SecureBits=keep-caps
 
 # ── Filesystem hardening ──────────────────────────────────────────────────
@@ -54,7 +56,8 @@ SecureBits=keep-caps
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
-PrivateDevices=false          # needs access to /dev/null etc.
+# Keep host devices visible for the kernel sensor (for example /dev/null).
+PrivateDevices=false
 
 # ReadWritePaths grants write access only to the daemon-owned paths.
 ReadWritePaths=/var/lib/ardur/kernelcapture /run/ardur/kernelcapture /sys/fs/bpf/ardur
@@ -81,10 +84,11 @@ ProtectClock=true
 # Block setuid/setgid bit execution from within the service.
 RestrictSUIDSGID=true
 # No new privileges after start.
-NoNewPrivileges=false         # must be false to retain AmbientCapabilities
+# This must remain false so the service retains AmbientCapabilities.
+NoNewPrivileges=false
 
 # Limit syscalls to those needed by eBPF and the socket control plane.
-SystemCallFilter=@system-service @network-io bpf perf_event_open perf_event_read
+SystemCallFilter=@system-service @network-io bpf perf_event_open pidfd_open pidfd_getfd
 SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
 

--- a/python/tests/test_enforce_demo_scripts.py
+++ b/python/tests/test_enforce_demo_scripts.py
@@ -7,6 +7,7 @@ VNG_METRIC_SCRIPT = (
     REPO_ROOT / "docs" / "demo" / "enforce-e2e" / "ci-vng-observability-gap.sh"
 )
 KERNEL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "kernel-enforce.yml"
+SYSTEMD_UNIT = REPO_ROOT / "packaging" / "systemd" / "ardur-kernelcaptured.service"
 
 
 def test_bpf_demo_uses_writable_run_home_and_propagates_failures() -> None:
@@ -28,3 +29,16 @@ def test_kvm_metric_proof_uses_permissive_data_plane() -> None:
     assert 'run.sh" permissive' in wrapper
     assert "ci-vng-observability-gap.sh" in workflow
     assert "ci-vng-enforce.sh" not in workflow
+
+
+def test_systemd_profile_allows_seccomp_control_plane_socket_emulation() -> None:
+    unit = SYSTEMD_UNIT.read_text(encoding="utf-8")
+
+    ambient = next(line for line in unit.splitlines() if line.startswith("AmbientCapabilities="))
+    bounding = next(line for line in unit.splitlines() if line.startswith("CapabilityBoundingSet="))
+    syscall_filter = next(line for line in unit.splitlines() if line.startswith("SystemCallFilter="))
+
+    assert "CAP_SYS_PTRACE" in ambient.split("=", 1)[1].split()
+    assert "CAP_SYS_PTRACE" in bounding.split("=", 1)[1].split()
+    assert "pidfd_open" in syscall_filter.split("=", 1)[1].split()
+    assert "pidfd_getfd" in syscall_filter.split("=", 1)[1].split()

--- a/python/tests/test_kernel_correlation.py
+++ b/python/tests/test_kernel_correlation.py
@@ -335,13 +335,18 @@ def test_apply_policy_encodes_and_sends_lowered_plan(sockdir: Path) -> None:
     )
     daemon.start()
     plan = lower_to_bpf_policy_plan(
-        forbidden_tools=["bash"],
+        forbidden_tools=["bash", "fetch"],
         resource_scope=["/data"],
         enforce_mode=ENFORCE_MODE_ENFORCE,
     )
     try:
         client = kc.KernelCaptureClient(sock)
-        resp = client.apply_policy(session_id="sess-apply-1", plan=plan, generation=1)
+        resp = client.apply_policy(
+            session_id="sess-apply-1",
+            plan=plan,
+            generation=1,
+            control_plane_endpoint=("127.0.0.1", 43210),
+        )
     finally:
         daemon.close()
 
@@ -354,6 +359,7 @@ def test_apply_policy_encodes_and_sends_lowered_plan(sockdir: Path) -> None:
     assert payload["enforce_mode"] == ENFORCE_MODE_ENFORCE
     assert payload["path_allow"] == ["/data"]
     assert "net_allow" not in payload  # omitted (empty) rather than sent as []
+    assert payload["control_plane_endpoint"] == {"ip": "127.0.0.1", "port": 43210}
 
     op_by_code = {entry["op"]: entry for entry in payload["op_policies"]}
     assert op_by_code[OP_EXEC]["action"] == ACT_DENY  # forbidden_tools:bash -> OP_EXEC deny
@@ -403,3 +409,11 @@ def test_apply_policy_validates_inputs(tmp_path: Path) -> None:
         client.apply_policy(session_id="s", plan=plan, generation=0)
     with pytest.raises(ValueError, match="generation"):
         client.apply_policy(session_id="s", plan=plan, generation=-1)
+    with pytest.raises(ValueError, match="loopback"):
+        client.apply_policy(
+            session_id="s", plan=plan, generation=1, control_plane_endpoint=("192.0.2.10", 443)
+        )
+    with pytest.raises(ValueError, match="port"):
+        client.apply_policy(
+            session_id="s", plan=plan, generation=1, control_plane_endpoint=("127.0.0.1", 0)
+        )

--- a/python/tests/test_run_bridge.py
+++ b/python/tests/test_run_bridge.py
@@ -406,6 +406,7 @@ def test_ardur_run_applies_kernel_policy_when_daemon_available(
     assert apply_req["session_id"] == result.session_id
     assert apply_req["generation"] == 1
     assert apply_req["enforce_mode"] == 1  # ENFORCE_MODE_ENFORCE
+    assert "control_plane_endpoint" not in apply_req
 
     from vibap.bpf_types import ACT_DENY, OP_EXEC
 
@@ -870,6 +871,9 @@ def test_no_resource_scope_omits_file_ops_from_lowered_plan(
     assert result.kernel_policy["applied"] is True
     apply_req = next(req["apply_policy"] for req in daemon.received if req.get("method") == "apply_policy")
     assert "path_allow" not in apply_req
+    endpoint = apply_req["control_plane_endpoint"]
+    assert endpoint["ip"] == "127.0.0.1"
+    assert 0 < endpoint["port"] <= 65535
     ops = {entry["op"] for entry in apply_req["op_policies"]}
     from vibap.bpf_types import OP_FILE_READ, OP_FILE_WRITE, OP_NET_CONNECT
 

--- a/python/vibap/kernel_correlation.py
+++ b/python/vibap/kernel_correlation.py
@@ -51,6 +51,7 @@ client never sends them.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import shutil
@@ -260,6 +261,7 @@ class KernelCaptureClient:
         session_id: str,
         plan: BpfPolicyPlan,
         generation: int,
+        control_plane_endpoint: tuple[str, int] | None = None,
     ) -> dict[str, Any]:
         """Install a lowered BPF policy plan for ``session_id``'s cgroup.
 
@@ -270,6 +272,8 @@ class KernelCaptureClient:
         "uninitialized" and the daemon rejects it. Deep validation (op/action/
         enforce_mode enum values, duplicate ops, absolute paths) happens
         daemon-side; a rejection surfaces as :class:`DaemonProtocolError`.
+        ``control_plane_endpoint`` is reserved for the session-owning run
+        bridge and must be one exact literal loopback IP and non-zero port.
         """
         if not session_id:
             raise ValueError("session_id is required")
@@ -288,6 +292,17 @@ class KernelCaptureClient:
             apply_policy["path_allow"] = list(plan.path_allow)
         if plan.net_allow:
             apply_policy["net_allow"] = list(plan.net_allow)
+        if control_plane_endpoint is not None:
+            host, port = control_plane_endpoint
+            try:
+                ip = ipaddress.ip_address(host)
+            except ValueError as exc:
+                raise ValueError("control_plane_endpoint host must be a literal loopback IP") from exc
+            if not ip.is_loopback:
+                raise ValueError("control_plane_endpoint host must be a loopback IP")
+            if isinstance(port, bool) or not isinstance(port, int) or not 0 < port <= 65535:
+                raise ValueError("control_plane_endpoint port must be an integer from 1 to 65535")
+            apply_policy["control_plane_endpoint"] = {"ip": str(ip), "port": port}
         return self._roundtrip(
             {
                 "protocol_version": DAEMON_PROTOCOL_VERSION,

--- a/python/vibap/run_bridge.py
+++ b/python/vibap/run_bridge.py
@@ -40,11 +40,14 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from . import kernel_correlation as kc
 from .launch_gate import RELEASE_BYTE as LAUNCH_GATE_RELEASE_BYTE
 from .package_assets import claude_code_plugin_dir
+
+if TYPE_CHECKING:
+    from .passport import MissionPassport
 
 # Environment-variable contract the bridge exports to the launched agent. The
 # proxy-routed path (EnvProxyAdapter) and any cooperating agent read these.
@@ -708,6 +711,7 @@ def _apply_kernel_policy(
     correlation: kc.CorrelationResult,
     enforce: bool,
     seccomp_plan: SeccompShimPlan,
+    control_plane_endpoint: tuple[str, int] | None = None,
 ) -> dict[str, Any]:
     """Lower the passport's policy and push it to the daemon's BPF maps.
 
@@ -759,9 +763,17 @@ def _apply_kernel_policy(
         }
 
     generation = 1  # first (and only) apply for this fresh session/cgroup pair.
+    if seccomp_plan.tier == kc.ENFORCEMENT_TIER_SECCOMP and control_plane_endpoint is None:
+        reason = "seccomp tier requires an exact governance control-plane endpoint"
+        if enforce:
+            raise KernelPolicyEnforcementError(reason)
+        return {"applied": False, "reason": reason, "tier2_ops": tier2_ops}
     try:
         kc.KernelCaptureClient(kc.daemon_socket_path()).apply_policy(
-            session_id=session_id, plan=plan, generation=generation
+            session_id=session_id,
+            plan=plan,
+            generation=generation,
+            control_plane_endpoint=control_plane_endpoint,
         )
     except (kc.DaemonUnavailable, kc.DaemonProtocolError, ValueError) as exc:
         reason = f"kernel policy apply rejected: {exc}"
@@ -954,8 +966,9 @@ def run_governed(
         proxy.receipt_private_key,
         receipt_registrar=receipt_registrar,
     )
+    proxy_host = str(server.server_address[0])
     port = server.server_address[1]
-    proxy_url = f"http://127.0.0.1:{port}"
+    proxy_url = f"http://{proxy_host}:{port}"
     server_thread = threading.Thread(target=server.serve_forever, name="ardur-run-proxy", daemon=True)
     server_thread.start()
 
@@ -1085,6 +1098,9 @@ def run_governed(
                 correlation=correlation,
                 enforce=enforce,
                 seccomp_plan=seccomp_plan,
+                control_plane_endpoint=(proxy_host, port)
+                if seccomp_plan.tier == kc.ENFORCEMENT_TIER_SECCOMP
+                else None,
             )
         except KernelPolicyEnforcementError as exc:
             notes.append(f"ENFORCE abort: {exc}")

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -2,7 +2,7 @@
 title: "Ardur"
 description: "Ardur governs AI-agent tool calls that pass through a configured adapter or"
 source_path: "README.md"
-source_sha256: "079705b68eba3f923d10b05a9d81b77cb10daafb184791aefea44c0a37eb87b5"
+source_sha256: "7b35d32d6b8b75bdf36e487d29620cc301ba962d6e88fe58c2804bd4929451b2"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -68,14 +68,14 @@ claim.
 
 ## Verification Snapshot
 
-At the reviewed `dev` tree on 2026-07-09, the current gates were:
+At the reviewed `dev` tree on 2026-07-10, the current gates were:
 
 | Gate | Verified result |
 |---|---|
-| Python local matrix (Python 3.13) | 1,600 passed, 32 skipped; CI separately enforces its coverage threshold |
+| Python local matrix (Python 3.13) | 1,601 passed, 32 skipped; CI separately enforces its coverage threshold |
 | Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
 | Go CI | Tests, vet, lint, and vulnerability scan passed |
-| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, seccomp smoke, and full `ardur run --enforce` seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
 | Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
 These gates verify the checked-in runtime and its configured integration

--- a/site/content/source/docs/demo/enforce-e2e.md
+++ b/site/content/source/docs/demo/enforce-e2e.md
@@ -2,7 +2,7 @@
 title: "ardur run` — BPF-LSM enforcement and observability demo"
 description: "This demo exercises the BPF-LSM enforcement and process-observability stack on"
 source_path: "docs/demo/enforce-e2e.md"
-source_sha256: "aae83d249c098a7757ae3fc4a5f8bd04e427844ae84b81d2147c226fd3faad31"
+source_sha256: "030defcee0758a7081c3c278a67fb5aa6cd8a9c06e196fcce9b49b8d16cd6611"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -92,6 +92,45 @@ $ docker build -f docs/demo/enforce-e2e/Dockerfile -t ardur-enforce-demo .
 The image builds `ardur-kernelcaptured` and the `enforce-verify` tool from
 source (the committed `processguard_bpfel.o` is used as-is — no clang needed)
 and installs the `ardur` CLI.
+
+## Run — seccomp fallback control-plane proof
+
+The seccomp path is an independent full `ardur run` E2E and does not require
+`bpf` in the active LSM list. The demo forces `-disable-bpf-lsm`, then runs a
+network-deny mission through the seccomp listener:
+
+```console
+$ docker run --rm --privileged --pid=host \
+    -v /tmp/ardur-demo-out:/out \
+    ardur-enforce-demo \
+    bash /opt/ardur/demo/run-seccomp.sh enforce
+```
+
+The agent first completes an authenticated `/evaluate` call and produces a
+signed governance receipt. It then deliberately attempts a separate
+`127.0.0.3:19999` connection so the kernel tier is tested independently of the
+proxy decision. The script requires the governance decision, a non-zero
+evaluated-call and receipt count, `DENIED_EPERM`, an exact denied data-plane
+event, no control-plane event, an intact evidence chain, and an attestation
+digest match. Every assertion is fail-fast.
+
+The governance exception is one daemon-stored IP-and-port tuple, not loopback
+or CIDR allowlisting. The supervisor connects a `pidfd_getfd(2)` duplicate of
+the target socket using trusted tuple bytes and returns success without
+`SECCOMP_USER_NOTIF_FLAG_CONTINUE`; see
+[Kernel Capture Daemon Operations](/__ardur_internal__/source/docs/reference/kernel-capture-daemon/#seccomp-governance-endpoint)
+for the Linux 5.6 and ptrace-permission requirements and the remaining tier
+boundary.
+
+The paired permissive control uses the same governance call and data-plane
+target but expects `ECONNREFUSED` and zero denied verdicts:
+
+```console
+$ docker run --rm --privileged --pid=host \
+    -v /tmp/ardur-demo-out:/out \
+    ardur-enforce-demo \
+    bash /opt/ardur/demo/run-seccomp.sh permissive
+```
 
 ---
 

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "22bc55554e92f61c4da02dc9d5f63f9a66191d7ade34ff52e1ac8be23264baf1"
+source_sha256: "0c26a5e208e7b2fd9fe3d2bab7fc3b1e8036eae459b89a28f7bd4eb78773ae3d"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -44,6 +44,45 @@ Do not use `--no-ringbuf` as a production fallback for a failing event
 consumer. A healthy socket in this mode proves control-plane liveness only; it
 does not prove that a governed process is observed or constrained below the
 tool-call boundary.
+
+## Seccomp governance endpoint
+
+On a seccomp-tier `ardur run`, the network policy also traps the agent's TCP
+connection to the run's embedded governance proxy. The authenticated,
+session-owning parent includes that proxy's exact literal loopback IP and port
+in `apply_policy`. The daemon validates the tuple and stores it separately from
+the mission's `net_allow`; hostnames, non-loopback addresses, port zero, an
+endpoint without `OP_NET_CONNECT`, and broad `127/8` or `::1` CIDR exceptions
+are not accepted.
+
+For that exact tuple only, the daemon does not resume the tracee's original
+`connect(2)` with `SECCOMP_USER_NOTIF_FLAG_CONTINUE`. Another target thread
+could rewrite a pointer argument after inspection. Instead, the supervisor
+uses `pidfd_open(2)` and `pidfd_getfd(2)` to duplicate the target socket,
+connects the shared socket using the daemon-stored tuple, revalidates the
+notification, and returns synthetic success with no continue flag. Any lookup,
+permission, duplication, connect, or notification-validity failure returns
+`EPERM`. The control connection is transport plumbing and does not emit a
+mission enforcement event; unrelated loopback connections still follow the
+mission policy and remain visible in evidence.
+
+This emulation requires Linux 5.6 or newer and permission for the daemon to
+perform the kernel's `PTRACE_MODE_ATTACH_REALCREDS` check for the target. A
+production daemon normally satisfies that through its privileged service
+identity; restrictive capability, Yama, LSM, or container settings can still
+deny it, in which case the connection fails closed. See the Linux kernel
+[seccomp user-notification documentation](https://docs.kernel.org/userspace-api/seccomp_filter.html),
+[`seccomp_unotify(2)`](https://www.man7.org/linux/man-pages/man2/seccomp_unotify.2.html),
+and [`pidfd_getfd(2)`](https://www.man7.org/linux/man-pages/man2/pidfd_getfd.2.html).
+The shipped systemd unit includes `CAP_SYS_PTRACE` in both its ambient and
+bounding sets and explicitly permits `pidfd_open` and `pidfd_getfd`; custom
+units must preserve those three requirements for the seccomp endpoint path.
+
+Ordinary seccomp mission-policy allows still use `CONTINUE` and retain the
+documented weaker-than-BPF-LSM race boundary. The BPF-LSM tier does not use the
+endpoint field or this emulation path. Its full enforce-mode launch bootstrap
+remains tracked separately in
+[#241](https://github.com/ArdurAI/ardur/issues/241).
 
 ## Process lifecycle cgroup filter
 


### PR DESCRIPTION
Closes #240

## Summary

- carry the embedded run bridge's exact loopback IP and port through the authenticated, session-owned `apply_policy` request, independently of mission `net_allow`
- validate and match only that exact tuple; reject hostnames, non-loopback addresses, port zero, endpoint-without-`OP_NET_CONNECT`, adjacent ports, and unrelated loopback addresses
- connect a `pidfd_getfd` duplicate of the target socket using daemon-owned address bytes and return synthetic success without `SECCOMP_USER_NOTIF_FLAG_CONTINUE`
- handle nonblocking target sockets with bounded poll + `SO_ERROR`, then verify `getpeername` still matches the trusted tuple
- grant the production systemd profile the bounded `CAP_SYS_PTRACE`, `pidfd_open`, and `pidfd_getfd` access this path requires
- restore a real authenticated `/evaluate` call to the seccomp E2E, harden the script against false-green pipelines, and document Linux 5.6+/ptrace and tier boundaries

## Security boundary

The governed child cannot install or widen the endpoint: `apply_policy` remains gated by the active session owner's peer PID and process-start time. The endpoint is not a CIDR or mission allowlist entry. Ordinary seccomp policy ALLOW decisions retain their documented `CONTINUE` race boundary; only the exact governance tuple uses socket emulation. BPF-LSM full enforce bootstrap remains separately tracked by #241.

## Validation

- Python: `1601 passed, 32 skipped, 6` pre-existing warnings
- Go: full `go test ./...`, `go vet ./...`, affected race tests on host and Linux
- Linux unit regression: real nonblocking TCP connect through the trusted-socket helper
- `govulncheck ./...`: no called vulnerabilities
- `systemd-analyze verify`: clean on systemd 252
- Ruff on touched files, ShellCheck on the E2E script, Actionlint parser, diff checks
- source docs: 100 pages / 95 artifacts; 10 public claims
- Hugo: 266 pages / 98 static files; rendered links and provenance pass
- Python sdist/wheel build passes

### Privileged release-candidate proof

Enforce:
- 1 authenticated `/evaluate` call and 1 signed receipt
- exact governance tuple emulated
- unrelated `127.0.0.3:19999` denied with `EPERM`
- one denied evidence entry, no control-plane evidence entry
- intact chain and exact attestation digest `b64b4b49803516314b9bfdea0f9b105c1130dd19c7a819c0d01871c943d84c98`

Permissive control:
- same authenticated call and receipt
- unrelated target reaches the normal kernel and returns `ECONNREFUSED`
- one blocked/not-enforced entry, zero denied verdicts
- intact chain and exact attestation digest `c12db846075d0a8eb223fb10e68ccf6e8b6097f0a4baab5d5cff36dd468eedcb`

Semgrep was not used.
