### PR TITLE
fix(kernel): fail closed on unverifiable peer PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to Ardur will be documented in this file.
 ### Security
 - Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
   health, in-flight mutations, tier withdrawal, and close cannot race
+- Make the Linux cgroup-ownership verifier independently fail closed when a
+  non-root handshake has no resolvable peer PID, preserving the upstream
+  `SO_PEERCRED` identity gate as defense in depth
 - Pin Biscuit holder verification to a server-owned issuer key, JWT-SVID trust
   bundle, and audience; require configured binding on every presentation; and
   reject caller-supplied roots plus non-`jwt-svid` bundle keys

--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -125,6 +125,15 @@ wait for already-matched evidence work, then remove the cgroup. Multiple active
 sessions retain independent entries. The BPF allowlist capacity is 4,096,
 matching the daemon session registry's active-session limit.
 
+For non-root socket peers, registration also fails closed unless the daemon can
+resolve the kernel-supplied `SO_PEERCRED` PID in its `/proc` view, verify that
+`root_pid` descends from that peer, and confirm that `root_pid` occupies the
+claimed cgroup. Run the enforcement daemon in a PID namespace that can observe
+its clients (normally the host/ancestor namespace, with a matching procfs
+mount). A topology that cannot map the peer PID is rejected rather than granted
+unverified cgroup-enforcement rights; there is no implicit cross-namespace
+bypass.
+
 If startup reconciliation itself fails, the daemon leaves filtering disabled
 and continues the prior permissive capture behavior rather than enabling a
 partial allowlist that could hide governed events. It logs the degradation; the

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
@@ -71,9 +71,9 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	peerPID := handshake.Authorization.PID
 	rootPID := reg.RootPID
 	// register_session validation already requires root_pid != 0 and
-	// cgroup_id != 0; peerPID comes from SO_PEERCRED. If either is missing
-	// there is nothing to bind — let the registry's own validation speak.
-	if peerPID == 0 || rootPID == 0 {
+	// cgroup_id != 0. If rootPID is missing there is no claim to inspect; let
+	// the registry's own validation reject the malformed request.
+	if rootPID == 0 {
 		return nil
 	}
 	// A root (uid 0) peer is already fully privileged on the host — it can move
@@ -88,17 +88,22 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if handshake.Authorization.UID == 0 {
 		return nil
 	}
-	// Confirm the peer itself is visible in the daemon's /proc view. If it is
-	// not (an unusual cross-PID-namespace deployment where the daemon cannot
-	// see client PIDs at all), we cannot establish ancestry either way — skip
-	// rather than reject and break such a deployment, but say so loudly. Since
-	// resolving root_pid's cgroup below relies on the same /proc visibility, a
-	// daemon that can't see the peer generally can't see root_pid either, so
-	// both checks are skipped together here.
+	// peerPID comes from SO_PEERCRED and is translated into the receiver's PID
+	// namespace. A zero/unavailable value cannot bind this socket peer to the
+	// claimed process tree, so UID authorization alone is insufficient.
+	if peerPID == 0 {
+		log.Warn("register_session rejected: peer pid unavailable for cgroup ownership verification",
+			"root_pid", rootPID, "cgroup_id", reg.CgroupID)
+		return fmt.Errorf("peer pid is unavailable in the daemon pid namespace; cannot verify ownership of root_pid %d and cgroup_id %d", rootPID, reg.CgroupID)
+	}
+	// Confirm the peer itself is visible in the daemon's /proc view. /proc is
+	// tied to the PID namespace that mounted it; if lookup fails, ancestry and
+	// ownership cannot be established. Failing open here would restore the
+	// cross-workload enforcement path closed by issue #119.
 	if _, err := os.Stat("/proc/" + strconv.FormatUint(uint64(peerPID), 10)); err != nil {
-		log.Warn("register_session cgroup ownership check skipped: peer pid not visible in /proc (cross-namespace daemon?)",
-			"peer_pid", peerPID, "root_pid", rootPID)
-		return nil
+		log.Warn("register_session rejected: peer pid not visible for cgroup ownership verification",
+			"peer_pid", peerPID, "root_pid", rootPID, "cgroup_id", reg.CgroupID, "error", err)
+		return fmt.Errorf("peer pid %d is not visible in the daemon /proc view (%w); cannot verify ownership of root_pid %d and cgroup_id %d", peerPID, err, rootPID, reg.CgroupID)
 	}
 
 	// Check 1: ancestry. The peer registering its own process is trivially a

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
@@ -3,12 +3,14 @@
 package main
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
@@ -141,12 +143,57 @@ func TestVerifyRegisterSessionCgroup_BogusRootRejected(t *testing.T) {
 	}
 }
 
-func TestVerifyRegisterSessionCgroup_PeerNotVisibleSkips(t *testing.T) {
-	// If the peer itself is not visible in /proc (cross-PID-namespace daemon),
-	// neither ancestry nor cgroup ownership can be established — skip rather
-	// than break such a deployment.
-	if err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger()); err != nil {
-		t.Fatalf("unresolvable peer should skip the check, got: %v", err)
+func TestVerifyRegisterSessionCgroup_PeerNotVisibleRejected(t *testing.T) {
+	// If the peer itself is not visible in /proc, neither ancestry nor cgroup
+	// ownership can be established. Accepting the registration would restore
+	// the cross-workload enforcement path closed by issue #119, so fail closed.
+	err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger())
+	if err == nil {
+		t.Fatal("unresolvable non-root peer should be rejected, not granted enforce rights")
+	}
+	if !strings.Contains(err.Error(), "not visible in the daemon /proc view") {
+		t.Fatalf("unresolvable peer error = %q, want explicit daemon /proc visibility failure", err)
+	}
+}
+
+func TestVerifyRegisterSessionCgroup_PeerPIDUnavailableRejected(t *testing.T) {
+	// Cross-namespace peer-credential translation can yield no usable PID in
+	// the receiver's namespace. UID authorization alone cannot bind that peer
+	// to root_pid or cgroup_id, so an unavailable PID must also fail closed.
+	err := verifyRegisterSessionCgroup(hsWithPID(0), regReq(1, 12345), quietLogger())
+	if err == nil {
+		t.Fatal("non-root peer without a usable peer pid should be rejected")
+	}
+	if !strings.Contains(err.Error(), "peer pid is unavailable") {
+		t.Fatalf("missing peer pid error = %q, want explicit unavailable-pid failure", err)
+	}
+}
+
+func TestHandleAuthorizedRequest_PeerNotVisibleDoesNotRegisterSession(t *testing.T) {
+	d := newTestDaemon(t)
+	d.cgroupVerifier = verifyRegisterSessionCgroup
+	const sessionID = "proc-invisible-peer"
+	req := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    sessionID,
+			RootPID:      1,
+			CgroupID:     12345,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   60,
+		},
+	}
+
+	resp := d.handleAuthorizedRequest(context.Background(), req, hsWithPID(1<<30))
+	if resp.OK {
+		t.Fatalf("register_session for an unresolvable non-root peer succeeded: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "peer pid") || !strings.Contains(resp.Error, "not visible") {
+		t.Fatalf("register_session error = %q, want explicit peer-pid visibility failure", resp.Error)
+	}
+	if _, registered := d.registry.Session(sessionID); registered {
+		t.Fatal("rejected unresolvable peer was persisted in the session registry")
 	}
 }
 

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "8c3af753655eb0917726c4346d1c27b3ad52b60e1b203a05f0e32015326a6fcc"
+source_sha256: "17e8b18547dd9b50dbec283c6e562606d1cdb17d7cc591247ba720845e2db9d3"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -24,6 +24,9 @@ All notable changes to Ardur will be documented in this file.
 ### Security
 - Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
   health, in-flight mutations, tier withdrawal, and close cannot race
+- Make the Linux cgroup-ownership verifier independently fail closed when a
+  non-root handshake has no resolvable peer PID, preserving the upstream
+  `SO_PEERCRED` identity gate as defense in depth
 - Pin Biscuit holder verification to a server-owned issuer key, JWT-SVID trust
   bundle, and audience; require configured binding on every presentation; and
   reject caller-supplied roots plus non-`jwt-svid` bundle keys

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "059f077769377f17ca3c6355d1bd8720cfc1c25c56d50c2eb94ac7fc5c511029"
+source_sha256: "f042c10a9495d5f353843d0f40540a919e7496b020e14547c0d0bef8b3fdc9e6"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -141,6 +141,15 @@ the new session. Session end and TTL expiry first retire the userspace route and
 wait for already-matched evidence work, then remove the cgroup. Multiple active
 sessions retain independent entries. The BPF allowlist capacity is 4,096,
 matching the daemon session registry's active-session limit.
+
+For non-root socket peers, registration also fails closed unless the daemon can
+resolve the kernel-supplied `SO_PEERCRED` PID in its `/proc` view, verify that
+`root_pid` descends from that peer, and confirm that `root_pid` occupies the
+claimed cgroup. Run the enforcement daemon in a PID namespace that can observe
+its clients (normally the host/ancestor namespace, with a matching procfs
+mount). A topology that cannot map the peer PID is rejected rather than granted
+unverified cgroup-enforcement rights; there is no implicit cross-namespace
+bypass.
 
 If startup reconciliation itself fails, the daemon leaves filtering disabled
 and continues the prior permissive capture behavior rather than enabling a


### PR DESCRIPTION
## Summary

Make the Linux cgroup-ownership verifier independently reject non-root handshakes whose peer PID is missing or cannot be resolved in the daemon procfs view. Add focused verifier and handler regressions, document the supported PID-namespace topology, and update the Unreleased security changelog.

Closes #259.

## Reachability correction

The original issue impact was too strong. The current production socket ingress already fails closed before handler dispatch:

- `ObserveLinuxUnixPeerCredentials` rejects a zero `SO_PEERCRED` PID and unreadable `/proc/<pid>/stat`.
- `AuthorizeObservedDaemonPeer` independently requires nonzero PID and process-start identity.
- No alternate production caller bypasses those gates today.

This PR therefore hardens the downstream verifier as defense in depth; it does not claim that #119 is presently reachable through the production accept loop.

## Research basis

- [Linux unix(7)](https://man7.org/linux/man-pages/man7/unix.7.html): `SO_PEERCRED` returns connected-peer credentials.
- [Linux pid_namespaces(7)](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html): UNIX-socket PIDs are translated into the receiver PID namespace; processes are visible from their own and ancestor namespaces; procfs visibility follows the namespace that mounted it.
- [Linux cgroup v2 documentation](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html): `/proc/<pid>/cgroup` is rendered in the reader cgroup-namespace view.

A daemon that cannot map the socket peer PID cannot bind that identity to the claimed process tree/cgroup. The safe verifier behavior is rejection, not unverified enforce rights.

## Verification

- Red first: both new verifier regressions failed against the legacy skip behavior.
- Focused Linux ownership + handler tests: passed under `-race`.
- Full Linux Go: `go test -race -count=1 ./...`, `go vet ./...`, and `go build ./...` passed.
- Fresh Python 3.13: 1,769 passed, 34 environment-expected skips, six existing warnings.
- Privileged seccomp smoke: denied connect returned EPERM; allowed control reached the kernel.
- Full `ardur run` seccomp demo: enforce and permissive modes passed; receipt chain and attestation digest verified offline.
- Local KVM BPF-LSM smoke: unavailable because the local Docker VM has no `/dev/kvm`; the native `kernel-enforce` CI job is required before merge.
- Hugo 0.161.1: 282 pages, 115 static files; source mirrors, claims, and rendered links passed.
- Lychee: 494 links, zero errors.
- Gitleaks: 505 commits / 13.51 MB, zero leaks.
- `govulncheck`: zero called/imported-package vulnerabilities; one required-module advisory is unreachable.
- Two adversarial review rounds completed. Round one produced the reachability correction above; round two was clean.
- Semgrep was not used.

## Compatibility and scope

- No wire-format or policy behavior change for valid peers.
- Root privileged bypass remains unchanged.
- Existing owned-cgroup and #119 regression paths remain green.
- README was checked; the operator reference and changelog are the correct documentation surfaces.
- `main` and release-promotion PR #17 are untouched.

Checkpoint: `architect/sessions/ardur-phase0-20260709/journal.md`

Notion: https://app.notion.com/p/39b2637edb0781779054ce15ab595b2b