### PR TITLE
fix(kernel): serialize policy map handle lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
+  health, in-flight mutations, tier withdrawal, and close cannot race
 - Pin Biscuit holder verification to a server-owned issuer key, JWT-SVID trust
   bundle, and audience; require configured binding on every presentation; and
   reject caller-supplied roots plus non-`jwt-svid` bundle keys
@@ -41,6 +43,8 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Prevent torn `PolicyMaps` reads and use-after-close during BPF-LSM guard
+  startup, degradation, and shutdown; reject late guards after seccomp fallback
 - Reject attacker-signed JWT-SVIDs even when their SPIFFE ID matches the
   Biscuit holder claim; `svid_bound=true` now requires pinned-root verification
 - Enforce cumulative direct-hook tool-call budgets from verified receipt chains

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ At the reviewed `dev` tree on 2026-07-11, the current gates were:
 | Python local matrix (Python 3.13) | 1,665 passed, 33 skipped; CI separately enforces its coverage threshold |
 | Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
 | Go CI | Tests, vet, lint, and vulnerability scan passed |
-| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, strict BPF `ardur run --enforce` with a kernel-stopped, exact-artifact bootstrap and denied child exec, seccomp smoke, and full seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, policy-map startup/teardown lifetime races, live BPF-LSM kernel smoke, strict BPF `ardur run --enforce` with a kernel-stopped, exact-artifact bootstrap and denied child exec, seccomp smoke, and full seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
 | Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
 These gates verify the checked-in runtime and its configured integration

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,6 +36,14 @@ environment, or file content. It does not attest or enforce. Issue #67 remains
 in progress for stronger fingerprints and corpus-backed precision/recall
 thresholds.
 
+The Linux kernel-capture daemon now publishes its BPF policy-map handle set and
+`bpf_lsm` tier as one synchronized lifecycle transition. Every map operation,
+health-tier read, withdrawal, and close boundary uses the same mutex; teardown
+withdraws the tier and map reachability only after in-flight users drain, then
+closes the handles. A readiness timeout commits seccomp under the same lock, so
+a late BPF load cannot replace the selected fallback. Mid-run guard loss still
+degrades honestly to `none`; automatic BPF-to-seccomp failover is not claimed.
+
 The Python Biscuit session path now accepts JWT-SVID holder binding only from
 server-owned Biscuit issuer-key, trust-bundle, and audience configuration. A
 configured binding is mandatory for every Biscuit presentation; per-call

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -206,6 +206,22 @@ can be replayed during its validity window if both the Biscuit and SVID are
 stolen. Deployments needing channel-bound workload identity should prefer the
 X.509-SVID mTLS pattern in ADR-022.
 
+## BPF policy-map teardown is serialized, but mid-run failover is not automatic
+
+The Linux daemon publishes the complete BPF policy-map handle set and the
+`bpf_lsm` tier under one lifecycle mutex. Health reads and every map operation
+participate in that same boundary. On guard exit, the daemon waits for in-flight
+map users, withdraws the tier and all shared map references, and only then
+closes the underlying BPF handles. Startup fallback selection is serialized as
+well, so a BPF load completing after the readiness timeout cannot replace an
+already selected seccomp tier.
+
+If a live BPF-LSM guard exits mid-run, the daemon records degradation and
+reports enforcement tier `none`. It does not automatically start or migrate
+the workload to seccomp user-notify after that failure; seccomp supervision is
+currently selected only during startup. Operators must treat the degradation
+event as an availability incident rather than assuming transparent failover.
+
 ## Operator + webhook /metrics endpoints (deployment hardening required)
 
 The `cmd/operator` and `cmd/webhook` binaries expose Prometheus metrics

--- a/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
@@ -154,7 +154,7 @@ func TestHandleApplyPolicy_ReapplyRevokesDroppedAllowlist(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, h := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	registerTestSession(t, d, "ses-prune", 5500)
 	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
 
@@ -195,7 +195,7 @@ func TestHandleApplyPolicy_ConcurrentAppliesSerialized(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, h := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	registerTestSession(t, d, "ses-conc", 6600)
 	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
 

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_degrade_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_degrade_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
@@ -123,29 +124,14 @@ func TestHealthReflectsTrueTier_AfterGuardConsumerDeath(t *testing.T) {
 	d.fs = newStubFS()
 
 	// Simulate a successful guard load: policyMaps populated, tier live.
-	d.policyMaps = kernelcapture.PolicyMaps{
-		CgroupOpPolicy:           &fakeHealthPolicyMap{},
-		CgroupPathAllow:          &fakeHealthPolicyMap{},
-		CgroupFileAllow:          &fakeHealthPolicyMap{},
-		CgroupBootstrapFileAllow: &fakeHealthPolicyMap{},
-		BootstrapFileObservation: &fakeHealthPolicyMap{},
-		CgroupControlPlaneAllow:  &fakeHealthPolicyMap{},
-		CgroupTrustedRoot:        &fakeHealthPolicyMap{},
-		CgroupNetAllow:           &fakeHealthPolicyMap{},
-		CgroupManaged:            &fakeHealthPolicyMap{},
-		KillSwitch:               &fakeHealthPolicyMap{},
-	}
-	d.setActiveTier(daemonTierBPFLSM)
+	d.activatePolicyMaps(readyHealthPolicyMaps())
 
 	before := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
 	if before.EnforcementTier != kernelcapture.EnforcementTierBPFLSM {
 		t.Fatalf("precondition: EnforcementTier = %q, want %q", before.EnforcementTier, kernelcapture.EnforcementTierBPFLSM)
 	}
 
-	// The guard consumer dies mid-run: its defer clears policyMaps (mirrors
-	// runGuardConsumer's defer in daemon_guard_linux.go), and the goroutine
-	// that awaited it calls degradeGuardTier -- exactly what main() now does.
-	d.policyMaps = kernelcapture.PolicyMaps{}
+	// The guard consumer dies mid-run and atomically withdraws the tier/maps.
 	d.degradeGuardTier(errors.New("guard died"), d.log)
 
 	after := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
@@ -170,7 +156,7 @@ func TestActiveTier_ConcurrentReadWriteIsRaceFree(t *testing.T) {
 	go func() {
 		defer close(done)
 		for i := 0; i < 200; i++ {
-			d.setActiveTier(daemonTierBPFLSM)
+			d.activatePolicyMaps(readyHealthPolicyMaps())
 			d.degradeGuardTier(errors.New("flap"), d.log)
 		}
 	}()
@@ -180,4 +166,68 @@ func TestActiveTier_ConcurrentReadWriteIsRaceFree(t *testing.T) {
 		_ = d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
 	}
 	<-done
+}
+
+func TestDegradeGuardTierWaitsForPolicyMapUsers(t *testing.T) {
+	d := newTestDaemon(t)
+	d.fs = newStubFS()
+	d.activatePolicyMaps(readyHealthPolicyMaps())
+
+	d.applyMu.Lock()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		d.degradeGuardTier(errors.New("guard died"), d.log)
+		close(done)
+	}()
+	<-started
+
+	completedBeforeMapUser := false
+	select {
+	case <-done:
+		completedBeforeMapUser = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	d.applyMu.Unlock()
+
+	if completedBeforeMapUser {
+		t.Fatal("guard degradation completed while a policy-map user still held applyMu")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("guard degradation did not complete after the policy-map user released applyMu")
+	}
+	if kernelcapture.PolicyMapsReady(d.policyMaps) {
+		t.Fatal("policy maps remained reachable after guard degradation")
+	}
+}
+
+func TestLateGuardCannotReplaceCommittedSeccompTier(t *testing.T) {
+	d := newTestDaemon(t)
+	if !d.activateSeccompTier() {
+		t.Fatal("seccomp fallback did not win an unclaimed startup tier")
+	}
+	if d.activatePolicyMaps(readyHealthPolicyMaps()) {
+		t.Fatal("late BPF guard replaced an already committed seccomp tier")
+	}
+	if got := d.enforcementTier(); got != daemonTierSeccomp {
+		t.Fatalf("enforcement tier = %q, want %q", got, daemonTierSeccomp)
+	}
+	if kernelcapture.PolicyMapsReady(d.policyMaps) {
+		t.Fatal("rejected late guard still published policy maps")
+	}
+}
+
+func TestIncompletePolicyMapsCannotActivateBPFLSM(t *testing.T) {
+	d := newTestDaemon(t)
+	if d.activatePolicyMaps(kernelcapture.PolicyMaps{
+		CgroupOpPolicy: &fakeHealthPolicyMap{},
+	}) {
+		t.Fatal("incomplete policy-map set activated BPF-LSM")
+	}
+	if got := d.enforcementTier(); got != daemonTierNone {
+		t.Fatalf("enforcement tier = %q, want %q", got, daemonTierNone)
+	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
@@ -29,11 +29,9 @@ package main
 // kernel state instead of dropping it — see that function's doc comment.
 //
 // Fail-open on mid-run death (issue #121): if this function returns while the
-// daemon is still running (main()'s ctx not yet cancelled) — whether from a
-// real error or a clean ringbuf close caused by something other than our own
-// shutdown watcher below — the caller in main() calls d.degradeGuardTier so
-// activeTier (and therefore every health response) stops claiming bpf_lsm the
-// moment nothing is actually attached anymore.
+// daemon is still running (main()'s ctx not yet cancelled), its lifecycle
+// defer withdraws activeTier and policyMaps before closing the handles and
+// records the degradation.
 
 import (
 	"context"
@@ -66,7 +64,7 @@ const tamperAuditInterval = 15 * time.Second
 // blocks on it (with a timeout) to make the BPF-LSM-vs-seccomp tier decision
 // (plan E4) without guessing from preflight alone, since preflight can pass
 // while the actual load still fails for reasons preflight doesn't check.
-func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready chan<- error) error {
+func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready chan<- error) (retErr error) {
 	// Preflight: check BTF and BPF-LSM availability.
 	preflightReport := kernelcapture.InspectBPFLSMPreflight()
 	for _, f := range preflightReport.Findings {
@@ -88,8 +86,11 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready ch
 		return err
 	}
 	defer func() {
-		// Clear policy maps reference so subsequent apply_policy calls fail safely.
-		d.policyMaps = kernelcapture.PolicyMaps{}
+		if ctx.Err() == nil {
+			d.degradeGuardTier(retErr, log)
+		} else {
+			d.deactivatePolicyMaps()
+		}
 		handles.Close()
 	}()
 	if err := kernelcapture.ClearBootstrapFileObservations(handles); err != nil {
@@ -98,8 +99,14 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready ch
 		return err
 	}
 
-	// Expose maps to the daemon for apply_policy calls.
-	d.policyMaps = kernelcapture.PolicyMapsFromHandles(handles)
+	// Publish maps and the live tier atomically before reporting readiness. A
+	// startup timeout may already have committed seccomp; a late guard must not
+	// overwrite that decision.
+	if !d.activatePolicyMaps(kernelcapture.PolicyMapsFromHandles(handles)) {
+		err = fmt.Errorf("BPF-LSM guard loaded after another enforcement tier was selected")
+		ready <- err
+		return err
+	}
 
 	log.Info("BPF-LSM process_guard loaded",
 		"hooks", "bprm_check_security, lsm.s/file_open, socket_connect",

--- a/go/cmd/ardur-kernelcaptured/daemon_health_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_health_test.go
@@ -67,7 +67,19 @@ func TestHandleAuthorizedRequest_HealthReportsNoneWithoutGuard(t *testing.T) {
 func TestHandleAuthorizedRequest_HealthReportsBPFLSMWhenGuardLoaded(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
-	d.policyMaps = kernelcapture.PolicyMaps{
+	d.activatePolicyMaps(readyHealthPolicyMaps())
+
+	resp := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
+	if !resp.OK {
+		t.Fatalf("health response = %+v, want OK", resp)
+	}
+	if resp.EnforcementTier != kernelcapture.EnforcementTierBPFLSM {
+		t.Fatalf("EnforcementTier = %q, want %q", resp.EnforcementTier, kernelcapture.EnforcementTierBPFLSM)
+	}
+}
+
+func readyHealthPolicyMaps() kernelcapture.PolicyMaps {
+	return kernelcapture.PolicyMaps{
 		CgroupOpPolicy:           &fakeHealthPolicyMap{},
 		CgroupPathAllow:          &fakeHealthPolicyMap{},
 		CgroupFileAllow:          &fakeHealthPolicyMap{},
@@ -78,14 +90,6 @@ func TestHandleAuthorizedRequest_HealthReportsBPFLSMWhenGuardLoaded(t *testing.T
 		CgroupNetAllow:           &fakeHealthPolicyMap{},
 		CgroupManaged:            &fakeHealthPolicyMap{},
 		KillSwitch:               &fakeHealthPolicyMap{},
-	}
-
-	resp := d.handleAuthorizedRequest(context.Background(), healthReq(), validHealthHandshake())
-	if !resp.OK {
-		t.Fatalf("health response = %+v, want OK", resp)
-	}
-	if resp.EnforcementTier != kernelcapture.EnforcementTierBPFLSM {
-		t.Fatalf("EnforcementTier = %q, want %q", resp.EnforcementTier, kernelcapture.EnforcementTierBPFLSM)
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_kill_switch_receipt_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_kill_switch_receipt_test.go
@@ -57,7 +57,7 @@ func TestHandleSetKillSwitch_WritesAttributedHashChainedReceipt(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, _ := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 
 	// Admin (uid 0) peer; testPeerHandshakeUID pins PID 4321.
 	root := testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 0)
@@ -114,7 +114,7 @@ func TestHandleSetKillSwitch_EvidenceFailureRollsBackWithoutAdvancingChain(t *te
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, observed := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	stub := newStubFS()
 	stub.err = errors.New("evidence volume unavailable")
 	d.fs = stub
@@ -162,7 +162,7 @@ func TestHandleSetKillSwitch_RollbackFailureSurfacesSessionEvidenceGap(t *testin
 	maps, _ := countingPolicyMaps()
 	kill := &rollbackFailKillSwitchMap{}
 	maps.KillSwitch = kill
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	stub := newStubFS()
 	stub.err = errors.New("evidence volume unavailable")
 	d.fs = stub
@@ -191,7 +191,7 @@ func TestHandleSetKillSwitch_SessionStatusBindsTamperHeadAndImpact(t *testing.T)
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, _ := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
 		SessionID: "attested-session", RootPID: 4321, CgroupID: 43,
 	}, "attested-session")
@@ -221,7 +221,7 @@ func TestHandleSetKillSwitch_DeniedNonRootWritesNoReceipt(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, _ := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 
 	nonRoot := testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 501)
 	if resp := d.handleSetKillSwitch(setKillSwitchReq(true), nonRoot); resp.OK {
@@ -252,7 +252,7 @@ func TestHandleSetKillSwitch_ReceiptOrderingUnderConcurrentAuditTicks(t *testing
 	t.Parallel()
 	d := newTestDaemon(t)
 	maps, _ := countingPolicyMaps()
-	d.policyMaps = maps
+	d.activatePolicyMaps(maps)
 	root := testPeerHandshakeUID("", kernelcapture.DaemonProtocolMethodSetKillSwitch, 0)
 
 	const iterations = 40

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -210,11 +210,12 @@ type daemon struct {
 	// goroutine and read from every socket-handling goroutine concurrently.
 	activeTier string
 
-	// applyMu serializes every BPF policy-map mutation — ApplyPolicyMaps,
-	// RemovePolicyMaps, SetKillSwitch. Those run in per-connection goroutines
-	// (and RemovePolicyMaps also on session-end), and ApplyPolicyMaps' double
-	// buffer is a read-active-slot / write-inactive-slot / flip sequence that is
-	// only atomic if writers are serialized. Distinct from mu (routing index).
+	// applyMu serializes every BPF policy-map mutation and owns the lifetime of
+	// policyMaps. Guard startup publishes the complete handle set under this
+	// lock; teardown withdraws the tier and handle set under it before closing
+	// the underlying BPF fds. Every map user holds applyMu for its full operation,
+	// so teardown cannot close a handle that an in-flight request still uses.
+	// Distinct from mu (routing index); when both are needed, applyMu comes first.
 	applyMu sync.Mutex
 
 	// appliedAllow tracks, per session, the path/net allowlist entries most
@@ -578,23 +579,61 @@ func (d *daemon) handleRegisterReceipt(req kernelcapture.DaemonProtocolRequest, 
 // enforcementTier reports which kernel-enforcement backend is currently live —
 // EnforcementTierBPFLSM, daemonTierSeccomp, or EnforcementTierNone.
 //
-// The authoritative source is activeTier, which main()'s startup tier selection
-// sets to bpf_lsm, seccomp, or none (E4 added the seccomp fallback; a plain
-// PolicyMapsReady probe can't tell seccomp from none, since the seccomp tier
-// holds no BPF policy maps). When activeTier hasn't been decided yet — the
-// zero value or the daemonTierNone default, e.g. a unit test that populates
-// policyMaps directly without going through startup — fall back to a live
-// policyMaps probe so a loaded guard still reports bpf_lsm. In real runtime
-// activeTier is set to bpf_lsm exactly when the maps load, so the two never
-// disagree there; the fallback only matters for that bypass path.
+// The authoritative source is activeTier. BPF map publication commits
+// activeTier=bpf_lsm in the same applyMu critical section, so health never
+// needs to infer a tier from a separately changing handle struct.
 func (d *daemon) enforcementTier() string {
-	if tier := d.getActiveTier(); tier != "" && tier != daemonTierNone {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	if tier := d.getActiveTier(); tier == daemonTierBPFLSM || tier == daemonTierSeccomp {
 		return tier
 	}
-	if kernelcapture.PolicyMapsReady(d.policyMaps) {
-		return kernelcapture.EnforcementTierBPFLSM
-	}
 	return kernelcapture.EnforcementTierNone
+}
+
+// activatePolicyMaps publishes one complete guard handle set and its live tier
+// as a single lifecycle transition. The caller retains ownership of the
+// underlying handles and must call deactivatePolicyMaps before closing them.
+func (d *daemon) activatePolicyMaps(maps kernelcapture.PolicyMaps) bool {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	if !kernelcapture.PolicyMapsReady(maps) {
+		return false
+	}
+	if tier := d.getActiveTier(); tier != "" && tier != daemonTierNone {
+		return false
+	}
+	d.policyMaps = maps
+	d.setActiveTier(daemonTierBPFLSM)
+	return true
+}
+
+// activateSeccompTier commits the startup fallback only if a BPF guard did not
+// win the same lifecycle lock first. A guard that loads after this returns
+// false from activatePolicyMaps and closes without publishing its handles.
+func (d *daemon) activateSeccompTier() bool {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	if tier := d.getActiveTier(); tier != "" && tier != daemonTierNone {
+		return false
+	}
+	d.setActiveTier(daemonTierSeccomp)
+	return true
+}
+
+// deactivatePolicyMaps makes the guard unreachable to new map users and waits
+// for every in-flight user to finish. It returns whether BPF-LSM was live so a
+// mid-run caller can decide whether to emit degradation evidence. The owner may
+// close the withdrawn handles only after this method returns.
+func (d *daemon) deactivatePolicyMaps() bool {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	wasActive := d.getActiveTier() == daemonTierBPFLSM
+	if wasActive {
+		d.setActiveTier(daemonTierNone)
+	}
+	d.policyMaps = kernelcapture.PolicyMaps{}
+	return wasActive
 }
 
 // getActiveTier returns the current activeTier under mu. See activeTier's
@@ -624,9 +663,8 @@ func (d *daemon) setActiveTier(tier string) {
 // reason OTHER than this daemon's own ctx-cancellation watcher — e.g. the
 // guard was force-detached externally (bpftool link detach, or the same
 // external-tamper class RunTamperAudit checks for on its own timer). Either
-// way, d.policyMaps was already cleared to its zero value by runGuardConsumer's
-// defer by the time this runs; activeTier must not keep claiming bpf_lsm past
-// that point.
+// way, this transition withdraws activeTier and policyMaps before the guard
+// owner closes the underlying BPF handles.
 //
 // No-op if activeTier was never actually bpf_lsm — covers the startup-load-
 // failure case, where runGuardConsumer returns immediately (before this
@@ -642,11 +680,10 @@ func (d *daemon) setActiveTier(tier string) {
 // (degraded) tier — never silently keeping a stale bpf_lsm claim alive — is
 // the fix; auto-failover is a larger, separate change.
 func (d *daemon) degradeGuardTier(cause error, log *slog.Logger) {
-	previous := d.getActiveTier()
-	if previous != daemonTierBPFLSM {
+	if !d.deactivatePolicyMaps() {
 		return
 	}
-	d.setActiveTier(daemonTierNone)
+	previous := daemonTierBPFLSM
 
 	detail := fmt.Sprintf(
 		"guard consumer exited while the daemon is still running; enforcement tier downgraded from %q to %q",
@@ -2018,18 +2055,14 @@ func main() {
 					log.Warn("BPF-LSM guard unavailable (enforcement degraded to seccomp-advertised)",
 						"error", err)
 				}
-				// Reached whether runGuardConsumer failed mid-run (err != nil)
-				// or its ringbuf closed cleanly for a reason other than our
-				// own shutdown watcher (err == nil — e.g. an external force-
-				// detach); either way the guard is no longer attached. Issue
-				// #121: never leave activeTier claiming bpf_lsm past this point.
-				d.degradeGuardTier(err, log)
+				// runGuardConsumer withdraws the tier and map handles before
+				// returning, so this goroutine only reports the terminal cause.
 			}()
 
 			select {
 			case err := <-guardOutcome:
 				if err == nil {
-					d.setActiveTier(daemonTierBPFLSM)
+					// runGuardConsumer already published maps + tier atomically.
 				} else {
 					log.Warn("BPF-LSM tier not active, falling back to seccomp tier", "error", err)
 				}
@@ -2042,8 +2075,7 @@ func main() {
 			log.Warn("BPF-LSM guard tier disabled via --disable-bpf-lsm; forcing seccomp user-notify tier")
 		}
 
-		if d.getActiveTier() != daemonTierBPFLSM && ctx.Err() == nil {
-			d.setActiveTier(daemonTierSeccomp)
+		if ctx.Err() == nil && d.activateSeccompTier() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/go/pkg/kernelcapture/README.md
+++ b/go/pkg/kernelcapture/README.md
@@ -268,7 +268,9 @@ It rejects repository-controlled privileged paths when repository-root validatio
 ## Concurrency contract
 
 - `Correlator` is goroutine-safe and supports concurrent receipt registration and event correlation.
-- Race-safety is covered by `go test -race ./pkg/kernelcapture`.
+- Race-safety is covered by `go test -race ./...` on Linux, including daemon
+  policy-map publication, tier selection, in-flight use, withdrawal, and close
+  ordering.
 
 ## Current MVP claim boundary
 

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "e42e344db87b16457a1a7d8ff4e7166b402588b07e84cf11ec5ca474061d4835"
+source_sha256: "8c3af753655eb0917726c4346d1c27b3ad52b60e1b203a05f0e32015326a6fcc"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -22,6 +22,8 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
+  health, in-flight mutations, tier withdrawal, and close cannot race
 - Pin Biscuit holder verification to a server-owned issuer key, JWT-SVID trust
   bundle, and audience; require configured binding on every presentation; and
   reject caller-supplied roots plus non-`jwt-svid` bundle keys
@@ -58,6 +60,8 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Prevent torn `PolicyMaps` reads and use-after-close during BPF-LSM guard
+  startup, degradation, and shutdown; reject late guards after seccomp fallback
 - Reject attacker-signed JWT-SVIDs even when their SPIFFE ID matches the
   Biscuit holder claim; `svid_bound=true` now requires pinned-root verification
 - Enforce cumulative direct-hook tool-call budgets from verified receipt chains

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -2,7 +2,7 @@
 title: "Ardur"
 description: "Ardur governs AI-agent tool calls that pass through a configured adapter or"
 source_path: "README.md"
-source_sha256: "7288038d4c91e2aefb13c2a7434c8c10d44a6539251f4d6fdcf8bce18d32d216"
+source_sha256: "67f8980c78305524e926db33f9a7b27340a2b4b349bb208283abe76b7eea385b"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -98,7 +98,7 @@ At the reviewed `dev` tree on 2026-07-11, the current gates were:
 | Python local matrix (Python 3.13) | 1,665 passed, 33 skipped; CI separately enforces its coverage threshold |
 | Python CI | Python 3.10 and 3.13 passed; lint and wheel smoke passed |
 | Go CI | Tests, vet, lint, and vulnerability scan passed |
-| Linux enforcement CI | BPF generation plus Go build/vet/race tests, live BPF-LSM kernel smoke, strict BPF `ardur run --enforce` with a kernel-stopped, exact-artifact bootstrap and denied child exec, seccomp smoke, and full seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
+| Linux enforcement CI | BPF generation plus Go build/vet/race tests, policy-map startup/teardown lifetime races, live BPF-LSM kernel smoke, strict BPF `ardur run --enforce` with a kernel-stopped, exact-artifact bootstrap and denied child exec, seccomp smoke, and full seccomp E2E with an authenticated governance call followed by a denied unrelated loopback connect passed |
 | Security and release hygiene | CodeQL for Python and Go, secret scanning, formats, links, Hugo, package build, and OCI smoke passed |
 
 These gates verify the checked-in runtime and its configured integration

--- a/site/content/source/STATUS.md
+++ b/site/content/source/STATUS.md
@@ -2,7 +2,7 @@
 title: "Status"
 description: "Today, an installed Ardur Claude Code hook records the tool-call events Claude"
 source_path: "STATUS.md"
-source_sha256: "123f185c432b1a3ebd401b476ed3a8056d8b4b4222f5f48f5915b9e1c3d92763"
+source_sha256: "ef74ee0d6b15b22eb010660cad3aaef3af6cba44d890f798a8ed873084b6b7ba"
 weight: 100
 maturity: ["in-progress", "public-now"]
 claim_types: ["status"]
@@ -52,6 +52,14 @@ basename but not its parent path and does not collect argv, hashes, uid,
 environment, or file content. It does not attest or enforce. Issue #67 remains
 in progress for stronger fingerprints and corpus-backed precision/recall
 thresholds.
+
+The Linux kernel-capture daemon now publishes its BPF policy-map handle set and
+`bpf_lsm` tier as one synchronized lifecycle transition. Every map operation,
+health-tier read, withdrawal, and close boundary uses the same mutex; teardown
+withdraws the tier and map reachability only after in-flight users drain, then
+closes the handles. A readiness timeout commits seccomp under the same lock, so
+a late BPF load cannot replace the selected fallback. Mid-run guard loss still
+degrades honestly to `none`; automatic BPF-to-seccomp failover is not claimed.
 
 The Python Biscuit session path now accepts JWT-SVID holder binding only from
 server-owned Biscuit issuer-key, trust-bundle, and audience configuration. A

--- a/site/content/source/docs/known-limitations.md
+++ b/site/content/source/docs/known-limitations.md
@@ -2,7 +2,7 @@
 title: "Known Limitations"
 description: "This page distinguishes documented product boundaries from implementation bugs."
 source_path: "docs/known-limitations.md"
-source_sha256: "1995b42fa18efb7a0de1c15978f95f8994237b9cd90301242cdcc91002309d7f"
+source_sha256: "bc9b7a8ad7aa764a8f409d6529a564085a3131358afa36b2439cabb3ba7bcb23"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["limitation"]
@@ -222,6 +222,22 @@ of a live channel or one-time possession. JWT-SVID is a bearer credential and
 can be replayed during its validity window if both the Biscuit and SVID are
 stolen. Deployments needing channel-bound workload identity should prefer the
 X.509-SVID mTLS pattern in ADR-022.
+
+## BPF policy-map teardown is serialized, but mid-run failover is not automatic
+
+The Linux daemon publishes the complete BPF policy-map handle set and the
+`bpf_lsm` tier under one lifecycle mutex. Health reads and every map operation
+participate in that same boundary. On guard exit, the daemon waits for in-flight
+map users, withdraws the tier and all shared map references, and only then
+closes the underlying BPF handles. Startup fallback selection is serialized as
+well, so a BPF load completing after the readiness timeout cannot replace an
+already selected seccomp tier.
+
+If a live BPF-LSM guard exits mid-run, the daemon records degradation and
+reports enforcement tier `none`. It does not automatically start or migrate
+the workload to seccomp user-notify after that failure; seccomp supervision is
+currently selected only during startup. Operators must treat the degradation
+event as an availability incident rather than assuming transparent failover.
 
 ## Operator + webhook /metrics endpoints (deployment hardening required)
 

--- a/site/content/source/go/pkg/kernelcapture/README.md
+++ b/site/content/source/go/pkg/kernelcapture/README.md
@@ -2,7 +2,7 @@
 title: "kernelcapture proof harness"
 description: "This package is the Ardur Linux proof harness for process-exec capture with paired process-exit lifecycle metadata and kernel-effect synthetic receipts."
 source_path: "go/pkg/kernelcapture/README.md"
-source_sha256: "f83814739062741077d660559fda5f9f790effea17e8dc2bbcabd941616379d7"
+source_sha256: "122f3d1e4b502f42bb056ac16e954d1ca22a5b17836b5a280a0eb5ed57f0bd5b"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -285,7 +285,9 @@ It rejects repository-controlled privileged paths when repository-root validatio
 ## Concurrency contract
 
 - `Correlator` is goroutine-safe and supports concurrent receipt registration and event correlation.
-- Race-safety is covered by `go test -race ./pkg/kernelcapture`.
+- Race-safety is covered by `go test -race ./...` on Linux, including daemon
+  policy-map publication, tier selection, in-flight use, withdrawal, and close
+  ordering.
 
 ## Current MVP claim boundary
 


### PR DESCRIPTION
## Summary

- use the daemon's existing `applyMu` as the complete BPF policy-map handle lifetime boundary
- atomically publish a complete map set with `bpf_lsm`, drain users before withdrawing maps, and close handles only after shared reachability is removed
- serialize seccomp fallback selection against BPF activation so a late guard cannot replace a committed tier
- remove health's raw-handle inference and report only the lifecycle tier
- update public status/limitations and generated source mirrors without claiming automatic mid-run failover

## Race evidence

The deterministic regression failed on clean `dev` because degradation completed while a simulated map user still held `applyMu`. After the fix it proves:

- degradation waits for the in-flight map user
- shared map reachability is removed before teardown completes
- incomplete `PolicyMaps` cannot activate BPF-LSM
- a late BPF guard cannot replace committed seccomp
- concurrent activate/degrade/health loops are race-clean

## Validation

- final rebased full repository gate: 1,770 Python passed, 33 skipped; all Go tests and `go vet` passed
- macOS daemon package: `go test -race ./cmd/ardur-kernelcaptured`
- Linux arm64 / Go 1.26.5 Docker: `go test -race ./...` passed, including Linux-only daemon files
- source docs: 112 pages and mirrored artifacts synchronized
- JSON/YAML, schema, repository hygiene, and public-content checks passed
- Semgrep was not used

## Residual limitation

Mid-run BPF-LSM guard loss records degradation and reports tier `none`; this change does not dynamically start or migrate to seccomp after startup.

Closes #256
