### PR TITLE
feat: add personal action firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Ardur will be documented in this file.
 - Remove internal fixture/hashing helpers in favor of stdlib
 
 ### Added
+- Personal action-firewall profile and one-command provider-free ASK/DENY proof
+- Readable Claude Code action summaries with signed action-budget evidence
 - Execution Receipt v0.2 schema, embedded package copy, and canonical golden fixture
 - Comprehensive E2E showcase test suite (28 tests, 7 layers)
 - Live adversarial scoreboard and continuous harness
@@ -32,6 +34,9 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Enforce cumulative direct-hook tool-call budgets from verified receipt chains
+- Compose mission-declared policy backends in the direct Claude Code hook
+- Canonicalize persisted forbid-rule hashes and key them by actual mission ID
 - CI baseline repair after AskUserQuestion landing
 - Claude AskUserQuestion hash handling
 - Gemini hook contract aligned with CLI 0.44.1

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Start with the source-checkout walkthrough in
 [`docs/guides/claude-code-mvp-quickstart.md`](docs/guides/claude-code-mvp-quickstart.md).
 It gives three bounded paths:
 
+- a **personal action-firewall proof** using `ardur personal-firewall demo`;
+  it shows one local `ASK` outcome (Claude Code's normal permission flow stays
+  in charge), three pre-dispatch denials for outside-workspace, secret-like,
+  and network requests, and four verified signed receipt summaries without an
+  API key or retained demo state;
 - a **60-second deliberate deny proof** using
   `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
   adapter, verifies a signed violation receipt, checks an unchanged canary, and
@@ -147,6 +152,10 @@ That guide also separates **Works now**, **Not claimed**, and **Coming soon**
 to clearly mark the boundary between shipped, deferred, and in-progress
 capabilities — package-manager release status, provider-hidden behavior,
 and subprocess/kernel/network side-effect gaps.
+
+The personal mode enforces a signed governed-tool-call budget. It does not
+claim a dollar-denominated cost cap unless an adapter supplies trusted signed
+cost telemetry.
 
 After a run, use the
 [`Phase 1 Demo Packet`](docs/guides/phase1-demo-packet.md) to assemble a bounded

--- a/docs/guides/ardur-personal-hub.md
+++ b/docs/guides/ardur-personal-hub.md
@@ -16,6 +16,18 @@ pip install -e python/
 ardur --version
 ```
 
+See the personal safety boundary locally before configuring a provider:
+
+```bash
+ardur personal-firewall demo
+```
+
+The command uses temporary local fixtures only. It shows an `ASK` result for a
+safe workspace read without bypassing Claude Code's normal permission flow,
+then denies an outside-workspace write, a secret-like argument, and external
+network access. It verifies four signed, hash-linked receipts and removes all
+temporary state.
+
 Create a simple guardrail file:
 
 ```bash
@@ -68,16 +80,25 @@ complete release artifact.
 
 ## Options Users Can Choose
 
+- `personal-firewall`: allows reads and edits inside the protected folder,
+  denies shell and external network tools, blocks common secret-like argument
+  markers, and caps the signed session at 40 governed tool calls.
 - `read-only`: review code without editing files or running commands.
 - `safe-coding`: edit files inside the protected folder, but block shell
   commands.
 - `ARDUR.md`: plain Markdown profile for the same settings, suitable for
   non-technical users.
 - Advanced CLI flags: `ardur protect claude-code --scope . --mode read-only`
-  and `ardur protect claude-code --scope . --mode safe-coding`.
+  and `ardur protect claude-code --scope . --mode personal-firewall`.
 
 The Markdown profile compiles into the same Mission Passport and receipt path
 as advanced CLI setup. No policy capability is removed.
+
+The personal session cap is an action budget, not a provider-billing estimate.
+A dollar-denominated cap requires trusted signed cost telemetry from the
+provider adapter. Secret markers are conservative patterns, not universal data
+loss prevention, and allowed actions still pass through the agent's native
+permission flow.
 
 For source installs, `pip install -e python/` installs Ardur's required Python
 dependencies from `python/pyproject.toml`. The development Homebrew formula is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -858,6 +858,28 @@ before a manifest is emitted with the same output shape and `error`/`condition:
 validation only; it does not prove browser-store deployment, Native Messaging
 installation, live provider/API behavior, or release readiness.
 
+### `ardur personal-firewall demo`
+
+Run a provider-free local proof of the conservative personal action firewall.
+
+```text
+ardur personal-firewall demo [--timeout-s SECONDS]
+                             [--temp-parent DIR] [--json]
+```
+
+The command creates only temporary local profile, key, project, and receipt
+state. It proves four pre-action decisions: a workspace read remains subject to
+the agent's native permission flow (`ASK`), while an outside-workspace write, a
+secret-like argument, and external network access are denied. It then verifies
+the four signed receipts as one hash-linked chain and removes temporary state.
+
+The JSON result includes readable decisions, receipt counts, verification
+guidance, and an explicit cost boundary. The enforced session budget is measured
+in governed tool calls. `monetary_cost` is
+`unavailable_without_signed_adapter_data`; the command does not contact a
+provider or claim a dollar-denominated cap, universal secret detection, kernel
+enforcement, or visibility into provider-hidden behavior.
+
 ### `ardur profile init`
 
 Write a starter `ARDUR.md` profile from a built-in template.
@@ -867,7 +889,8 @@ ardur profile init --template TEMPLATE
                    [--path PATH] [--force] [--json]
 ```
 
-Templates: `read-only`, `safe-coding`. Default path: `./ARDUR.md`.
+Templates: `personal-firewall`, `read-only`, `safe-coding`. Default path:
+`./ARDUR.md`.
 
 Empty, whitespace-only, or traversal-escaping paths are rejected **before any
 filesystem operation**. `ardur profile init` rejects paths that are empty,
@@ -924,7 +947,7 @@ exact `claude` invocation that pairs the plugin with the active passport.
 
 ```text
 ardur protect claude-code [--scope DIR] [--profile PATH]
-                          [--mode read-only|safe-coding]
+                          [--mode personal-firewall|read-only|safe-coding]
                           [--json] [--home DIR] [--plugin-dir DIR]
                           [--keys-dir DIR] [--agent-id ID]
                           [--mission TEXT]
@@ -1130,6 +1153,13 @@ ardur claude-code-report [--home DIR] [--chain-dir DIR] [--keys-dir DIR]
 
 `--verify-expiry` also enforces short receipt expiry windows during chain
 verification (off by default so reports work on archived chains).
+
+Each chain includes a redacted `actions` list with the requested tool/action
+class, allow or deny verdict, policy backends, stable rule identifiers, signed
+tool-call budget delta, and remaining action budget. Human output prints the
+latest 20 summaries and a placeholder-only verification command. The report
+does not expose raw policy-reason prose or tool arguments, and it does not claim
+a monetary cost when the adapter supplied no trusted signed cost data.
 
 When no local Claude Code hook receipts are present, the JSON report includes a
 `next_steps` array and the human output prints a concise "Next steps" section:

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -27,6 +27,12 @@ pip install -e python/
 ardur profile init --template read-only --path ARDUR.md
 ```
 
+To see the conservative personal flow before configuring Claude Code, run:
+
+```bash
+ardur personal-firewall demo
+```
+
 Open `ARDUR.md` in any text editor:
 
 ```markdown
@@ -109,6 +115,9 @@ Claim boundary — per-platform numbers:
 
 ## Built-In Options
 
+- `ardur profile init --template personal-firewall`: workspace-scoped reads
+  and edits, common secret-like argument blocks, no shell/network tools, and a
+  signed 40-action session cap.
 - `ardur profile init --template read-only`: safest first run. Allows reading
   and searching only.
 - `ardur profile init --template safe-coding`: allows local file edits inside
@@ -117,6 +126,12 @@ Claim boundary — per-platform numbers:
   a Markdown profile.
 - `ardur protect claude-code --scope . --mode safe-coding`: flag-based setup
   for technical users.
+- `ardur protect claude-code --scope . --mode personal-firewall`: the same
+  native capability defaults without a Markdown profile; use the profile when
+  you also want its secret-like argument rules.
+
+The action cap is enforced in governed tool calls. Ardur does not infer a
+dollar cost when Claude Code supplies no trusted signed billing telemetry.
 
 Advanced users can still use `ardur issue`, `ARDUR_MISSION_PASSPORT`,
 `ARDUR_CC_HOOK_DIR`, and custom Mission Passport fields directly. The Markdown

--- a/python/README.md
+++ b/python/README.md
@@ -39,6 +39,18 @@ ardur verify --token <token-from-issue-output>
 That walks through key generation, mission compilation, ES256-signed passport
 issuance, and verification - all local, no LLM calls.
 
+Run the conservative personal action-firewall proof with one command:
+
+```bash
+ardur personal-firewall demo
+```
+
+The provider-free demo preserves the agent's normal permission prompt for a
+safe workspace read, denies outside-workspace writes, secret-like arguments,
+and external network access, then verifies the signed receipt chain. Its
+session cap is measured in governed tool calls; monetary cost remains unknown
+unless an adapter supplies trusted signed cost telemetry.
+
 Every durable receipt sink also queues an idempotent local transparency-anchor
 sidecar. Network submission is a separate `ardur anchor` operation, and
 `ardur verify --anchor-bundle ...` verifies completed proofs offline with an

--- a/python/tests/test_ardur_profile.py
+++ b/python/tests/test_ardur_profile.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from vibap.ardur_profile import InvalidProfilePathError, load_ardur_profile, write_profile_template
+from vibap.backed_policy_store import FileBackedPolicyStore
 from vibap.cli import (
     claude_code_doctor,
     cmd_profile_init,
@@ -242,6 +243,52 @@ Duration: 2h
     assert parsed.max_duration_s == 7200
     assert parsed.allowed_tools == ["Read", "Glob", "Grep"]
     assert parsed.forbidden_tools == ["Bash", "Write"]
+
+
+def test_personal_firewall_profile_embeds_canonical_policy_and_store_key(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    profile = write_profile_template(
+        project / "ARDUR.md",
+        template="personal-firewall",
+    )
+    parsed = load_ardur_profile(profile)
+
+    assert parsed.allowed_tools == ["Read", "Glob", "Grep", "Edit", "MultiEdit", "Write"]
+    assert parsed.forbidden_tools == ["Bash", "WebFetch", "WebSearch"]
+    assert parsed.max_tool_calls == 40
+    assert parsed.forbid_rules[0]["forbid_when"]["arg_contains"] == [
+        "api_key=",
+        "api-key=",
+        "access_token=",
+        "authorization: bearer",
+        "password=",
+        "BEGIN PRIVATE KEY",
+        "AKIA",
+        "ghp_",
+        "github_pat_",
+        "xoxb-",
+    ]
+
+    home = tmp_path / "home"
+    keys = tmp_path / "keys"
+    result = protect_claude_code(
+        _protect_args(profile=profile, home=home, keys_dir=keys)
+    )
+    claims = verify_passport(
+        Path(str(result["active_passport"])).read_text().strip(),
+        load_public_key(keys),
+    )
+
+    policies = claims["additional_policies"]
+    assert policies[0]["backend"] == "forbid_rules"
+    assert len(policies[0]["policy_sha256"]) == 64
+    assert FileBackedPolicyStore(home).get_policies(
+        mission_id=claims["mission_id"]
+    ) == policies
 
 
 def test_protect_claude_code_from_profile_writes_verifiable_passport(tmp_path):

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -203,7 +203,7 @@ def test_direct_hook_fails_closed_for_malformed_additional_policies_claim(
 
 
 def test_direct_hook_fails_closed_for_oversized_budget_chain(tmp_path, monkeypatch):
-    import vibap.claude_code_hook as hook
+    from vibap import claude_code_hook as hook
 
     token = _issue_wildcard_test_passport(tmp_path)
     chain_dir = tmp_path / "chains"
@@ -227,6 +227,67 @@ def test_direct_hook_fails_closed_for_oversized_budget_chain(tmp_path, monkeypat
     assert _deny_reason(output) == (
         "ardur: blocked - signed receipt chain is unavailable or invalid"
     )
+
+
+def test_direct_hook_reuses_verified_state_and_detects_same_size_tamper(
+    tmp_path, monkeypatch
+):
+    from vibap import claude_code_hook as hook
+    from vibap import receipt
+
+    token = _issue_wildcard_test_passport(tmp_path)
+    chain_dir = tmp_path / "chains"
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(chain_dir))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "cached-budget-chain")
+
+    first = hook.handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "one.txt")},
+            suffix="cached-one",
+        ),
+        keys_dir=tmp_path,
+    )
+    assert first["continue"] is True
+
+    verify_calls = 0
+    original_verify_chain = receipt.verify_chain
+
+    def counted_verify_chain(*args, **kwargs):
+        nonlocal verify_calls
+        verify_calls += 1
+        return original_verify_chain(*args, **kwargs)
+
+    monkeypatch.setattr(receipt, "verify_chain", counted_verify_chain)
+    second = hook.handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "two.txt")},
+            suffix="cached-two",
+        ),
+        keys_dir=tmp_path,
+    )
+    assert second["continue"] is True
+    assert verify_calls == 0
+
+    receipt_file = chain_dir / "cached-budget-chain" / "receipts.jsonl"
+    raw = receipt_file.read_bytes()
+    replacement = b"f" if raw[:1] != b"f" else b"e"
+    receipt_file.write_bytes(replacement + raw[1:])
+
+    tampered = hook.handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "three.txt")},
+            suffix="cached-three",
+        ),
+        keys_dir=tmp_path,
+    )
+    assert _deny_reason(tampered) == (
+        "ardur: blocked - signed receipt chain is unavailable or invalid"
+    )
+    assert verify_calls == 1
 
 
 def _issue_wildcard_test_passport(

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -54,6 +54,181 @@ def _deny_reason(output: dict) -> str:
     return hook_output["permissionDecisionReason"]
 
 
+def _pre_hook_input(*, tool_name: str, tool_input: dict[str, Any], suffix: str) -> dict[str, Any]:
+    return {
+        "session_id": "personal-firewall-test",
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_use_id": f"tool-{suffix}",
+        "tool_input": tool_input,
+    }
+
+
+def test_direct_hook_enforces_cumulative_signed_tool_call_budget(tmp_path, monkeypatch):
+    from vibap.claude_code_hook import handle_pre_tool_use
+    from vibap.claude_code_report import build_claude_code_report
+
+    keys = tmp_path / "keys"
+    private_key, _public_key = generate_keypair(keys_dir=keys)
+    mission = MissionPassport(
+        agent_id="personal-budget",
+        mission="enforce one governed action",
+        allowed_tools=["Read"],
+        resource_scope=[str(tmp_path), f"{tmp_path}/*"],
+        cwd=str(tmp_path),
+        max_tool_calls=1,
+        max_duration_s=600,
+    )
+    token = issue_passport(mission, private_key, ttl_s=600)
+    chain_dir = tmp_path / "chains"
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(chain_dir))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "personal-budget")
+
+    first = handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "one.txt")},
+            suffix="one",
+        ),
+        keys_dir=keys,
+    )
+    second = handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "two.txt")},
+            suffix="two",
+        ),
+        keys_dir=keys,
+    )
+
+    assert first["continue"] is True
+    assert "budget exceeded: 1/1 tool calls used" in _deny_reason(second)
+    report = build_claude_code_report(chain_dir=chain_dir, keys_dir=keys)
+    assert report["totals"]["verdicts"] == {"compliant": 1, "violation": 1}
+    assert report["chains"][0]["actions"][0]["budget_remaining"] == {"tool_calls": 0}
+    assert report["chains"][0]["actions"][1]["explanation"] == (
+        "blocked because the signed session action budget is exhausted"
+    )
+
+
+def test_direct_hook_composes_signed_forbid_rules_policy(tmp_path, monkeypatch):
+    from vibap.claude_code_hook import handle_pre_tool_use
+    from vibap.claude_code_report import build_claude_code_report
+
+    rules = [
+        {
+            "id": "personal_secret_like_argument",
+            "forbid_when": {"arg_contains": ["api_key="]},
+        }
+    ]
+    canonical = json.dumps(rules, sort_keys=True, separators=(",", ":"))
+    policy = {
+        "backend": "forbid_rules",
+        "label": "profile-forbid-rules",
+        "policy_inline": "",
+        "policy_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        "data_inline": rules,
+    }
+    keys = tmp_path / "keys"
+    private_key, _public_key = generate_keypair(keys_dir=keys)
+    mission = MissionPassport(
+        agent_id="personal-secret",
+        mission="deny secret-like action arguments",
+        allowed_tools=["Write"],
+        resource_scope=[str(tmp_path), f"{tmp_path}/*"],
+        cwd=str(tmp_path),
+        max_tool_calls=10,
+        max_duration_s=600,
+        additional_policies=[policy],
+    )
+    token = issue_passport(mission, private_key, ttl_s=600)
+    chain_dir = tmp_path / "chains"
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(chain_dir))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "personal-secret")
+
+    output = handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Write",
+            tool_input={
+                "file_path": str(tmp_path / "config.txt"),
+                "content": "api_key=synthetic-value",
+            },
+            suffix="secret",
+        ),
+        keys_dir=keys,
+    )
+
+    assert "personal_secret_like_argument" in _deny_reason(output)
+    report = build_claude_code_report(chain_dir=chain_dir, keys_dir=keys)
+    assert report["chains"][0]["actions"][0]["policies"] == [
+        {"backend": "native", "decision": "Allow"},
+        {
+            "backend": "forbid_rules",
+            "decision": "Deny",
+            "rule_id": "personal_secret_like_argument",
+        },
+    ]
+    assert report["chains"][0]["actions"][0]["applied_rule"] == (
+        "personal_secret_like_argument"
+    )
+
+
+def test_direct_hook_fails_closed_for_malformed_additional_policies_claim(
+    tmp_path, monkeypatch
+):
+    from vibap.claude_code_hook import handle_pre_tool_use
+
+    token = _issue_wildcard_test_passport(
+        tmp_path,
+        extra_claims={"additional_policies": "not-a-policy-list"},
+    )
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(tmp_path / "chains"))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "malformed-policies")
+
+    output = handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "README.md")},
+            suffix="malformed-policy",
+        ),
+        keys_dir=tmp_path,
+    )
+
+    assert "unknown policy backend: invalid_additional_policies" in _deny_reason(
+        output
+    )
+
+
+def test_direct_hook_fails_closed_for_oversized_budget_chain(tmp_path, monkeypatch):
+    import vibap.claude_code_hook as hook
+
+    token = _issue_wildcard_test_passport(tmp_path)
+    chain_dir = tmp_path / "chains"
+    receipt_file = chain_dir / "oversized-budget-chain" / "receipts.jsonl"
+    receipt_file.parent.mkdir(parents=True)
+    receipt_file.write_bytes(b"x" * 17)
+    monkeypatch.setattr(hook, "HOOK_STATE_MAX_BYTES", 16)
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(chain_dir))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "oversized-budget-chain")
+
+    output = hook.handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Read",
+            tool_input={"file_path": str(tmp_path / "README.md")},
+            suffix="oversized-chain",
+        ),
+        keys_dir=tmp_path,
+    )
+
+    assert _deny_reason(output) == (
+        "ardur: blocked - signed receipt chain is unavailable or invalid"
+    )
+
+
 def _issue_wildcard_test_passport(
     tmp_path: Path,
     *,

--- a/python/tests/test_personal_firewall.py
+++ b/python/tests/test_personal_firewall.py
@@ -31,3 +31,15 @@ def test_provider_free_personal_firewall_demo_is_verified_and_private(
     assert result["temporary_state_removed"] is True
     assert str(tmp_path) not in json.dumps(result, sort_keys=True)
     assert list(tmp_path.iterdir()) == []
+
+
+def test_personal_firewall_demo_human_output_uses_safe_fixed_details(tmp_path, capsys):
+    run_personal_firewall_demo(temp_parent=tmp_path, emit=True)
+
+    output = capsys.readouterr().out
+    assert "synthetic-demo-value" not in output
+    assert (
+        "DENY  secret-like argument: matched the personal secret-like argument policy"
+        in output
+    )
+    assert str(tmp_path) not in output

--- a/python/tests/test_personal_firewall.py
+++ b/python/tests/test_personal_firewall.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+
+from vibap.personal_firewall import run_personal_firewall_demo
+
+
+def test_provider_free_personal_firewall_demo_is_verified_and_private(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", "poisoned-parent-token")
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(tmp_path / "outside-chain"))
+    result = run_personal_firewall_demo(temp_parent=tmp_path, emit=False)
+
+    assert result["ok"] is True
+    assert [item["result"] for item in result["decisions"]] == [
+        "ASK",
+        "DENY",
+        "DENY",
+        "DENY",
+    ]
+    assert result["receipts"] == {
+        "count": 4,
+        "chains": 1,
+        "verified": True,
+        "readable_summaries": True,
+    }
+    assert result["cost_boundary"]["monetary_cost"] == (
+        "unavailable_without_signed_adapter_data"
+    )
+    assert result["temporary_state_removed"] is True
+    assert str(tmp_path) not in json.dumps(result, sort_keys=True)
+    assert list(tmp_path.iterdir()) == []

--- a/python/vibap/ardur_profile.py
+++ b/python/vibap/ardur_profile.py
@@ -21,6 +21,9 @@ FRIENDLY_TOOL_ALIASES = {
     "shell commands": ["Bash"],
     "run commands": ["Bash"],
     "bash": ["Bash"],
+    "external network access": ["WebFetch", "WebSearch"],
+    "external network": ["WebFetch", "WebSearch"],
+    "network access": ["WebFetch", "WebSearch"],
 }
 
 PROFILE_TEMPLATES = {
@@ -68,6 +71,26 @@ Duration: 1d
 #   action == Action::"read_file",
 #   resource is Resource
 # ) when { resource.path like "/data/*" };
+""",
+    "personal-firewall": """# Ardur Personal Action Firewall
+Mode: personal firewall
+Mission: Help inside this project while keeping risky actions local and reviewable.
+Protect folder: .
+Max tool calls: 40
+Duration: 4h
+
+## Allow
+- Read files
+- Search files
+- Edit files
+- Write files
+
+## Block
+- Run shell commands
+- External network access
+
+## Forbid Rules
+- personal_secret_like_argument: forbid_when arg_contains api_key=, api-key=, access_token=, authorization: bearer, password=, BEGIN PRIVATE KEY, AKIA, ghp_, github_pat_, xoxb-
 """,
 }
 
@@ -301,7 +324,7 @@ def _parse_forbid_rule_items(items: list[str]) -> list[dict[str, Any]]:
 
 
 def _set_predicate(dst: dict[str, Any], key: str, raw: str) -> None:
-    if key == "tool_name_in":
+    if key in {"tool_name_in", "arg_contains"}:
         dst[key] = [v.strip() for v in raw.split(",") if v.strip()]
     else:
         dst[key] = raw.rstrip(",")

--- a/python/vibap/claude_code_hook.py
+++ b/python/vibap/claude_code_hook.py
@@ -17,6 +17,7 @@ import os
 import re
 import stat
 import time
+from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -45,6 +46,7 @@ CLAUDE_CODE_VISIBILITY_FULL = "full"
 HOOK_INPUT_MAX_CHARS = 1024 * 1024
 HOOK_STATE_MAX_BYTES = 16 * 1024 * 1024
 HOOK_STATE_MAX_RECEIPTS = 8192
+HOOK_SESSION_CACHE_MAX_ENTRIES = 128
 _SAFE_TRACE_ID_RE = re.compile(r"^[a-zA-Z0-9._-]{1,64}$")
 
 
@@ -118,6 +120,18 @@ class ChainState:
         return self.trace_dir / SUBAGENT_REGISTRY_FILENAME
 
 
+@dataclass
+class _VerifiedSessionCacheEntry:
+    passport_digest: str
+    chain_hasher: Any
+    chain_size: int
+    tool_call_count: int
+    by_class: dict[str, int]
+
+
+_VERIFIED_SESSION_CACHE: "OrderedDict[str, _VerifiedSessionCacheEntry]" = OrderedDict()
+
+
 def resolve_chain_state(*, trace_id: str) -> ChainState:
     base = Path(os.environ.get(CHAIN_DIR_ENV_VAR, str(DEFAULT_CHAIN_DIR))).expanduser()
     safe_trace_id = _normalize_trace_id(trace_id)
@@ -155,12 +169,19 @@ def append_receipt(state: ChainState, signed_jwt: str) -> None:
         _append_receipt_unlocked(state, signed_jwt)
 
 
-def _append_receipt_unlocked(state: ChainState, signed_jwt: str) -> None:
+def _append_receipt_unlocked(
+    state: ChainState,
+    signed_jwt: str,
+    *,
+    receipt_obj: Any | None = None,
+) -> None:
     with open(state.file, "a", encoding="utf-8") as f:
         f.write(signed_jwt.strip() + "\n")
     from .transparency import queue_receipt_anchor_best_effort
 
     queue_receipt_anchor_best_effort(signed_jwt, state.file)
+    if receipt_obj is not None:
+        _advance_verified_session_cache_unlocked(state, signed_jwt, receipt_obj)
 
 
 def _append_subagent_event_unlocked(state: ChainState, record: Mapping[str, Any]) -> None:
@@ -624,9 +645,10 @@ def _verified_pretool_session_state_unlocked(
     public_key: Any,
     passport_claims: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Rebuild cumulative hook budget state from the verified receipt chain."""
+    """Return cumulative state from a verified chain, caching daemon hot paths."""
     from .receipt import verify_chain
 
+    raw = b""
     tokens = []
     try:
         flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
@@ -643,6 +665,24 @@ def _verified_pretool_session_state_unlocked(
         tokens = [line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()]
         if len(tokens) > HOOK_STATE_MAX_RECEIPTS:
             raise ValueError("Claude Code receipt chain has too many receipts")
+
+    passport_digest = _hook_session_passport_digest(public_key, passport_claims)
+    chain_hasher = hashlib.sha256(raw)
+    cache_key = str(state.file.resolve(strict=False))
+    cached = _VERIFIED_SESSION_CACHE.get(cache_key)
+    if (
+        cached is not None
+        and cached.passport_digest == passport_digest
+        and cached.chain_size == len(raw)
+        and cached.chain_hasher.digest() == chain_hasher.digest()
+    ):
+        _VERIFIED_SESSION_CACHE.move_to_end(cache_key)
+        return _hook_session_state(
+            passport_claims=passport_claims,
+            tool_call_count=cached.tool_call_count,
+            by_class=cached.by_class,
+        )
+
     receipt_claims = verify_chain(tokens, public_key, verify_expiry=False) if tokens else []
     permitted_pre = [
         claim
@@ -654,17 +694,88 @@ def _verified_pretool_session_state_unlocked(
     for claim in permitted_pre:
         side_effect = str(claim.get("side_effect_class", "none"))
         by_class[side_effect] = by_class.get(side_effect, 0) + 1
+    _VERIFIED_SESSION_CACHE[cache_key] = _VerifiedSessionCacheEntry(
+        passport_digest=passport_digest,
+        chain_hasher=chain_hasher,
+        chain_size=len(raw),
+        tool_call_count=len(permitted_pre),
+        by_class=dict(by_class),
+    )
+    _VERIFIED_SESSION_CACHE.move_to_end(cache_key)
+    while len(_VERIFIED_SESSION_CACHE) > HOOK_SESSION_CACHE_MAX_ENTRIES:
+        _VERIFIED_SESSION_CACHE.popitem(last=False)
+    return _hook_session_state(
+        passport_claims=passport_claims,
+        tool_call_count=len(permitted_pre),
+        by_class=by_class,
+    )
+
+
+def _hook_session_passport_digest(
+    public_key: Any,
+    passport_claims: Mapping[str, Any],
+) -> str:
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    claims = json.dumps(
+        dict(passport_claims),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    key = public_key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+    return hashlib.sha256(key + b"\x00" + claims).hexdigest()
+
+
+def _hook_session_state(
+    *,
+    passport_claims: Mapping[str, Any],
+    tool_call_count: int,
+    by_class: Mapping[str, int],
+) -> dict[str, Any]:
     try:
         issued_at = float(passport_claims.get("iat", time.time()))
     except (TypeError, ValueError):
         issued_at = time.time()
     return {
-        "tool_call_count": len(permitted_pre),
-        "tool_call_count_by_class": by_class,
-        "side_effect_counts": by_class,
+        "tool_call_count": tool_call_count,
+        "tool_call_count_by_class": dict(by_class),
+        "side_effect_counts": dict(by_class),
         "delegated_budget_reserved": 0,
         "elapsed_s": max(0.0, time.time() - issued_at),
     }
+
+
+def _advance_verified_session_cache_unlocked(
+    state: ChainState,
+    signed_jwt: str,
+    receipt_obj: Any,
+) -> None:
+    cache_key = str(state.file.resolve(strict=False))
+    cached = _VERIFIED_SESSION_CACHE.get(cache_key)
+    if cached is None:
+        return
+
+    line = (signed_jwt.strip() + "\n").encode("utf-8")
+    chain_hasher = cached.chain_hasher.copy()
+    chain_hasher.update(line)
+    tool_call_count = cached.tool_call_count
+    by_class = dict(cached.by_class)
+    if (
+        str(getattr(receipt_obj, "step_id", "")).endswith(":pre")
+        and getattr(receipt_obj, "verdict", "") == "compliant"
+    ):
+        tool_call_count += 1
+        side_effect = str(getattr(receipt_obj, "side_effect_class", "none"))
+        by_class[side_effect] = by_class.get(side_effect, 0) + 1
+    _VERIFIED_SESSION_CACHE[cache_key] = _VerifiedSessionCacheEntry(
+        passport_digest=cached.passport_digest,
+        chain_hasher=chain_hasher,
+        chain_size=cached.chain_size + len(line),
+        tool_call_count=tool_call_count,
+        by_class=by_class,
+    )
+    _VERIFIED_SESSION_CACHE.move_to_end(cache_key)
 
 
 def _hook_budget_evidence(
@@ -802,7 +913,7 @@ def _emit_chained_receipt_unlocked(
         record = dict(subagent_record)
         record["receipt_id"] = receipt_obj.receipt_id
         _append_subagent_event_unlocked(state, record)
-    _append_receipt_unlocked(state, signed)
+    _append_receipt_unlocked(state, signed, receipt_obj=receipt_obj)
     return receipt_obj
 
 
@@ -1019,7 +1130,7 @@ def handle_post_tool_use(
         )
         receipt_obj.result_hash = _result_hash(tool_response)
         signed = sign_receipt(receipt_obj, private_key)
-        _append_receipt_unlocked(state, signed)
+        _append_receipt_unlocked(state, signed, receipt_obj=receipt_obj)
     return {"continue": True}
 
 

--- a/python/vibap/claude_code_hook.py
+++ b/python/vibap/claude_code_hook.py
@@ -15,6 +15,8 @@ import hashlib
 import json
 import os
 import re
+import stat
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -41,6 +43,8 @@ CHAIN_FILENAME = "receipts.jsonl"
 SUBAGENT_REGISTRY_FILENAME = "subagents.jsonl"
 CLAUDE_CODE_VISIBILITY_FULL = "full"
 HOOK_INPUT_MAX_CHARS = 1024 * 1024
+HOOK_STATE_MAX_BYTES = 16 * 1024 * 1024
+HOOK_STATE_MAX_RECEIPTS = 8192
 _SAFE_TRACE_ID_RE = re.compile(r"^[a-zA-Z0-9._-]{1,64}$")
 
 
@@ -545,36 +549,150 @@ def _backfill_telemetry_fields(receipt_obj: Any, arguments: Mapping[str, Any]) -
         receipt_obj.instruction_bearing = bool(instruction_bearing)
 
 
-def _evaluate_native_policy(
+def _evaluate_composed_policy(
     event: Any,
     claims: dict[str, Any],
+    *,
+    session_state: Mapping[str, Any] | None = None,
 ) -> "tuple[str, list[Any]]":
-    """Run the native backend; return (final_decision_str, decisions_list).
-
-    Only the native backend runs here — forbid_rules and other additional
-    backends are driven by mission-declared ``additional_policies`` in the
-    full proxy, not as a default. Calling forbid_rules without a valid
-    mission-provided policy_spec (including a SHA-256 integrity hash) would
-    unconditionally Deny every call.
-    """
-    from .policy_backend import compose_decisions, get_backend, timed_evaluate
-
-    native_backend = get_backend("native")
-    decision = timed_evaluate(
-        native_backend,
-        tool_name=event.tool_name,
-        arguments=event.arguments,
-        principal=event.actor,
-        target=event.target,
-        # Match the proxy's shared_context shape: key is "passport", not
-        # "passport_claims". The NativeBackend reads context["passport"] to
-        # access allowed_tools, forbidden_tools, resource_scope, etc.
-        context={"passport": claims, "session": {}},
-        policy_spec={},
+    """Evaluate native and mission-declared policy backends with deny-wins."""
+    from .policy_backend import (
+        PolicyDecision,
+        compose_decisions,
+        get_backend,
+        timed_evaluate,
     )
-    decisions = [decision]
+
+    context = {
+        "passport": claims,
+        "session": dict(session_state or {}),
+        "action_class": event.action_class,
+        "resource_family": event.resource_family,
+        "side_effect_class": event.side_effect_class,
+        "policy_metadata": {
+            "action_class": event.action_class,
+            "resource_family": event.resource_family,
+            "side_effect_class": event.side_effect_class,
+        },
+    }
+    decisions: list[Any] = []
+    additional = claims.get("additional_policies", [])
+    if not isinstance(additional, list):
+        additional = [{"backend": "invalid_additional_policies"}]
+    specs: list[Mapping[str, Any]] = [
+        {"backend": "native", "label": "ardur_builtin"}
+    ]
+    for item in additional:
+        specs.append(
+            item
+            if isinstance(item, Mapping)
+            else {"backend": "invalid_additional_policy_entry"}
+        )
+    for spec in specs:
+        backend_name = str(spec.get("backend", ""))
+        label = str(spec.get("label", ""))
+        try:
+            backend = get_backend(backend_name)
+        except KeyError:
+            decisions.append(
+                PolicyDecision(
+                    backend=backend_name or "unknown",
+                    label=label,
+                    decision="Deny",
+                    reasons=(f"unknown policy backend: {backend_name or '<empty>'}",),
+                    eval_ms=0.0,
+                )
+            )
+            continue
+        decisions.append(
+            timed_evaluate(
+                backend,
+                tool_name=event.tool_name,
+                arguments=event.arguments,
+                principal=event.actor,
+                target=event.target,
+                context=context,
+                policy_spec={} if backend_name == "native" else dict(spec),
+            )
+        )
     final, _denier = compose_decisions(decisions)
     return final, decisions
+
+
+def _verified_pretool_session_state_unlocked(
+    state: ChainState,
+    public_key: Any,
+    passport_claims: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Rebuild cumulative hook budget state from the verified receipt chain."""
+    from .receipt import verify_chain
+
+    tokens = []
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(state.file, flags)
+    except FileNotFoundError:
+        fd = None
+    if fd is not None:
+        with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise ValueError("Claude Code receipt chain is not a regular file")
+            raw = handle.read(HOOK_STATE_MAX_BYTES + 1)
+        if len(raw) > HOOK_STATE_MAX_BYTES:
+            raise ValueError("Claude Code receipt chain exceeds the verification limit")
+        tokens = [line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()]
+        if len(tokens) > HOOK_STATE_MAX_RECEIPTS:
+            raise ValueError("Claude Code receipt chain has too many receipts")
+    receipt_claims = verify_chain(tokens, public_key, verify_expiry=False) if tokens else []
+    permitted_pre = [
+        claim
+        for claim in receipt_claims
+        if str(claim.get("step_id", "")).endswith(":pre")
+        and claim.get("verdict") == "compliant"
+    ]
+    by_class: dict[str, int] = {}
+    for claim in permitted_pre:
+        side_effect = str(claim.get("side_effect_class", "none"))
+        by_class[side_effect] = by_class.get(side_effect, 0) + 1
+    try:
+        issued_at = float(passport_claims.get("iat", time.time()))
+    except (TypeError, ValueError):
+        issued_at = time.time()
+    return {
+        "tool_call_count": len(permitted_pre),
+        "tool_call_count_by_class": by_class,
+        "side_effect_counts": by_class,
+        "delegated_budget_reserved": 0,
+        "elapsed_s": max(0.0, time.time() - issued_at),
+    }
+
+
+def _hook_budget_evidence(
+    *,
+    passport_claims: Mapping[str, Any],
+    session_state: Mapping[str, Any],
+    event: Any,
+    permitted: bool,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    ceiling = max(0, int(passport_claims.get("max_tool_calls", 0)))
+    used_before = max(0, int(session_state.get("tool_call_count", 0)))
+    amount = 1 if permitted else 0
+    remaining_before = max(0, ceiling - used_before)
+    remaining_after = max(0, remaining_before - amount)
+    return (
+        {
+            "operation": "consume" if permitted else "reject",
+            "resource": "tool_call",
+            "amount": amount,
+            "unit": "tool_call",
+            "remaining_for_parent": remaining_before,
+            "remaining_after": remaining_after,
+            "used_total": used_before,
+            "reserved_total": 0,
+            "side_effect_class": event.side_effect_class,
+        },
+        {"tool_calls": remaining_after},
+    )
 
 
 def _policy_decision_dicts(decisions: list[Any]) -> list[dict[str, Any]]:
@@ -614,6 +732,7 @@ def _emit_chained_receipt(
     hook_input: Mapping[str, Any] | None = None,
     measurements: Mapping[str, Any] | None = None,
     subagent_record: Mapping[str, Any] | None = None,
+    budget_remaining: Mapping[str, int] | None = None,
 ) -> Any:
     """Build, sign, and append one receipt to the per-trace chain.
 
@@ -624,48 +743,66 @@ def _emit_chained_receipt(
     ``build_receipt`` and ``sign_receipt`` to land the digest inside the
     signed payload.
     """
-    from .receipt import build_receipt, sign_receipt
-
     private_key = load_private_key(keys_dir=keys_dir)
     state = resolve_chain_state(trace_id=trace_id)
     with _locked(state):
-        # Parent lookup and append must be in one critical section. Claude Code
-        # can dispatch parallel subagents, producing multiple hook processes at
-        # the same time; a split read/sign/append lets several receipts become
-        # independent roots and breaks chain verification.
-        parent_hash = _strip_hash_prefix(_previous_receipt_hash_unlocked(state))
-        if decisions:
-            event.policy_decisions = _policy_decision_dicts(decisions)
-        receipt_obj = build_receipt(
-            decision_enum,
-            event,
-            parent_hash,
-            # Pass None so build_receipt calls _signed_policy_decisions internally,
-            # which normalises event.policy_decisions to the schema-valid
-            # {"backend","decision","reason"} shape. Raw PolicyDecision.to_dict()
-            # output carries extra fields ("label", "reasons") that fail the
-            # receipt schema validator if passed through directly.
-            policy_decisions=None,
+        return _emit_chained_receipt_unlocked(
+            state=state,
+            private_key=private_key,
+            decision_enum=decision_enum,
+            event=event,
+            decisions=decisions,
             reason=reason,
-        )
-        # Backfill the four content-class telemetry fields from arguments onto
-        # the receipt's first-class optional fields. Without this, those fields
-        # pass the proxy gate (which reads them from arguments) but never land
-        # in the signed receipt payload that auditors verify.
-        _backfill_telemetry_fields(receipt_obj, event.arguments)
-        _attach_claude_code_measurements(
-            receipt_obj,
-            hook_input or {},
             trace_id=trace_id,
-            tool_name=str(getattr(event, "tool_name", "")),
-            metadata=measurements,
+            hook_input=hook_input,
+            measurements=measurements,
+            subagent_record=subagent_record,
+            budget_remaining=budget_remaining,
         )
-        signed = sign_receipt(receipt_obj, private_key)
-        if subagent_record is not None:
-            record = dict(subagent_record)
-            record["receipt_id"] = receipt_obj.receipt_id
-            _append_subagent_event_unlocked(state, record)
-        _append_receipt_unlocked(state, signed)
+
+
+def _emit_chained_receipt_unlocked(
+    *,
+    state: ChainState,
+    private_key: Any,
+    decision_enum: Any,
+    event: Any,
+    decisions: list,
+    reason: str,
+    trace_id: str,
+    hook_input: Mapping[str, Any] | None = None,
+    measurements: Mapping[str, Any] | None = None,
+    subagent_record: Mapping[str, Any] | None = None,
+    budget_remaining: Mapping[str, int] | None = None,
+) -> Any:
+    """Append one receipt while the caller holds the trace lock."""
+    from .receipt import build_receipt, sign_receipt
+
+    parent_hash = _strip_hash_prefix(_previous_receipt_hash_unlocked(state))
+    if decisions:
+        event.policy_decisions = _policy_decision_dicts(decisions)
+    receipt_obj = build_receipt(
+        decision_enum,
+        event,
+        parent_hash,
+        policy_decisions=None,
+        reason=reason,
+        budget_remaining=dict(budget_remaining or {}),
+    )
+    _backfill_telemetry_fields(receipt_obj, event.arguments)
+    _attach_claude_code_measurements(
+        receipt_obj,
+        hook_input or {},
+        trace_id=trace_id,
+        tool_name=str(getattr(event, "tool_name", "")),
+        metadata=measurements,
+    )
+    signed = sign_receipt(receipt_obj, private_key)
+    if subagent_record is not None:
+        record = dict(subagent_record)
+        record["receipt_id"] = receipt_obj.receipt_id
+        _append_subagent_event_unlocked(state, record)
+    _append_receipt_unlocked(state, signed)
     return receipt_obj
 
 
@@ -688,7 +825,7 @@ def handle_pre_tool_use(
         trace context to chain into).
     """
     from .claude_code_telemetry import map_tool_call
-    from .proxy import Decision, PolicyEvent
+    from .proxy import Decision, PolicyEvent, _legacy_denial_reason
 
     try:
         claims = load_active_passport(keys_dir=keys_dir)
@@ -706,60 +843,81 @@ def handle_pre_tool_use(
         arguments=arguments,
         trace_id=trace_id,
     )
-    final, decisions = _evaluate_native_policy(event, claims)
+    private_key = load_private_key(keys_dir=keys_dir)
+    state = resolve_chain_state(trace_id=trace_id)
+    try:
+        with _locked(state):
+            session_state = _verified_pretool_session_state_unlocked(
+                state,
+                private_key.public_key(),
+                claims,
+            )
+            final, decisions = _evaluate_composed_policy(
+                event,
+                claims,
+                session_state=session_state,
+            )
+            budget_delta, budget_remaining = _hook_budget_evidence(
+                passport_claims=claims,
+                session_state=session_state,
+                event=event,
+                permitted=final == "Allow",
+            )
+            event.budget_delta = budget_delta
 
-    if final == "Deny":
-        denier = next(
-            (d for d in decisions if d.decision == "Deny"),
-            None,
-        )
-        reasons = list(denier.reasons) if denier else ["denied by composed policy"]
-        reason_text = "; ".join(reasons)
+            if final == "Deny":
+                denier = next(
+                    (d for d in decisions if d.decision == "Deny"),
+                    None,
+                )
+                reasons = list(denier.reasons) if denier else ["denied by composed policy"]
+                reason_text = "; ".join(reasons)
+                deny_event = PolicyEvent(
+                    timestamp=event.timestamp,
+                    step_id=event.step_id,
+                    actor=event.actor,
+                    verifier_id=event.verifier_id,
+                    tool_name=event.tool_name,
+                    arguments=event.arguments,
+                    action_class=event.action_class,
+                    target=event.target,
+                    resource_family=event.resource_family,
+                    side_effect_class=event.side_effect_class,
+                    decision=Decision.DENY,
+                    reason=reason_text,
+                    passport_jti=event.passport_jti,
+                    trace_id=event.trace_id,
+                    denial_reason=_legacy_denial_reason(Decision.DENY, reason_text),
+                    budget_delta=budget_delta,
+                )
+                _emit_chained_receipt_unlocked(
+                    state=state,
+                    private_key=private_key,
+                    decision_enum=Decision.DENY,
+                    event=deny_event,
+                    decisions=decisions,
+                    reason=reason_text,
+                    trace_id=trace_id,
+                    hook_input=hook_input,
+                    budget_remaining=budget_remaining,
+                )
+                return _pre_tool_use_deny_output(f"ardur: blocked - {reason_text}")
 
-        # Reconstruct the event with the actual deny verdict so the
-        # receipt's ER claims reflect what really happened. Preserve
-        # `denial_reason` from the original event so any DenialReason
-        # the backend set propagates into receipt.internal_denial_code
-        # rather than collapsing to the "unknown" fallback.
-        deny_event = PolicyEvent(
-            timestamp=event.timestamp,
-            step_id=event.step_id,
-            actor=event.actor,
-            verifier_id=event.verifier_id,
-            tool_name=event.tool_name,
-            arguments=event.arguments,
-            action_class=event.action_class,
-            target=event.target,
-            resource_family=event.resource_family,
-            side_effect_class=event.side_effect_class,
-            decision=Decision.DENY,
-            reason=reason_text,
-            passport_jti=event.passport_jti,
-            trace_id=event.trace_id,
-            denial_reason=event.denial_reason,
-            budget_delta=event.budget_delta,
+            receipt_obj = _emit_chained_receipt_unlocked(
+                state=state,
+                private_key=private_key,
+                decision_enum=Decision.PERMIT,
+                event=event,
+                decisions=decisions,
+                reason="allowed by composed policy",
+                trace_id=trace_id,
+                hook_input=hook_input,
+                budget_remaining=budget_remaining,
+            )
+    except Exception:  # noqa: BLE001 - hook boundary must deny on policy/chain failure
+        return _pre_tool_use_deny_output(
+            "ardur: blocked - signed receipt chain is unavailable or invalid"
         )
-        _emit_chained_receipt(
-            decision_enum=Decision.DENY,
-            event=deny_event,
-            decisions=decisions,
-            reason=reason_text,
-            trace_id=trace_id,
-            keys_dir=keys_dir,
-            hook_input=hook_input,
-        )
-        return _pre_tool_use_deny_output(f"ardur: blocked - {reason_text}")
-
-    # Allow: build + sign + chain receipt via the shared helper.
-    receipt_obj = _emit_chained_receipt(
-        decision_enum=Decision.PERMIT,
-        event=event,
-        decisions=decisions,
-        reason="allowed by composed policy",
-        trace_id=trace_id,
-        keys_dir=keys_dir,
-        hook_input=hook_input,
-    )
     return {
         "continue": True,
         "systemMessage": f"ardur: allowed (receipt {receipt_obj.receipt_id})",

--- a/python/vibap/claude_code_report.py
+++ b/python/vibap/claude_code_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping
@@ -10,6 +11,9 @@ from typing import Any, Mapping
 from .passport import DEFAULT_HOME, load_public_key
 from .receipt import verify_chain
 from .shareable_redaction import path_aliases, redact_local_paths
+
+
+_RULE_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 
 
 def _counter_dict(values: list[str]) -> dict[str, int]:
@@ -208,6 +212,56 @@ def _merge_attribution_mode(modes: list[str]) -> str:
     return "exact"
 
 
+def _action_summary(claim: Mapping[str, Any]) -> dict[str, Any]:
+    verdict = str(claim.get("verdict", ""))
+    public_reason = str(claim.get("public_denial_reason", "") or "")
+    step_id = str(claim.get("step_id", ""))
+    phase = "pre" if step_id.endswith(":pre") else "post" if step_id.endswith(":post") else "other"
+    if phase == "post":
+        explanation = "recorded a post-action result observation"
+    elif verdict == "compliant":
+        explanation = "allowed by configured policy; the agent's normal permission flow remains in charge"
+    elif public_reason == "budget_exhausted":
+        explanation = "blocked because the signed session action budget is exhausted"
+    elif public_reason:
+        explanation = f"blocked by configured policy ({public_reason})"
+    else:
+        explanation = "blocked because the receipt did not prove a compliant action"
+    policies: list[dict[str, str]] = []
+    applied_rule = "session_action_budget" if public_reason == "budget_exhausted" else "configured_policy"
+    for item in claim.get("policy_decisions", []):
+        if not isinstance(item, Mapping):
+            continue
+        summary = {
+            "backend": str(item.get("backend", "unknown")),
+            "decision": str(item.get("decision", "unknown")),
+        }
+        if summary["backend"] == "forbid_rules":
+            candidate = str(item.get("reason", "")).split("(", 1)[0]
+            if _RULE_ID_RE.fullmatch(candidate):
+                summary["rule_id"] = candidate
+                if summary["decision"] == "Deny":
+                    applied_rule = candidate
+        policies.append(summary)
+    return {
+        "receipt_id": str(claim.get("receipt_id", "")),
+        "timestamp": str(claim.get("timestamp", "")),
+        "phase": phase,
+        "request": {
+            "tool": str(claim.get("tool", "")),
+            "action_class": str(claim.get("action_class", "")),
+            "resource_family": str(claim.get("resource_family", "")),
+            "side_effect_class": str(claim.get("side_effect_class", "")),
+        },
+        "verdict": verdict,
+        "explanation": explanation,
+        "applied_rule": applied_rule,
+        "policies": policies,
+        "budget_delta": dict(claim.get("budget_delta", {}) or {}),
+        "budget_remaining": dict(claim.get("budget_remaining", {}) or {}),
+    }
+
+
 def _chain_report(
     *,
     trace_id: str,
@@ -290,6 +344,7 @@ def _chain_report(
         "verdicts": _counter_dict([str(claim.get("verdict", "")) for claim in claims]),
         "action_classes": _counter_dict([str(claim.get("action_class", "")) for claim in claims]),
         "side_effect_classes": _counter_dict([str(claim.get("side_effect_class", "")) for claim in claims]),
+        "actions": [_action_summary(claim) for claim in claims],
         "dispatches": dispatches,
         "dispatch_launches": dispatch_launches,
         "dispatch_observations": dispatch_observations,
@@ -364,6 +419,18 @@ def build_claude_code_report(
         "chain_dir": str(resolved_chain_dir),
         "keys_dir": str(resolved_keys_dir),
         "chain_verification": {"ok": True, "verify_expiry": verify_expiry},
+        "verification": {
+            "command": "ardur claude-code-report --home <ardur-home>",
+            "detail": "Re-run the local report to verify signatures and hash links for every receipt chain.",
+        },
+        "cost_boundary": {
+            "enforced_unit": "governed tool calls",
+            "monetary_cost": "unavailable_without_signed_adapter_data",
+            "detail": (
+                "The signed action budget is enforced locally. A dollar-denominated "
+                "cap requires trusted cost telemetry from the provider adapter."
+            ),
+        },
         "chain_count": len(chains),
         "receipt_count": len(all_claims),
         "next_steps": _empty_report_next_steps() if not all_claims else [],

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -38,6 +38,7 @@ from .passport import (
     KeyDirectoryError,
     MissionPassport,
     _ensure_default_home_dir,
+    derive_mission_id,
     generate_keypair,
     load_existing_private_key,
     load_existing_public_key,
@@ -61,6 +62,11 @@ from .personal_hub import (
     setup_personal,
     status_response_with_next_steps,
     uninstall_personal,
+)
+from .personal_firewall import (
+    MAX_DEMO_SECONDS as PERSONAL_FIREWALL_MAX_DEMO_SECONDS,
+    PersonalFirewallDemoError,
+    run_personal_firewall_demo,
 )
 from .claude_code_report import build_claude_code_report
 from .claude_code_hook import main as claude_code_hook_main
@@ -2294,6 +2300,22 @@ def cmd_claude_code_report(args: argparse.Namespace) -> int:
     )
     print(f"Per-child attribution: {report['coverage']['per_child_attribution']}")
     print(f"Attribution: {report['coverage']['attribution']}")
+    actions = [action for chain in report["chains"] for action in chain.get("actions", [])]
+    if actions:
+        print("Actions:")
+        for action in actions[-20:]:
+            request = action["request"]
+            remaining = action.get("budget_remaining", {}).get("tool_calls")
+            budget_text = f"; {remaining} governed calls remain" if remaining is not None else ""
+            print(
+                f"- {action['verdict'].upper()} {request['tool']} "
+                f"({request['action_class']}/{request['side_effect_class']}): "
+                f"{action['explanation']}{budget_text}"
+            )
+        if len(actions) > 20:
+            print(f"  Showing the latest 20 of {len(actions)} signed actions.")
+    print(f"Cost boundary: {report['cost_boundary']['detail']}")
+    print(f"Verify later: {report['verification']['command']}")
     _print_report_next_steps(report)
     return 0
 
@@ -3401,7 +3423,43 @@ def cmd_personal_native_manifest(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_personal_firewall_demo(args: argparse.Namespace) -> int:
+    try:
+        result = run_personal_firewall_demo(
+            timeout_s=args.timeout_s,
+            temp_parent=args.temp_parent.expanduser().resolve() if args.temp_parent else None,
+            emit=not args.json,
+        )
+    except PersonalFirewallDemoError as exc:
+        failure = {
+            "ok": False,
+            "error": "personal_firewall_demo_failed",
+            "condition": "personal_firewall_demo_failed",
+            "message": str(exc),
+            "next_steps": [
+                {
+                    "action": "retry_local_demo",
+                    "command": "ardur personal-firewall demo",
+                    "detail": "Retry the provider-free local proof with the default temporary directory.",
+                }
+            ],
+        }
+        if args.json:
+            _print_json(failure)
+        else:
+            print(f"FAIL  {failure['message']}")
+        return 1
+    if args.json:
+        _print_json(result)
+    return 0
+
+
 CLAUDE_CODE_PROTECT_MODES = {
+    "personal-firewall": {
+        "mission": "Local personal action firewall for Claude Code.",
+        "allowed_tools": ["Read", "Glob", "Grep", "Edit", "MultiEdit", "Write"],
+        "forbidden_tools": ["Bash", "WebFetch", "WebSearch"],
+    },
     "safe-coding": {
         "mission": "Safe Claude Code work inside the selected folder.",
         "allowed_tools": ["Read", "Glob", "Grep", "Edit", "MultiEdit", "Write"],
@@ -3978,6 +4036,10 @@ def _resolve_protect_policies(
     """Build additional_policies from CLI flags + profile."""
     policies: list[dict[str, object]] = []
 
+    def forbid_rules_sha256(rules: object) -> str:
+        canonical = json.dumps(rules, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
     # Reject empty/whitespace-only policy path arguments before Path()
     # normalises them to the current working directory. ``type=str`` on the
     # parser keeps the raw value so an empty/whitespace input can be detected
@@ -4016,9 +4078,7 @@ def _resolve_protect_policies(
             "backend": "forbid_rules",
             "label": "cli-forbid-rules",
             "policy_inline": "",
-            "policy_sha256": hashlib.sha256(
-                json.dumps(rules, sort_keys=True).encode()
-            ).hexdigest(),
+            "policy_sha256": forbid_rules_sha256(rules),
             "data_inline": rules,
         })
     if cedar_policy_raw is not None:
@@ -4042,9 +4102,7 @@ def _resolve_protect_policies(
             "backend": "forbid_rules",
             "label": "profile-forbid-rules",
             "policy_inline": "",
-            "policy_sha256": hashlib.sha256(
-                json.dumps(profile.forbid_rules, sort_keys=True).encode()
-            ).hexdigest(),
+            "policy_sha256": forbid_rules_sha256(profile.forbid_rules),
             "data_inline": profile.forbid_rules,
         })
     if profile and profile.cedar_policy:
@@ -4607,16 +4665,24 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         cwd=str(scope),
         max_tool_calls=max_tool_calls,
         max_duration_s=max_duration_s,
+        additional_policies=additional_policies,
     )
     token = issue_passport(mission, private_key, ttl_s=args.ttl_s or max_duration_s)
+    claims = verify_passport(token, public_key)
     # Seed additional policies (Cedar / forbid_rules) into the persistent
     # store so the proxy picks them up at session-start time. Policies are
     # resolved from CLI flags first, then from the profile.
     if additional_policies:
         from vibap.backed_policy_store import FileBackedPolicyStore
         store = FileBackedPolicyStore(home)
-        store.put_policies(mission_id=args.agent_id, policies=additional_policies)
-    claims = verify_passport(token, public_key)
+        store.put_policies(
+            mission_id=str(
+                claims.get("mission_id")
+                or mission.mission_id
+                or derive_mission_id(mission.agent_id, mission.mission)
+            ),
+            policies=additional_policies,
+        )
     active_passport = home / "active_mission.jwt"
     _write_private_text(active_passport, token + "\n")
     hook_python = home / "claude-code-hook-python"
@@ -5494,6 +5560,32 @@ def build_parser() -> argparse.ArgumentParser:
         default="chrome",
     )
     personal_native_manifest.set_defaults(func=cmd_personal_native_manifest)
+
+    personal_firewall = subparsers.add_parser(
+        "personal-firewall",
+        help="run and inspect the conservative local personal action firewall",
+    )
+    personal_firewall_subparsers = personal_firewall.add_subparsers(
+        dest="personal_firewall_command",
+        required=True,
+    )
+    personal_firewall_demo = personal_firewall_subparsers.add_parser(
+        "demo",
+        help="run a provider-free ASK/DENY and signed-receipt proof",
+    )
+    personal_firewall_demo.add_argument(
+        "--timeout-s",
+        type=float,
+        default=PERSONAL_FIREWALL_MAX_DEMO_SECONDS,
+        help="overall demo deadline in seconds (maximum 60)",
+    )
+    personal_firewall_demo.add_argument(
+        "--temp-parent",
+        type=Path,
+        help="existing directory that receives temporary demo state",
+    )
+    personal_firewall_demo.add_argument("--json", action="store_true")
+    personal_firewall_demo.set_defaults(func=cmd_personal_firewall_demo)
 
     profile = subparsers.add_parser(
         "profile",

--- a/python/vibap/personal_firewall.py
+++ b/python/vibap/personal_firewall.py
@@ -1,0 +1,369 @@
+"""Provider-free proof for Ardur's personal action-firewall profile."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+from .shareable_redaction import redact_local_path_text
+
+
+MAX_DEMO_SECONDS = 60.0
+TRACE_ID = "personal-firewall-demo"
+
+
+class PersonalFirewallDemoError(RuntimeError):
+    """Fail-closed demo error safe to show without local path details."""
+
+
+def _remaining(deadline: float, label: str) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise PersonalFirewallDemoError(f"deadline expired before {label}")
+    return remaining
+
+
+def _run_json(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    deadline: float,
+    label: str,
+    stdin_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            list(command),
+            cwd=cwd,
+            env=env,
+            input=json.dumps(stdin_payload) if stdin_payload is not None else None,
+            capture_output=True,
+            text=True,
+            timeout=_remaining(deadline, label),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise PersonalFirewallDemoError(f"{label} exceeded the demo deadline") from exc
+    if result.returncode != 0:
+        raise PersonalFirewallDemoError(f"{label} failed closed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise PersonalFirewallDemoError(f"{label} returned malformed JSON") from exc
+    if not isinstance(payload, dict):
+        raise PersonalFirewallDemoError(f"{label} returned a non-object response")
+    return payload
+
+
+def _require_ok(payload: dict[str, Any], label: str) -> None:
+    if payload.get("ok") is not True:
+        raise PersonalFirewallDemoError(f"{label} did not complete")
+
+
+def _hook_fixture(
+    *,
+    project: Path,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    suffix: str,
+) -> dict[str, Any]:
+    return {
+        "session_id": "personal-firewall-demo-session",
+        "transcript_path": str(project / "transcript.jsonl"),
+        "cwd": str(project),
+        "permission_mode": "default",
+        "hook_event_name": "PreToolUse",
+        "tool_use_id": f"personal-firewall-{suffix}",
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+
+
+def _require_native_prompt(payload: dict[str, Any]) -> None:
+    if payload.get("continue") is not True:
+        hook_output = payload.get("hookSpecificOutput")
+        reason = (
+            str(hook_output.get("permissionDecisionReason", "policy denied"))
+            if isinstance(hook_output, dict)
+            else "policy denied"
+        )
+        raise PersonalFirewallDemoError(
+            f"safe local read was not permitted: {redact_local_path_text(reason)}"
+        )
+    hook_output = payload.get("hookSpecificOutput")
+    if (
+        isinstance(hook_output, dict)
+        and hook_output.get("permissionDecision") == "allow"
+    ):
+        raise PersonalFirewallDemoError(
+            "Ardur bypassed the agent's native permission flow"
+        )
+
+
+def _require_deny(payload: dict[str, Any], label: str) -> str:
+    hook_output = payload.get("hookSpecificOutput")
+    if (
+        not isinstance(hook_output, dict)
+        or hook_output.get("permissionDecision") != "deny"
+    ):
+        raise PersonalFirewallDemoError(f"{label} was not denied")
+    reason = hook_output.get("permissionDecisionReason")
+    if not isinstance(reason, str) or not reason.startswith("ardur: blocked"):
+        raise PersonalFirewallDemoError(f"{label} deny omitted a readable reason")
+    return redact_local_path_text(reason)
+
+
+def _validate_report(report: dict[str, Any]) -> None:
+    if (
+        report.get("ok") is not True
+        or report.get("chain_verification", {}).get("ok") is not True
+    ):
+        raise PersonalFirewallDemoError("signed receipt chain did not verify")
+    if report.get("chain_count") != 1 or report.get("receipt_count") != 4:
+        raise PersonalFirewallDemoError(
+            "receipt report did not contain four demo decisions"
+        )
+    totals = report.get("totals", {})
+    if totals.get("verdicts") != {"compliant": 1, "violation": 3}:
+        raise PersonalFirewallDemoError("receipt report verdict counts are incorrect")
+    actions = report.get("chains", [{}])[0].get("actions", [])
+    if len(actions) != 4:
+        raise PersonalFirewallDemoError(
+            "receipt report omitted readable action summaries"
+        )
+    secret_action = actions[2]
+    if not any(
+        policy.get("backend") == "forbid_rules" and policy.get("decision") == "Deny"
+        for policy in secret_action.get("policies", [])
+    ):
+        raise PersonalFirewallDemoError(
+            "secret-like request did not exercise forbid rules"
+        )
+
+
+def run_personal_firewall_demo(
+    *,
+    timeout_s: float = MAX_DEMO_SECONDS,
+    temp_parent: Path | None = None,
+    emit: bool = True,
+) -> dict[str, Any]:
+    if not 0 < timeout_s <= MAX_DEMO_SECONDS:
+        raise PersonalFirewallDemoError(
+            f"timeout must be greater than zero and at most {MAX_DEMO_SECONDS:g} seconds"
+        )
+    if temp_parent is not None and not temp_parent.is_dir():
+        raise PersonalFirewallDemoError(
+            "temporary parent must be an existing directory"
+        )
+
+    started = time.monotonic()
+    deadline = started + timeout_s
+    cli = [sys.executable, "-m", "vibap.cli"]
+    temp_root: Path | None = None
+
+    with tempfile.TemporaryDirectory(
+        prefix="ardur-personal-firewall-",
+        dir=str(temp_parent) if temp_parent is not None else None,
+    ) as temp_root_text:
+        temp_root = Path(temp_root_text).resolve()
+        project = temp_root / "project"
+        home = temp_root / "ardur-home"
+        keys = home / "keys"
+        profile = project / "ARDUR.md"
+        outside_target = temp_root / "outside-workspace.txt"
+        secret_target = project / "secret-like.txt"
+        project.mkdir()
+        safe_file = project / "README.md"
+        safe_file.write_text("local personal firewall fixture\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env.pop("ARDUR_MISSION_PASSPORT", None)
+        env["VIBAP_HOME"] = str(home)
+        env["ARDUR_CC_HOOK_DIR"] = str(home / "claude-code-hook")
+        env["ARDUR_TRACE_ID"] = TRACE_ID
+
+        profile_result = _run_json(
+            [
+                *cli,
+                "profile",
+                "init",
+                "--template",
+                "personal-firewall",
+                "--path",
+                str(profile),
+                "--json",
+            ],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="personal profile setup",
+        )
+        _require_ok(profile_result, "personal profile setup")
+        protect_result = _run_json(
+            [
+                *cli,
+                "protect",
+                "claude-code",
+                "--profile",
+                str(profile),
+                "--home",
+                str(home),
+                "--keys-dir",
+                str(keys),
+                "--agent-id",
+                "demo:personal-firewall",
+                "--json",
+            ],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="personal firewall activation",
+        )
+        _require_ok(protect_result, "personal firewall activation")
+
+        safe_read = _run_json(
+            [*cli, "claude-code-hook", "pre", "--keys-dir", str(keys)],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="safe read decision",
+            stdin_payload=_hook_fixture(
+                project=project,
+                tool_name="Read",
+                tool_input={"file_path": str(safe_file)},
+                suffix="safe-read",
+            ),
+        )
+        _require_native_prompt(safe_read)
+
+        outside_write = _run_json(
+            [*cli, "claude-code-hook", "pre", "--keys-dir", str(keys)],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="outside-workspace write decision",
+            stdin_payload=_hook_fixture(
+                project=project,
+                tool_name="Write",
+                tool_input={"file_path": str(outside_target), "content": "blocked\n"},
+                suffix="outside-write",
+            ),
+        )
+        _require_deny(outside_write, "outside-workspace write")
+        outside_reason = "outside the configured workspace scope"
+
+        secret_write = _run_json(
+            [*cli, "claude-code-hook", "pre", "--keys-dir", str(keys)],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="secret-like write decision",
+            stdin_payload=_hook_fixture(
+                project=project,
+                tool_name="Write",
+                tool_input={
+                    "file_path": str(secret_target),
+                    "content": "api_key=synthetic-demo-value\n",
+                },
+                suffix="secret-write",
+            ),
+        )
+        _require_deny(secret_write, "secret-like write")
+        secret_reason = "matched the personal secret-like argument policy"
+
+        network_call = _run_json(
+            [*cli, "claude-code-hook", "pre", "--keys-dir", str(keys)],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="network decision",
+            stdin_payload=_hook_fixture(
+                project=project,
+                tool_name="WebFetch",
+                tool_input={
+                    "url": "https://example.invalid/collect",
+                    "prompt": "send data",
+                },
+                suffix="network",
+            ),
+        )
+        _require_deny(network_call, "external network request")
+        network_reason = "external network tools are disabled by default"
+
+        if outside_target.exists() or secret_target.exists():
+            raise PersonalFirewallDemoError("a denied write reached the filesystem")
+
+        report = _run_json(
+            [
+                *cli,
+                "claude-code-report",
+                "--home",
+                str(home),
+                "--keys-dir",
+                str(keys),
+                "--json",
+            ],
+            cwd=project,
+            env=env,
+            deadline=deadline,
+            label="receipt verification",
+        )
+        _validate_report(report)
+
+    if temp_root is None or temp_root.exists():
+        raise PersonalFirewallDemoError("temporary demo state was not removed")
+    elapsed_s = time.monotonic() - started
+    result = {
+        "ok": True,
+        "schema_version": "ardur.personal_firewall_demo.v0.1",
+        "elapsed_s": round(elapsed_s, 3),
+        "decisions": [
+            {
+                "request": "workspace read",
+                "result": "ASK",
+                "detail": "native permission flow remains in charge",
+            },
+            {
+                "request": "outside-workspace write",
+                "result": "DENY",
+                "detail": outside_reason,
+            },
+            {
+                "request": "secret-like argument",
+                "result": "DENY",
+                "detail": secret_reason,
+            },
+            {"request": "external network", "result": "DENY", "detail": network_reason},
+        ],
+        "receipts": {
+            "count": 4,
+            "chains": 1,
+            "verified": True,
+            "readable_summaries": True,
+        },
+        "cost_boundary": report["cost_boundary"],
+        "verification": report["verification"],
+        "temporary_state_removed": True,
+        "evidence_boundary": (
+            "configured local Claude Code tool-boundary proof; not provider-hidden, "
+            "kernel, universal secret-detection, or monetary-cost evidence"
+        ),
+    }
+    if emit:
+        print("Ardur personal action firewall")
+        for decision in result["decisions"]:
+            print(
+                f"{decision['result']:4}  {decision['request']}: {decision['detail']}"
+            )
+        print("PASS  four signed decisions verified in one hash-linked receipt chain")
+        print(f"COST  {result['cost_boundary']['detail']}")
+        print(f"VERIFY  {result['verification']['command']}")
+        print(f"BOUNDARY  {result['evidence_boundary']}")
+    return result

--- a/python/vibap/personal_firewall.py
+++ b/python/vibap/personal_firewall.py
@@ -358,10 +358,12 @@ def run_personal_firewall_demo(
     }
     if emit:
         print("Ardur personal action firewall")
-        for decision in result["decisions"]:
-            print(
-                f"{decision['result']:4}  {decision['request']}: {decision['detail']}"
-            )
+        print("ASK   workspace read: native permission flow remains in charge")
+        print("DENY  outside-workspace write: outside the configured workspace scope")
+        print(
+            "DENY  secret-like argument: matched the personal secret-like argument policy"
+        )
+        print("DENY  external network: external network tools are disabled by default")
         print("PASS  four signed decisions verified in one hash-linked receipt chain")
         print(f"COST  {result['cost_boundary']['detail']}")
         print(f"VERIFY  {result['verification']['command']}")

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "81c2404a27135ac0f37702a957b240fcaabbcf47955ed68dd7b52e1250d69f50"
+source_sha256: "a6f092694200269a62cce11351ee9e9df61f674f963a4df0bbb7b4509f445aa8"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -30,6 +30,8 @@ All notable changes to Ardur will be documented in this file.
 - Remove internal fixture/hashing helpers in favor of stdlib
 
 ### Added
+- Personal action-firewall profile and one-command provider-free ASK/DENY proof
+- Readable Claude Code action summaries with signed action-budget evidence
 - Execution Receipt v0.2 schema, embedded package copy, and canonical golden fixture
 - Comprehensive E2E showcase test suite (28 tests, 7 layers)
 - Live adversarial scoreboard and continuous harness
@@ -49,6 +51,9 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Enforce cumulative direct-hook tool-call budgets from verified receipt chains
+- Compose mission-declared policy backends in the direct Claude Code hook
+- Canonicalize persisted forbid-rule hashes and key them by actual mission ID
 - CI baseline repair after AskUserQuestion landing
 - Claude AskUserQuestion hash handling
 - Gemini hook contract aligned with CLI 0.44.1

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -2,7 +2,7 @@
 title: "Ardur"
 description: "Ardur governs AI-agent tool calls that pass through a configured adapter or"
 source_path: "README.md"
-source_sha256: "2d87a4046d716f5f3d22f539599944a7a7507c9ce3a12bc504eb8a476ebc2788"
+source_sha256: "f058f42ce79df29796f26ed1ecee5499c90330e97a77d01b0e4342f88ce127b9"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -150,6 +150,11 @@ Start with the source-checkout walkthrough in
 [`docs/guides/claude-code-mvp-quickstart.md`](/__ardur_internal__/source/docs/guides/claude-code-mvp-quickstart/).
 It gives three bounded paths:
 
+- a **personal action-firewall proof** using `ardur personal-firewall demo`;
+  it shows one local `ASK` outcome (Claude Code's normal permission flow stays
+  in charge), three pre-dispatch denials for outside-workspace, secret-like,
+  and network requests, and four verified signed receipt summaries without an
+  API key or retained demo state;
 - a **60-second deliberate deny proof** using
   `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
   adapter, verifies a signed violation receipt, checks an unchanged canary, and
@@ -164,6 +169,10 @@ That guide also separates **Works now**, **Not claimed**, and **Coming soon**
 to clearly mark the boundary between shipped, deferred, and in-progress
 capabilities — package-manager release status, provider-hidden behavior,
 and subprocess/kernel/network side-effect gaps.
+
+The personal mode enforces a signed governed-tool-call budget. It does not
+claim a dollar-denominated cost cap unless an adapter supplies trusted signed
+cost telemetry.
 
 After a run, use the
 [`Phase 1 Demo Packet`](/__ardur_internal__/source/docs/guides/phase1-demo-packet/) to assemble a bounded

--- a/site/content/source/docs/guides/ardur-personal-hub.md
+++ b/site/content/source/docs/guides/ardur-personal-hub.md
@@ -2,7 +2,7 @@
 title: "Ardur Personal Hub"
 description: "Ardur Personal is the local product shape for regular users. It protects local"
 source_path: "docs/guides/ardur-personal-hub.md"
-source_sha256: "3b2e2e86b548d4ecac9cab002aadae908d1b1a32a967e7db0872e784abc607e5"
+source_sha256: "490b533e71e496575c11120e0066134d6438ad64242df718e2cda033ca6dc1b3"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -32,6 +32,18 @@ cd <ardur-repo>
 pip install -e python/
 ardur --version
 ```
+
+See the personal safety boundary locally before configuring a provider:
+
+```bash
+ardur personal-firewall demo
+```
+
+The command uses temporary local fixtures only. It shows an `ASK` result for a
+safe workspace read without bypassing Claude Code's normal permission flow,
+then denies an outside-workspace write, a secret-like argument, and external
+network access. It verifies four signed, hash-linked receipts and removes all
+temporary state.
 
 Create a simple guardrail file:
 
@@ -85,16 +97,25 @@ complete release artifact.
 
 ## Options Users Can Choose
 
+- `personal-firewall`: allows reads and edits inside the protected folder,
+  denies shell and external network tools, blocks common secret-like argument
+  markers, and caps the signed session at 40 governed tool calls.
 - `read-only`: review code without editing files or running commands.
 - `safe-coding`: edit files inside the protected folder, but block shell
   commands.
 - `ARDUR.md`: plain Markdown profile for the same settings, suitable for
   non-technical users.
 - Advanced CLI flags: `ardur protect claude-code --scope . --mode read-only`
-  and `ardur protect claude-code --scope . --mode safe-coding`.
+  and `ardur protect claude-code --scope . --mode personal-firewall`.
 
 The Markdown profile compiles into the same Mission Passport and receipt path
 as advanced CLI setup. No policy capability is removed.
+
+The personal session cap is an action budget, not a provider-billing estimate.
+A dollar-denominated cap requires trusted signed cost telemetry from the
+provider adapter. Secret markers are conservative patterns, not universal data
+loss prevention, and allowed actions still pass through the agent's native
+permission flow.
 
 For source installs, `pip install -e python/` installs Ardur's required Python
 dependencies from `python/pyproject.toml`. The development Homebrew formula is

--- a/site/content/source/docs/reference/cli.md
+++ b/site/content/source/docs/reference/cli.md
@@ -2,7 +2,7 @@
 title: "ardur` CLI Reference"
 description: "The `ardur` console entry point ships with the Python package. After"
 source_path: "docs/reference/cli.md"
-source_sha256: "dccfda4ce594c09a9875a9443b38b39de8848f73bb11e6f75c25165d462e9071"
+source_sha256: "8222b6ae0a95db22894d11884d795fa920928cb9b18cb0d50f4601dfb8171beb"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -875,6 +875,28 @@ before a manifest is emitted with the same output shape and `error`/`condition:
 validation only; it does not prove browser-store deployment, Native Messaging
 installation, live provider/API behavior, or release readiness.
 
+### `ardur personal-firewall demo`
+
+Run a provider-free local proof of the conservative personal action firewall.
+
+```text
+ardur personal-firewall demo [--timeout-s SECONDS]
+                             [--temp-parent DIR] [--json]
+```
+
+The command creates only temporary local profile, key, project, and receipt
+state. It proves four pre-action decisions: a workspace read remains subject to
+the agent's native permission flow (`ASK`), while an outside-workspace write, a
+secret-like argument, and external network access are denied. It then verifies
+the four signed receipts as one hash-linked chain and removes temporary state.
+
+The JSON result includes readable decisions, receipt counts, verification
+guidance, and an explicit cost boundary. The enforced session budget is measured
+in governed tool calls. `monetary_cost` is
+`unavailable_without_signed_adapter_data`; the command does not contact a
+provider or claim a dollar-denominated cap, universal secret detection, kernel
+enforcement, or visibility into provider-hidden behavior.
+
 ### `ardur profile init`
 
 Write a starter `ARDUR.md` profile from a built-in template.
@@ -884,7 +906,8 @@ ardur profile init --template TEMPLATE
                    [--path PATH] [--force] [--json]
 ```
 
-Templates: `read-only`, `safe-coding`. Default path: `./ARDUR.md`.
+Templates: `personal-firewall`, `read-only`, `safe-coding`. Default path:
+`./ARDUR.md`.
 
 Empty, whitespace-only, or traversal-escaping paths are rejected **before any
 filesystem operation**. `ardur profile init` rejects paths that are empty,
@@ -941,7 +964,7 @@ exact `claude` invocation that pairs the plugin with the active passport.
 
 ```text
 ardur protect claude-code [--scope DIR] [--profile PATH]
-                          [--mode read-only|safe-coding]
+                          [--mode personal-firewall|read-only|safe-coding]
                           [--json] [--home DIR] [--plugin-dir DIR]
                           [--keys-dir DIR] [--agent-id ID]
                           [--mission TEXT]
@@ -1147,6 +1170,13 @@ ardur claude-code-report [--home DIR] [--chain-dir DIR] [--keys-dir DIR]
 
 `--verify-expiry` also enforces short receipt expiry windows during chain
 verification (off by default so reports work on archived chains).
+
+Each chain includes a redacted `actions` list with the requested tool/action
+class, allow or deny verdict, policy backends, stable rule identifiers, signed
+tool-call budget delta, and remaining action budget. Human output prints the
+latest 20 summaries and a placeholder-only verification command. The report
+does not expose raw policy-reason prose or tool arguments, and it does not claim
+a monetary cost when the adapter supplied no trusted signed cost data.
 
 When no local Claude Code hook receipts are present, the JSON report includes a
 `next_steps` array and the human output prints a concise "Next steps" section:

--- a/site/content/source/plugins/claude-code/README.md
+++ b/site/content/source/plugins/claude-code/README.md
@@ -2,7 +2,7 @@
 title: "Ardur Claude Code Plugin"
 description: "This plugin protects Claude Code at the local tool boundary. `PreToolUse` runs"
 source_path: "plugins/claude-code/README.md"
-source_sha256: "f9a5a0b9233581ac18aa00208cd7cf09417ad87128e1756a89a05391785a18ae"
+source_sha256: "3861b480f43df0140bf783bb1c266aec4da76ffb3d15b25b3ddf7543458564de"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -42,6 +42,12 @@ guardrail file:
 cd <ardur-repo>
 pip install -e python/
 ardur profile init --template read-only --path ARDUR.md
+```
+
+To see the conservative personal flow before configuring Claude Code, run:
+
+```bash
+ardur personal-firewall demo
 ```
 
 Open `ARDUR.md` in any text editor:
@@ -126,6 +132,9 @@ Claim boundary — per-platform numbers:
 
 ## Built-In Options
 
+- `ardur profile init --template personal-firewall`: workspace-scoped reads
+  and edits, common secret-like argument blocks, no shell/network tools, and a
+  signed 40-action session cap.
 - `ardur profile init --template read-only`: safest first run. Allows reading
   and searching only.
 - `ardur profile init --template safe-coding`: allows local file edits inside
@@ -134,6 +143,12 @@ Claim boundary — per-platform numbers:
   a Markdown profile.
 - `ardur protect claude-code --scope . --mode safe-coding`: flag-based setup
   for technical users.
+- `ardur protect claude-code --scope . --mode personal-firewall`: the same
+  native capability defaults without a Markdown profile; use the profile when
+  you also want its secret-like argument rules.
+
+The action cap is enforced in governed tool calls. Ardur does not infer a
+dollar cost when Claude Code supplies no trusted signed billing telemetry.
 
 Advanced users can still use `ardur issue`, `ARDUR_MISSION_PASSPORT`,
 `ARDUR_CC_HOOK_DIR`, and custom Mission Passport fields directly. The Markdown

--- a/site/content/source/python/README.md
+++ b/site/content/source/python/README.md
@@ -2,7 +2,7 @@
 title: "Ardur — Python Reference Implementation"
 description: "The public Python runtime for Ardur lives here: a runtime governance and evidence layer for AI agents that issues signed mission passports, enforces them at execution time, and rec"
 source_path: "python/README.md"
-source_sha256: "5180404253589a247c27037c7a464412a00fb5353ecfc30bf363e461e7896e31"
+source_sha256: "bff2fac947020d545f0d8e5da64c0a150b1455679ba57d4321a09a57525593d4"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -55,6 +55,18 @@ ardur verify --token <token-from-issue-output>
 
 That walks through key generation, mission compilation, ES256-signed passport
 issuance, and verification - all local, no LLM calls.
+
+Run the conservative personal action-firewall proof with one command:
+
+```bash
+ardur personal-firewall demo
+```
+
+The provider-free demo preserves the agent's normal permission prompt for a
+safe workspace read, denies outside-workspace writes, secret-like arguments,
+and external network access, then verifies the signed receipt chain. Its
+session cap is measured in governed tool calls; monetary cost remains unknown
+unless an adapter supplies trusted signed cost telemetry.
 
 Every durable receipt sink also queues an idempotent local transparency-anchor
 sidecar. Network submission is a separate `ardur anchor` operation, and


### PR DESCRIPTION
## Summary
- add a conservative `personal-firewall` profile with workspace-scoped reads/writes, disabled shell/network tools, secret-like argument rules, and a 40-call signed session budget
- add `ardur personal-firewall demo`, a provider-free ASK/DENY proof with four verified signed receipt summaries and temporary-state cleanup
- enforce mission-declared policies and cumulative budgets in the direct Claude Code hook using the verified receipt chain under the trace lock
- add readable action/rule/budget summaries while preserving raw-argument and local-path redaction

## Security and claim boundaries
- Ardur never returns `permissionDecision=allow`; otherwise-permitted actions remain under Claude Code's native permission flow
- malformed, oversized, symlinked, non-regular, or unverifiable receipt-chain state fails closed
- the cap is measured in governed tool calls, not dollars; monetary cost remains unavailable without trusted signed adapter telemetry
- this does not claim universal secret detection, provider-hidden visibility, kernel enforcement, or enterprise DLP

## Validation
- focused affected surface: 140 passed
- full Python: 1,756 passed, 33 skipped, 6 pre-existing warnings
- Go: race, vet, and govulncheck passed; no called vulnerabilities
- Ruff 0.13.0, Actionlint, Gitleaks, JSON/YAML/schema sync, source-doc sync, and `git diff --check` passed
- Hugo 0.161.1 built 282 pages
- wheel/sdist and strict Twine passed; fresh-wheel demo passed and matched normalized source output
- pip-audit found no known vulnerabilities after upgrading the temporary verifier venv bootstrap pip to 26.1.2; `pip check` passed

Fixes #164

Semgrep was not used. `main` and PR #17 are untouched.