### PR TITLE
fix: bind seccomp handoff to delegated session root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Bind each seccomp listener handoff to the registered root process's
+  daemon-observed PID/start-time identity instead of accepting any peer on the
+  daemon-wide UID/GID allowlist
 - Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
   health, in-flight mutations, tier withdrawal, and close cannot race
 - Make the Linux cgroup-ownership verifier independently fail closed when a

--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -134,6 +134,28 @@ mount). A topology that cannot map the peer PID is rejected rather than granted
 unverified cgroup-enforcement rights; there is no implicit cross-namespace
 bypass.
 
+For non-root registration, the daemon also reads `root_pid`'s process start time
+from `/proc/<root_pid>/stat` before and after those ownership checks and retains
+the stable value; the already-privileged root path records one such observation.
+This is distinct from the control-socket owner: the launcher registers the
+session, then its PID-preserving child execs into `ardur-exec-shim`. The seccomp
+handoff therefore requires the independently authorized handoff peer's
+`SO_PEERCRED` PID and separately observed `/proc` start time to match that
+registered root identity before the daemon acknowledges or supervises the
+transferred listener. PID plus clock-tick start time hardens numeric PID reuse
+but is not a pidfd task handle. `SCM_RIGHTS` transfers the listener reference;
+it does not by itself establish Ardur session ownership. Immediately after
+reserving the listener, the daemon revalidates both that root identity and an
+immutable daemon-local registration generation, so an ended session cannot be
+silently replaced under the same `session_id` while a handoff is in flight. A
+shared lifecycle barrier also keeps register, end, and expiry transitions from
+interleaving with handoff acknowledgement or notification decisions. Listener
+entries and cleanup carry that generation, so a late supervisor exit from an
+older registration cannot remove a replacement listener. Each accepted
+registration also clears the reusable session ID's prior seccomp policy, and
+policy publication holds the same lifecycle read barrier, preventing an
+in-flight apply from crossing into a replacement generation.
+
 If startup reconciliation itself fails, the daemon leaves filtering disabled
 and continues the prior permissive capture behavior rather than enabling a
 partial allowlist that could hide governed events. It logs the degradation; the

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux.go
@@ -65,28 +65,34 @@ import (
 // racing process table can never spin the handler. A launcher-spawned agent is
 // a direct child (1 hop); the generous bound tolerates intervening wrapper
 // processes without ever being unbounded.
-const maxCgroupAncestryHops = 64
+const (
+	maxCgroupAncestryHops                       = 64
+	registerSessionRootProcessStartTimeRequired = true
+)
 
-func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHandshake, reg *kernelcapture.DaemonRegisterSessionRequest, log *slog.Logger) error {
+func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHandshake, reg *kernelcapture.DaemonRegisterSessionRequest, log *slog.Logger) (uint64, error) {
 	peerPID := handshake.Authorization.PID
 	rootPID := reg.RootPID
 	// register_session validation already requires root_pid != 0 and
 	// cgroup_id != 0. If rootPID is missing there is no claim to inspect; let
 	// the registry's own validation reject the malformed request.
 	if rootPID == 0 {
-		return nil
+		return 0, nil
+	}
+	rootStartBefore, err := kernelcapture.ObserveLinuxProcessStartTimeTicks(rootPID)
+	if err != nil {
+		return 0, fmt.Errorf("root_pid %d process identity could not be observed before ownership verification: %w", rootPID, err)
 	}
 	// A root (uid 0) peer is already fully privileged on the host — it can move
 	// any process between cgroups directly, so neither check below adds anything
 	// against it. Both checks exist to constrain a NON-root allowed peer (the
 	// sandboxed-workload threat) from binding a session to a cgroup/process tree
-	// it does not own. Skipping root also lets tiers that register a placeholder
-	// root_pid (the seccomp tier enforces per-shim'd-process, not by cgroup, and
-	// its smoke registers root_pid=1, whose real cgroup is the hierarchy root —
-	// never a session's claimed leaf cgroup) work when the daemon and client are
-	// root. Per-session ownership on apply_policy still applies to every peer.
+	// it does not own. Root still has to name a live root_pid above: its
+	// daemon-observed start identity is what later authenticates a delegated
+	// seccomp listener handoff. Per-session ownership on apply_policy still
+	// applies to every peer.
 	if handshake.Authorization.UID == 0 {
-		return nil
+		return rootStartBefore, nil
 	}
 	// peerPID comes from SO_PEERCRED and is translated into the receiver's PID
 	// namespace. A zero/unavailable value cannot bind this socket peer to the
@@ -94,7 +100,7 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if peerPID == 0 {
 		log.Warn("register_session rejected: peer pid unavailable for cgroup ownership verification",
 			"root_pid", rootPID, "cgroup_id", reg.CgroupID)
-		return fmt.Errorf("peer pid is unavailable in the daemon pid namespace; cannot verify ownership of root_pid %d and cgroup_id %d", rootPID, reg.CgroupID)
+		return 0, fmt.Errorf("peer pid is unavailable in the daemon pid namespace; cannot verify ownership of root_pid %d and cgroup_id %d", rootPID, reg.CgroupID)
 	}
 	// Confirm the peer itself is visible in the daemon's /proc view. /proc is
 	// tied to the PID namespace that mounted it; if lookup fails, ancestry and
@@ -103,14 +109,14 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if _, err := os.Stat("/proc/" + strconv.FormatUint(uint64(peerPID), 10)); err != nil {
 		log.Warn("register_session rejected: peer pid not visible for cgroup ownership verification",
 			"peer_pid", peerPID, "root_pid", rootPID, "cgroup_id", reg.CgroupID, "error", err)
-		return fmt.Errorf("peer pid %d is not visible in the daemon /proc view (%w); cannot verify ownership of root_pid %d and cgroup_id %d", peerPID, err, rootPID, reg.CgroupID)
+		return 0, fmt.Errorf("peer pid %d is not visible in the daemon /proc view (%w); cannot verify ownership of root_pid %d and cgroup_id %d", peerPID, err, rootPID, reg.CgroupID)
 	}
 
 	// Check 1: ancestry. The peer registering its own process is trivially a
 	// (zero-hop) descendant; anything else must be found by walking parents.
 	if rootPID != peerPID {
 		if err := verifyCgroupAncestry(rootPID, peerPID); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
@@ -122,14 +128,21 @@ func verifyRegisterSessionCgroup(handshake kernelcapture.DaemonProtocolPeerHands
 	if reg.CgroupID != 0 {
 		resolved, err := resolveCgroupID(rootPID)
 		if err != nil {
-			return fmt.Errorf("root_pid %d cgroup could not be resolved (%v); a peer may only register a cgroup_id its root_pid actually occupies", rootPID, err)
+			return 0, fmt.Errorf("root_pid %d cgroup could not be resolved (%v); a peer may only register a cgroup_id its root_pid actually occupies", rootPID, err)
 		}
 		if resolved != reg.CgroupID {
-			return fmt.Errorf("root_pid %d is in cgroup %d, not the claimed cgroup_id %d; a peer may only register a cgroup_id its root_pid actually occupies", rootPID, resolved, reg.CgroupID)
+			return 0, fmt.Errorf("root_pid %d is in cgroup %d, not the claimed cgroup_id %d; a peer may only register a cgroup_id its root_pid actually occupies", rootPID, resolved, reg.CgroupID)
 		}
 	}
 
-	return nil
+	rootStartAfter, err := kernelcapture.ObserveLinuxProcessStartTimeTicks(rootPID)
+	if err != nil {
+		return 0, fmt.Errorf("root_pid %d process identity could not be observed after ownership verification: %w", rootPID, err)
+	}
+	if rootStartAfter != rootStartBefore {
+		return 0, fmt.Errorf("root_pid %d process identity changed during ownership verification: before=%d after=%d", rootPID, rootStartBefore, rootStartAfter)
+	}
+	return rootStartAfter, nil
 }
 
 // verifyCgroupAncestry walks rootPID's parent chain looking for peerPID.

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_linux_test.go
@@ -39,6 +39,11 @@ func regReq(rootPID uint32, cgroupID uint64) *kernelcapture.DaemonRegisterSessio
 	return &kernelcapture.DaemonRegisterSessionRequest{SessionID: "s", RootPID: rootPID, CgroupID: cgroupID}
 }
 
+func verifyRegisterSessionCgroupErr(handshake kernelcapture.DaemonProtocolPeerHandshake, reg *kernelcapture.DaemonRegisterSessionRequest) error {
+	_, err := verifyRegisterSessionCgroup(handshake, reg, quietLogger())
+	return err
+}
+
 // spawnTestChild starts a real, short-lived child of the current test process
 // (guaranteeing genuine PID ancestry, the same relationship a launcher has to
 // the agent it Popen()s) and returns its PID. Killed and reaped on cleanup.
@@ -107,7 +112,7 @@ func TestResolveCgroupID_UnknownPidErrors(t *testing.T) {
 // (12345) because nothing checked it; it now must supply the real value.
 func TestVerifyRegisterSessionCgroup_SelfIsOwned(t *testing.T) {
 	self := uint32(os.Getpid())
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, selfCgroupID(t)), quietLogger()); err != nil {
+	if err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(self, selfCgroupID(t))); err != nil {
 		t.Fatalf("self-registration with the real cgroup_id should be owned, got: %v", err)
 	}
 }
@@ -119,7 +124,7 @@ func TestVerifyRegisterSessionCgroup_SelfIsOwned(t *testing.T) {
 func TestVerifyRegisterSessionCgroup_SelfWithWrongCgroupRejected(t *testing.T) {
 	self := uint32(os.Getpid())
 	wrong := selfCgroupID(t) + 1 // guaranteed != the real value by construction
-	err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(self, wrong), quietLogger())
+	err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(self, wrong))
 	if err == nil {
 		t.Fatal("self-registration claiming a cgroup_id that is not the pid's real cgroup should be rejected")
 	}
@@ -130,7 +135,7 @@ func TestVerifyRegisterSessionCgroup_NonDescendantRejected(t *testing.T) {
 	// pid 1 (init) exists but is not a descendant of the test process — a peer
 	// naming a process it did not spawn must be rejected, before cgroup
 	// ownership is even considered.
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(1, 12345), quietLogger()); err == nil {
+	if err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(1, 12345)); err == nil {
 		t.Fatal("registering pid 1 (not a descendant of the peer) should be rejected")
 	}
 }
@@ -138,7 +143,7 @@ func TestVerifyRegisterSessionCgroup_NonDescendantRejected(t *testing.T) {
 func TestVerifyRegisterSessionCgroup_BogusRootRejected(t *testing.T) {
 	self := uint32(os.Getpid())
 	// A pid that is not a live process cannot be verified — reject.
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(1<<30, 12345), quietLogger()); err == nil {
+	if err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(1<<30, 12345)); err == nil {
 		t.Fatal("registering a non-existent root_pid should be rejected")
 	}
 }
@@ -147,7 +152,7 @@ func TestVerifyRegisterSessionCgroup_PeerNotVisibleRejected(t *testing.T) {
 	// If the peer itself is not visible in /proc, neither ancestry nor cgroup
 	// ownership can be established. Accepting the registration would restore
 	// the cross-workload enforcement path closed by issue #119, so fail closed.
-	err := verifyRegisterSessionCgroup(hsWithPID(1<<30), regReq(1, 12345), quietLogger())
+	err := verifyRegisterSessionCgroupErr(hsWithPID(1<<30), regReq(1, 12345))
 	if err == nil {
 		t.Fatal("unresolvable non-root peer should be rejected, not granted enforce rights")
 	}
@@ -160,7 +165,7 @@ func TestVerifyRegisterSessionCgroup_PeerPIDUnavailableRejected(t *testing.T) {
 	// Cross-namespace peer-credential translation can yield no usable PID in
 	// the receiver's namespace. UID authorization alone cannot bind that peer
 	// to root_pid or cgroup_id, so an unavailable PID must also fail closed.
-	err := verifyRegisterSessionCgroup(hsWithPID(0), regReq(1, 12345), quietLogger())
+	err := verifyRegisterSessionCgroupErr(hsWithPID(0), regReq(1, 12345))
 	if err == nil {
 		t.Fatal("non-root peer without a usable peer pid should be rejected")
 	}
@@ -200,7 +205,7 @@ func TestHandleAuthorizedRequest_PeerNotVisibleDoesNotRegisterSession(t *testing
 func TestVerifyRegisterSessionCgroup_RootPeerSkips(t *testing.T) {
 	// A root peer is already fully privileged; both checks are skipped for it
 	// (a non-root peer with the same args is rejected — see above).
-	if err := verifyRegisterSessionCgroup(hsRootWithPID(uint32(os.Getpid())), regReq(1, 12345), quietLogger()); err != nil {
+	if err := verifyRegisterSessionCgroupErr(hsRootWithPID(uint32(os.Getpid())), regReq(1, 12345)); err != nil {
 		t.Fatalf("root peer should skip both checks, got: %v", err)
 	}
 }
@@ -230,7 +235,7 @@ func TestVerifyRegisterSessionCgroup_Issue119PocRejected(t *testing.T) {
 
 	// This is the exact call shape from the #119 report: ancestry passes
 	// (child really was spawned by self), cgroup_id does not match reality.
-	err = verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, victimCgroupID), quietLogger())
+	err = verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(child, victimCgroupID))
 	if err == nil {
 		t.Fatal("#119 PoC: register_session{root_pid: own child, cgroup_id: victim} " +
 			"was accepted (OK=true) — the cgroup-ownership gap is NOT closed")
@@ -253,7 +258,7 @@ func TestVerifyRegisterSessionCgroup_Issue119PocAcceptedWithCorrectCgroup(t *tes
 		t.Fatalf("resolveCgroupID(child): %v", err)
 	}
 
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, realCgroup), quietLogger()); err != nil {
+	if err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(child, realCgroup)); err != nil {
 		t.Fatalf("registering a spawned child with its REAL cgroup_id should be accepted, got: %v", err)
 	}
 }
@@ -308,7 +313,7 @@ func TestVerifyRegisterSessionCgroup_LegitAdoptFlowAccepted(t *testing.T) {
 	}
 
 	self := uint32(os.Getpid())
-	if err := verifyRegisterSessionCgroup(hsWithPID(self), regReq(child, resolvedCgroupID), quietLogger()); err != nil {
+	if err := verifyRegisterSessionCgroupErr(hsWithPID(self), regReq(child, resolvedCgroupID)); err != nil {
 		t.Fatalf("legit adopt-then-register flow should be accepted, got: %v", err)
 	}
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_unsupported.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_cgroup_verify_unsupported.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
 
-func verifyRegisterSessionCgroup(_ kernelcapture.DaemonProtocolPeerHandshake, _ *kernelcapture.DaemonRegisterSessionRequest, _ *slog.Logger) error {
-	return nil
+const registerSessionRootProcessStartTimeRequired = false
+
+func verifyRegisterSessionCgroup(_ kernelcapture.DaemonProtocolPeerHandshake, _ *kernelcapture.DaemonRegisterSessionRequest, _ *slog.Logger) (uint64, error) {
+	return 0, nil
 }

--- a/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_enforce_test.go
@@ -465,7 +465,7 @@ func TestHandleAuthorizedRequest_SessionStatusReportsSeccompListenerAttached(t *
 		t.Error("SeccompListenerAttached = true before any listener registered, want false")
 	}
 
-	if !d.registerSeccompListener("seccomp-status-session", func() {}) {
+	if !d.registerSeccompListener("seccomp-status-session", 1, func() {}) {
 		t.Fatal("registerSeccompListener: expected first registration to succeed")
 	}
 
@@ -477,7 +477,7 @@ func TestHandleAuthorizedRequest_SessionStatusReportsSeccompListenerAttached(t *
 		t.Error("SeccompListenerAttached = false while a listener is registered, want true")
 	}
 
-	d.unregisterSeccompListener("seccomp-status-session")
+	d.unregisterSeccompListener("seccomp-status-session", 1)
 
 	after := d.handleAuthorizedRequest(context.Background(), statusReq, handshake)
 	if !after.OK {
@@ -494,7 +494,7 @@ func TestHandleAuthorizedRequest_SessionStatusReportsSeccompListenerAttached(t *
 // some session somewhere does have a listener attached.
 func TestHandleAuthorizedRequest_HealthNeverReportsSeccompListenerAttached(t *testing.T) {
 	d := newTestDaemon(t)
-	if !d.registerSeccompListener("some-other-session", func() {}) {
+	if !d.registerSeccompListener("some-other-session", 1, func() {}) {
 		t.Fatal("registerSeccompListener: expected first registration to succeed")
 	}
 

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
@@ -47,9 +47,20 @@ type seccompHandoffResponse struct {
 	Error string `json:"error,omitempty"`
 }
 
+type receivedSeccompListenerHandoff struct {
+	sessionID     string
+	fd            int
+	observation   kernelcapture.DaemonSocketPeerObservation
+	authorization kernelcapture.DaemonPeerAuthorization
+}
+
 const (
 	seccompHandoffMaxHeaderBytes = 4096
 	seccompHandoffReadTimeout    = 10 * time.Second
+	// Linux caps one SCM_RIGHTS message at 253 descriptors. Receive enough
+	// control space to inspect and close every descriptor before enforcing the
+	// stricter Ardur contract of exactly one.
+	seccompHandoffMaxReceivedFDs = 253
 )
 
 // runSeccompHandoffServer accepts ardur-exec-shim connections on socketPath,
@@ -100,24 +111,31 @@ func runSeccompHandoffServer(ctx context.Context, socketPath string, d *daemon, 
 
 func (d *daemon) handleSeccompHandoffConnection(ctx context.Context, conn *net.UnixConn, socketPath string, log *slog.Logger) {
 	defer conn.Close()
+	// Freeze register/end/expiry transitions from credential observation
+	// through acknowledgment. The bounded read deadline below limits how long
+	// even an authorized peer can retain this shared lifecycle lease.
+	d.seccompSessionMu.RLock()
+	defer d.seccompSessionMu.RUnlock()
 
-	sessionID, fd, err := receiveSeccompListenerHandoff(conn, socketPath, d.peerPolicy)
+	handoff, err := receiveSeccompListenerHandoff(conn, socketPath, d.peerPolicy)
 	if err != nil {
 		log.Warn("seccomp handoff rejected", "error", err)
 		_ = sendSeccompHandoffResponse(conn, false, err.Error())
 		return
 	}
+	sessionID := handoff.sessionID
+	fd := handoff.fd
 
-	record, err := d.registry.ActiveSession(sessionID)
+	record, err := d.registry.ActiveSessionForDelegatedRootPeer(sessionID, handoff.observation, handoff.authorization)
 	if err != nil {
-		log.Warn("seccomp handoff for unknown/inactive session", "session_id", sessionID, "error", err)
+		log.Warn("seccomp handoff for unknown, inactive, or differently owned session", "session_id", sessionID, "error", err)
 		_ = sendSeccompHandoffResponse(conn, false, "session not found or not active")
 		unix.Close(fd)
 		return
 	}
 
 	superviseCtx, cancel := context.WithCancel(ctx)
-	if !d.registerSeccompListener(sessionID, cancel) {
+	if !d.registerSeccompListener(sessionID, record.RegistrationGeneration, cancel) {
 		// A listener for this session is already being supervised — most
 		// likely a retried handoff. Refuse the duplicate rather than run two
 		// supervisors racing to answer the same notifications.
@@ -127,10 +145,21 @@ func (d *daemon) handleSeccompHandoffConnection(ctx context.Context, conn *net.U
 		unix.Close(fd)
 		return
 	}
+	// Close the lookup-to-insert race with end_session: if session end landed
+	// before insertion, its cleanup could not see this listener. Revalidating
+	// after insertion either rejects/removes that stale attach, or guarantees a
+	// later end_session will observe and cancel the registered listener.
+	if _, err := d.registry.ActiveSessionForDelegatedRootPeerGeneration(sessionID, handoff.observation, handoff.authorization, record.RegistrationGeneration); err != nil {
+		log.Warn("seccomp handoff session ended, was replaced, or ownership changed during listener attachment", "session_id", sessionID, "error", err)
+		d.unregisterSeccompListener(sessionID, record.RegistrationGeneration)
+		_ = sendSeccompHandoffResponse(conn, false, "session not found or not active")
+		unix.Close(fd)
+		return
+	}
 
 	if err := sendSeccompHandoffResponse(conn, true, ""); err != nil {
 		log.Warn("ack seccomp handoff", "session_id", sessionID, "error", err)
-		d.unregisterSeccompListener(sessionID)
+		d.unregisterSeccompListener(sessionID, record.RegistrationGeneration)
 		cancel()
 		unix.Close(fd)
 		return
@@ -139,9 +168,9 @@ func (d *daemon) handleSeccompHandoffConnection(ctx context.Context, conn *net.U
 	log.Info("seccomp connect-notify listener attached",
 		"session_id", sessionID, "cgroup_id", record.CgroupID, "root_pid", record.RootPID)
 	go func() {
-		defer d.unregisterSeccompListener(sessionID)
+		defer d.unregisterSeccompListener(sessionID, record.RegistrationGeneration)
 		defer unix.Close(fd)
-		superviseSeccompListener(superviseCtx, fd, sessionID, record.CgroupID, d, log)
+		superviseSeccompListener(superviseCtx, fd, sessionID, record.RegistrationGeneration, record.CgroupID, d, log)
 	}()
 }
 
@@ -150,58 +179,85 @@ func (d *daemon) handleSeccompHandoffConnection(ctx context.Context, conn *net.U
 // SO_PEERCRED + UID/GID policy the main control socket uses. On any error the
 // received fd (if one was successfully parsed before the error) is closed —
 // callers must not assume the fd is still open after a non-nil error.
-func receiveSeccompListenerHandoff(conn *net.UnixConn, socketPath string, policy kernelcapture.DaemonPeerAuthorizationPolicy) (string, int, error) {
+func receiveSeccompListenerHandoff(conn *net.UnixConn, socketPath string, policy kernelcapture.DaemonPeerAuthorizationPolicy) (receivedSeccompListenerHandoff, error) {
 	observation, err := kernelcapture.ObserveLinuxUnixPeerCredentials(conn, socketPath)
 	if err != nil {
-		return "", -1, fmt.Errorf("observe peer credentials: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("observe peer credentials: %w", err)
 	}
-	if _, err := kernelcapture.AuthorizeObservedDaemonPeer(observation.Credentials, policy); err != nil {
-		return "", -1, fmt.Errorf("unauthorized peer: %w", err)
+	authorization, err := kernelcapture.AuthorizeObservedDaemonPeer(observation.Credentials, policy)
+	if err != nil {
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("unauthorized peer: %w", err)
 	}
 
 	if err := conn.SetReadDeadline(time.Now().Add(seccompHandoffReadTimeout)); err != nil {
-		return "", -1, fmt.Errorf("set read deadline: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("set read deadline: %w", err)
 	}
 
 	msgBuf := make([]byte, seccompHandoffMaxHeaderBytes)
-	oobBuf := make([]byte, unix.CmsgSpace(4)) // exactly one fd (4-byte int)
-	n, oobn, _, _, err := conn.ReadMsgUnix(msgBuf, oobBuf)
+	oobBuf := make([]byte, unix.CmsgSpace(4*seccompHandoffMaxReceivedFDs))
+	n, oobn, flags, _, err := conn.ReadMsgUnix(msgBuf, oobBuf)
 	if err != nil {
-		return "", -1, fmt.Errorf("read handoff message: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("read handoff message: %w", err)
+	}
+	if flags&unix.MSG_CTRUNC != 0 {
+		closeSeccompHandoffRights(oobBuf[:oobn])
+		return receivedSeccompListenerHandoff{}, errors.New("handoff ancillary data was truncated")
 	}
 	if oobn == 0 {
-		return "", -1, errors.New("handoff message carried no ancillary data (no fd)")
+		return receivedSeccompListenerHandoff{}, errors.New("handoff message carried no ancillary data (no fd)")
 	}
 
 	scms, err := unix.ParseSocketControlMessage(oobBuf[:oobn])
 	if err != nil {
-		return "", -1, fmt.Errorf("parse control message: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("parse control message: %w", err)
 	}
 	if len(scms) != 1 {
-		return "", -1, fmt.Errorf("expected exactly one control message, got %d", len(scms))
+		closeSeccompHandoffRights(oobBuf[:oobn])
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("expected exactly one control message, got %d", len(scms))
 	}
 	fds, err := unix.ParseUnixRights(&scms[0])
 	if err != nil {
-		return "", -1, fmt.Errorf("parse unix rights: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("parse unix rights: %w", err)
 	}
 	if len(fds) != 1 {
 		for _, extra := range fds {
 			unix.Close(extra)
 		}
-		return "", -1, fmt.Errorf("expected exactly one fd, got %d", len(fds))
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("expected exactly one fd, got %d", len(fds))
 	}
 	fd := fds[0]
 
 	var header seccompHandoffRequest
 	if err := json.Unmarshal(msgBuf[:n], &header); err != nil {
 		unix.Close(fd)
-		return "", -1, fmt.Errorf("decode handoff header: %w", err)
+		return receivedSeccompListenerHandoff{}, fmt.Errorf("decode handoff header: %w", err)
 	}
 	if header.SessionID == "" {
 		unix.Close(fd)
-		return "", -1, errors.New("handoff header missing session_id")
+		return receivedSeccompListenerHandoff{}, errors.New("handoff header missing session_id")
 	}
-	return header.SessionID, fd, nil
+	return receivedSeccompListenerHandoff{
+		sessionID:     header.SessionID,
+		fd:            fd,
+		observation:   observation,
+		authorization: authorization,
+	}, nil
+}
+
+func closeSeccompHandoffRights(oob []byte) {
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return
+	}
+	for i := range scms {
+		fds, err := unix.ParseUnixRights(&scms[i])
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			_ = unix.Close(fd)
+		}
+	}
 }
 
 func sendSeccompHandoffResponse(conn *net.UnixConn, ok bool, errMsg string) error {
@@ -220,7 +276,7 @@ func sendSeccompHandoffResponse(conn *net.UnixConn, ok bool, errMsg string) erro
 // is cancelled or the listener errors out — most commonly because the
 // governed process tree exited, closing the last reference to the seccomp
 // filter the notifications were flowing from.
-func superviseSeccompListener(ctx context.Context, fd int, sessionID string, cgroupID uint64, d *daemon, log *slog.Logger) {
+func superviseSeccompListener(ctx context.Context, fd int, sessionID string, registrationGeneration, cgroupID uint64, d *daemon, log *slog.Logger) {
 	// Unblock a pending RecvSeccompNotif on shutdown — SECCOMP_IOCTL_NOTIF_RECV
 	// has no context awareness of its own, the same limitation
 	// ringbuf.Reader.Read() has (see daemon_guard_linux.go's runGuardConsumer,
@@ -247,7 +303,17 @@ func superviseSeccompListener(ctx context.Context, fd int, sessionID string, cgr
 			log.Info("seccomp listener closed, stopping supervisor", "session_id", sessionID, "error", err)
 			return
 		}
+		d.seccompSessionMu.RLock()
+		if _, err := d.registry.ActiveSessionGeneration(sessionID, registrationGeneration); err != nil {
+			if sendErr := kernelcapture.SendSeccompNotifResp(fd, notif.ID, -1, int32(unix.EPERM), false); sendErr != nil {
+				log.Warn("seccomp notif send (stale registration deny)", "session_id", sessionID, "error", sendErr)
+			}
+			d.seccompSessionMu.RUnlock()
+			log.Warn("seccomp listener registration ended or was replaced", "session_id", sessionID, "registration_generation", registrationGeneration, "error", err)
+			return
+		}
 		d.handleSeccompConnectNotif(fd, notif, sessionID, cgroupID, log)
+		d.seccompSessionMu.RUnlock()
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux_test.go
@@ -1,0 +1,478 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+	"golang.org/x/sys/unix"
+)
+
+const seccompHandoffChildModeEnv = "ARDUR_SECCOMP_HANDOFF_TEST_CHILD"
+
+// TestSeccompHandoffChildProcess is re-executed by the ownership tests below
+// as a real sibling or delegated root process. The ordinary parent test run
+// leaves it inert.
+func TestSeccompHandoffChildProcess(t *testing.T) {
+	mode := os.Getenv(seccompHandoffChildModeEnv)
+	if mode == "" {
+		return
+	}
+	if mode == "victim" {
+		time.Sleep(30 * time.Second)
+		return
+	}
+	if mode != "handoff" {
+		t.Fatalf("unknown child mode %q", mode)
+	}
+
+	socketPath := os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_SOCKET")
+	sessionID := os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_SESSION")
+	readyFile := os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_READY")
+	expectedOK, err := strconv.ParseBool(os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_EXPECT_OK"))
+	if err != nil {
+		t.Fatalf("parse expected response: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ready file %s did not appear", readyFile)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("dial handoff socket: %v", err)
+	}
+	defer conn.Close()
+
+	// Match the real shim's ordering: connect before installing the filter so
+	// its own AF_UNIX dial cannot be trapped by the listener it is transferring.
+	runtime.LockOSThread()
+	listenerFD, err := kernelcapture.InstallConnectUserNotifyFilter()
+	if err != nil {
+		t.Fatalf("install real seccomp user-notify filter: %v", err)
+	}
+	defer unix.Close(listenerFD)
+	rightsFDs := []int{listenerFD}
+	var extraRead, extraWrite *os.File
+	if extra, _ := strconv.ParseBool(os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_EXTRA_FD")); extra {
+		extraRead, extraWrite, err = os.Pipe()
+		if err != nil {
+			t.Fatalf("create extra SCM_RIGHTS descriptor: %v", err)
+		}
+		defer extraRead.Close()
+		defer extraWrite.Close()
+		rightsFDs = append(rightsFDs, int(extraRead.Fd()))
+	}
+
+	header, err := json.Marshal(seccompHandoffRequest{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("encode handoff header: %v", err)
+	}
+	if _, _, err := conn.WriteMsgUnix(header, unix.UnixRights(rightsFDs...), nil); err != nil {
+		t.Fatalf("send real SCM_RIGHTS handoff: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set response deadline: %v", err)
+	}
+	responseBytes := make([]byte, 4096)
+	n, err := conn.Read(responseBytes)
+	if err != nil {
+		t.Fatalf("read handoff response: %v", err)
+	}
+	var response seccompHandoffResponse
+	if err := json.Unmarshal(responseBytes[:n], &response); err != nil {
+		t.Fatalf("decode handoff response: %v", err)
+	}
+	if response.OK != expectedOK {
+		t.Fatalf("handoff response = %+v, want ok=%t", response, expectedOK)
+	}
+	connectReady := os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_CONNECT_READY")
+	connectDone := os.Getenv("ARDUR_SECCOMP_HANDOFF_TEST_CONNECT_DONE")
+	if connectReady != "" {
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(connectReady); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("connect-ready file %s did not appear", connectReady)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		conn, _ := net.DialTimeout("tcp", "127.0.0.3:19999", time.Second)
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if err := os.WriteFile(connectDone, []byte("connect returned\n"), 0o600); err != nil {
+			t.Fatalf("write connect-done file: %v", err)
+		}
+	}
+}
+
+func TestHandleSeccompHandoffConnectionRejectsAuthorizedSiblingPeer(t *testing.T) {
+	d := newTestDaemon(t)
+	d.peerPolicy = kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}}
+	d.cgroupVerifier = verifyRegisterSessionCgroup
+
+	const sessionID = "seccomp-owned-by-another-root"
+	victim := startSeccompHandoffTestChild(t, "victim", "", sessionID, false, false)
+	registerRealDelegatedRootSession(t, d, sessionID, uint32(victim.cmd.Process.Pid))
+
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	sibling := startSeccompHandoffTestChild(t, "handoff", socketPath, sessionID, false, false)
+	serveTestSeccompHandoff(t, d, listener, sibling, sessionID)
+}
+
+func TestHandleSeccompHandoffConnectionAcceptsRegisteredRootPeer(t *testing.T) {
+	d := newTestDaemon(t)
+	d.peerPolicy = kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}}
+	d.cgroupVerifier = verifyRegisterSessionCgroup
+
+	const sessionID = "seccomp-delegated-root-peer"
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	root := startSeccompHandoffTestChild(t, "handoff", socketPath, sessionID, true, false)
+	registerRealDelegatedRootSession(t, d, sessionID, uint32(root.cmd.Process.Pid))
+	serveTestSeccompHandoff(t, d, listener, root, sessionID)
+}
+
+func TestHandleSeccompHandoffConnectionRejectsMultipleDescriptors(t *testing.T) {
+	d := newTestDaemon(t)
+	d.peerPolicy = kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}}
+	d.cgroupVerifier = verifyRegisterSessionCgroup
+
+	const sessionID = "seccomp-multiple-descriptors"
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	root := startSeccompHandoffTestChild(t, "handoff", socketPath, sessionID, false, true)
+	registerRealDelegatedRootSession(t, d, sessionID, uint32(root.cmd.Process.Pid))
+	serveTestSeccompHandoff(t, d, listener, root, sessionID)
+}
+
+func TestSeccompHandoffLifecycleBarrierBlocksReplacementDuringReceive(t *testing.T) {
+	d := newTestDaemon(t)
+	d.peerPolicy = kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}}
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	client, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("dial handoff socket: %v", err)
+	}
+	defer client.Close()
+	accepted, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatalf("accept handoff socket: %v", err)
+	}
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		d.handleSeccompHandoffConnection(context.Background(), accepted, socketPath, testLogger(t))
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for d.seccompSessionMu.TryLock() {
+		d.seccompSessionMu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("handoff handler did not acquire lifecycle read lease")
+		}
+		runtime.Gosched()
+	}
+	writerAcquired := make(chan struct{})
+	go func() {
+		d.seccompSessionMu.Lock()
+		close(writerAcquired)
+		d.seccompSessionMu.Unlock()
+	}()
+	select {
+	case <-writerAcquired:
+		t.Fatal("replacement lifecycle writer entered during in-flight handoff")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Complete the real socket read with a malformed no-FD handoff. The handler
+	// rejects it, releases the lease, and only then may the lifecycle writer run.
+	if _, err := client.Write([]byte(`{"session_id":"barrier-probe"}`)); err != nil {
+		t.Fatalf("write no-FD handoff: %v", err)
+	}
+	response := make([]byte, 4096)
+	if _, err := client.Read(response); err != nil {
+		t.Fatalf("read rejected handoff response: %v", err)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handoff handler did not release lifecycle lease")
+	}
+	select {
+	case <-writerAcquired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replacement lifecycle writer remained blocked after handoff")
+	}
+}
+
+func TestSeccompNotificationLifecycleBarrierBlocksEndUntilEvidenceCompletes(t *testing.T) {
+	d := newTestDaemon(t)
+	d.peerPolicy = kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}}
+	d.cgroupVerifier = verifyRegisterSessionCgroup
+	const sessionID = "seccomp-notification-lifecycle-barrier"
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	connectDir := t.TempDir()
+	connectReady := filepath.Join(connectDir, "connect-ready")
+	connectDone := filepath.Join(connectDir, "connect-done")
+	t.Setenv("ARDUR_SECCOMP_HANDOFF_TEST_CONNECT_READY", connectReady)
+	t.Setenv("ARDUR_SECCOMP_HANDOFF_TEST_CONNECT_DONE", connectDone)
+	root := startSeccompHandoffTestChild(t, "handoff", socketPath, sessionID, true, false)
+	ownerHandshake := registerRealDelegatedRootSession(t, d, sessionID, uint32(root.cmd.Process.Pid))
+	if err := kernelcapture.ApplySeccompPolicy(d.seccompPolicy, sessionID, kernelcapture.DaemonApplyPolicyRequest{
+		SessionID: sessionID,
+		OpPolicies: []kernelcapture.DaemonOpPolicy{{
+			Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		}},
+	}); err != nil {
+		t.Fatalf("apply notification test policy: %v", err)
+	}
+	if err := os.WriteFile(root.readyFile, []byte("ready\n"), 0o600); err != nil {
+		t.Fatalf("release handoff child: %v", err)
+	}
+	accepted, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatalf("accept handoff child: %v", err)
+	}
+	peerObservation, err := kernelcapture.ObserveLinuxUnixPeerCredentials(accepted, socketPath)
+	if err != nil {
+		t.Fatalf("observe notification child peer: %v", err)
+	}
+	record, ok := d.registry.Session(sessionID)
+	if !ok || record.RootPID != peerObservation.Credentials.PID || record.RootProcessStartTimeTicks != peerObservation.Credentials.ProcessStartTimeTicks {
+		t.Fatalf("notification child identity = pid:%d start:%d; registered = %+v, present=%t", peerObservation.Credentials.PID, peerObservation.Credentials.ProcessStartTimeTicks, record, ok)
+	}
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		d.handleSeccompHandoffConnection(context.Background(), accepted, socketPath, testLogger(t))
+	}()
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handoff handler did not acknowledge listener")
+	}
+
+	d.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			d.mu.Unlock()
+		}
+	}()
+	if err := os.WriteFile(connectReady, []byte("connect\n"), 0o600); err != nil {
+		d.mu.Unlock()
+		locked = false
+		t.Fatalf("release connect probe: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(connectDone); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			d.mu.Unlock()
+			locked = false
+			t.Fatal("real seccomp notification did not return a response")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	for d.seccompSessionMu.TryLock() {
+		d.seccompSessionMu.Unlock()
+		if time.Now().After(deadline) {
+			d.mu.Unlock()
+			locked = false
+			t.Fatal("notification handler did not retain lifecycle read lease through evidence")
+		}
+		runtime.Gosched()
+	}
+	endDone := make(chan kernelcapture.DaemonProtocolResponse, 1)
+	go func() {
+		endDone <- d.handleAuthorizedRequest(context.Background(), kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodEndSession,
+			EndSession:      &kernelcapture.DaemonEndSessionRequest{SessionID: sessionID},
+		}, ownerHandshake)
+	}()
+	select {
+	case response := <-endDone:
+		d.mu.Unlock()
+		locked = false
+		t.Fatalf("end_session crossed in-flight notification evidence: %+v", response)
+	case <-time.After(50 * time.Millisecond):
+	}
+	d.mu.Unlock()
+	locked = false
+	select {
+	case response := <-endDone:
+		if !response.OK {
+			t.Fatalf("end_session after notification = %+v", response)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("end_session remained blocked after notification evidence completed")
+	}
+	if err := root.cmd.Wait(); err != nil {
+		t.Fatalf("notification child failed: %v\n%s", err, root.output.String())
+	}
+}
+
+type seccompHandoffTestChild struct {
+	cmd       *exec.Cmd
+	output    *bytes.Buffer
+	readyFile string
+}
+
+func startSeccompHandoffTestChild(t *testing.T, mode, socketPath, sessionID string, expectedOK, extraFD bool) *seccompHandoffTestChild {
+	t.Helper()
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSeccompHandoffChildProcess$")
+	cmd.Env = append(os.Environ(),
+		seccompHandoffChildModeEnv+"="+mode,
+		"ARDUR_SECCOMP_HANDOFF_TEST_SOCKET="+socketPath,
+		"ARDUR_SECCOMP_HANDOFF_TEST_SESSION="+sessionID,
+		"ARDUR_SECCOMP_HANDOFF_TEST_READY="+readyFile,
+		"ARDUR_SECCOMP_HANDOFF_TEST_EXPECT_OK="+strconv.FormatBool(expectedOK),
+		"ARDUR_SECCOMP_HANDOFF_TEST_EXTRA_FD="+strconv.FormatBool(extraFD),
+	)
+	output := &bytes.Buffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s child process: %v", mode, err)
+	}
+	child := &seccompHandoffTestChild{cmd: cmd, output: output, readyFile: readyFile}
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	return child
+}
+
+func listenForTestSeccompHandoff(t *testing.T) (*net.UnixListener, string) {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "seccomp-handoff.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("listen on handoff socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener, socketPath
+}
+
+func serveTestSeccompHandoff(t *testing.T, d *daemon, listener *net.UnixListener, child *seccompHandoffTestChild, sessionID string) {
+	t.Helper()
+	if err := os.WriteFile(child.readyFile, []byte("ready\n"), 0o600); err != nil {
+		t.Fatalf("release handoff child: %v", err)
+	}
+	if err := listener.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set accept deadline: %v", err)
+	}
+	accepted, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatalf("accept handoff child: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleSeccompHandoffConnection(context.Background(), accepted, listener.Addr().String(), testLogger(t))
+	}()
+	if err := child.cmd.Wait(); err != nil {
+		t.Fatalf("handoff child failed: %v\n%s", err, child.output.String())
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("handoff handler did not return\nchild output: %s", child.output.String())
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for d.seccompListenerAttached(sessionID) {
+		if time.Now().After(deadline) {
+			t.Fatalf("seccomp listener supervisor did not exit\nchild output: %s", child.output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func registerRealDelegatedRootSession(t *testing.T, d *daemon, sessionID string, rootPID uint32) kernelcapture.DaemonProtocolPeerHandshake {
+	t.Helper()
+	launcherObservation, launcherAuthorization := observeRealTestLauncher(t)
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		SessionID:             sessionID,
+		SocketPath:            launcherObservation.SocketPath,
+		CredentialSource:      launcherObservation.CredentialSource,
+		ProcessStartTimeTicks: launcherAuthorization.ProcessStartTimeTicks,
+		Authorization:         launcherAuthorization,
+	}
+	cgroupID, err := resolveCgroupID(rootPID)
+	if err != nil {
+		t.Fatalf("resolve real root child cgroup: %v", err)
+	}
+	request := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    sessionID,
+			RootPID:      rootPID,
+			CgroupID:     cgroupID,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   60,
+		},
+	}
+	if response := d.handleAuthorizedRequest(context.Background(), request, handshake); !response.OK {
+		t.Fatalf("register real delegated root session: %+v", response)
+	}
+	record, ok := d.registry.Session(sessionID)
+	if !ok || record.RootPID != rootPID || record.RootProcessStartTimeTicks == 0 {
+		t.Fatalf("registered root identity = %+v, present=%t", record, ok)
+	}
+	return handshake
+}
+
+func observeRealTestLauncher(t *testing.T) (kernelcapture.DaemonSocketPeerObservation, kernelcapture.DaemonPeerAuthorization) {
+	t.Helper()
+	listener, socketPath := listenForTestSeccompHandoff(t)
+	client, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("dial launcher observation socket: %v", err)
+	}
+	defer client.Close()
+	accepted, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatalf("accept launcher observation socket: %v", err)
+	}
+	defer accepted.Close()
+	observation, err := kernelcapture.ObserveLinuxUnixPeerCredentials(accepted, socketPath)
+	if err != nil {
+		t.Fatalf("observe real launcher credentials: %v", err)
+	}
+	authorization, err := kernelcapture.AuthorizeObservedDaemonPeer(
+		observation.Credentials,
+		kernelcapture.DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{uint32(os.Getuid())}},
+	)
+	if err != nil {
+		t.Fatalf("authorize real launcher credentials: %v", err)
+	}
+	return observation, authorization
+}

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -76,14 +76,14 @@ func newTestDaemon(t *testing.T) *daemon {
 		fs:                        osEvidenceFS{},
 		tamperChain:               kernelcapture.NewTamperReceiptChain(),
 		seccompPolicy:             kernelcapture.NewSeccompPolicyStore(),
-		seccompListeners:          make(map[string]context.CancelFunc),
+		seccompListeners:          make(map[string]seccompListenerRegistration),
 		activeTier:                daemonTierNone,
 		appliedAllow:              make(map[string]*appliedAllowRecord),
 		// No-op cgroup verifier: daemon-flow tests register synthetic PIDs that
 		// aren't real /proc descendants. The real check is covered directly by
 		// daemon_cgroup_verify_linux_test.go.
-		cgroupVerifier: func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) error {
-			return nil
+		cgroupVerifier: func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) (uint64, error) {
+			return 1, nil
 		},
 	}
 	d.lifecycleFilter.markUnavailable(errors.New("lifecycle filter unavailable in unit test"))
@@ -291,7 +291,7 @@ func TestOnSessionEnded_ClearsSeccompState(t *testing.T) {
 	}
 
 	cancelled := false
-	if !d.registerSeccompListener("sec-session-001", func() { cancelled = true }) {
+	if !d.registerSeccompListener("sec-session-001", 1, func() { cancelled = true }) {
 		t.Fatal("registerSeccompListener: expected first registration to succeed")
 	}
 
@@ -335,7 +335,7 @@ func TestPruneExpiredSessions_ClearsSeccompState(t *testing.T) {
 		t.Fatalf("ApplySeccompPolicy: %v", err)
 	}
 	cancelled := false
-	if !d.registerSeccompListener("phantom-seccomp-session", func() { cancelled = true }) {
+	if !d.registerSeccompListener("phantom-seccomp-session", 1, func() { cancelled = true }) {
 		t.Fatal("registerSeccompListener: expected first registration to succeed")
 	}
 
@@ -362,11 +362,180 @@ func TestPruneExpiredSessions_ClearsSeccompState(t *testing.T) {
 // on this to refuse a retried/duplicate handoff.
 func TestRegisterSeccompListener_RejectsDuplicate(t *testing.T) {
 	d := newTestDaemon(t)
-	if !d.registerSeccompListener("dup-session", func() {}) {
+	if !d.registerSeccompListener("dup-session", 1, func() {}) {
 		t.Fatal("first registerSeccompListener call: expected success")
 	}
-	if d.registerSeccompListener("dup-session", func() {}) {
+	if d.registerSeccompListener("dup-session", 2, func() {}) {
 		t.Error("second registerSeccompListener call for the same session: expected rejection")
+	}
+}
+
+func TestUnregisterSeccompListener_DoesNotRemoveReplacementGeneration(t *testing.T) {
+	d := newTestDaemon(t)
+	firstCancelled := false
+	if !d.registerSeccompListener("reused-session", 1, func() { firstCancelled = true }) {
+		t.Fatal("register generation 1 listener")
+	}
+	d.unregisterSeccompListener("reused-session", 1)
+	if !firstCancelled {
+		t.Fatal("generation 1 listener was not cancelled")
+	}
+
+	secondCancelled := false
+	if !d.registerSeccompListener("reused-session", 2, func() { secondCancelled = true }) {
+		t.Fatal("register generation 2 listener")
+	}
+	// Model generation 1's supervisor defer arriving after generation 2 has
+	// attached. It must be a compare-and-delete no-op.
+	d.unregisterSeccompListener("reused-session", 1)
+	if secondCancelled {
+		t.Fatal("stale generation 1 cleanup cancelled generation 2 listener")
+	}
+	d.mu.RLock()
+	listener, ok := d.seccompListeners["reused-session"]
+	d.mu.RUnlock()
+	if !ok || listener.registrationGeneration != 2 {
+		t.Fatalf("replacement listener = %+v, present=%t; want generation 2", listener, ok)
+	}
+}
+
+func TestRegisterSessionRetiresPriorGenerationSeccompListener(t *testing.T) {
+	d := newTestDaemon(t)
+	oldCancelled := false
+	if !d.registerSeccompListener("replacement-registration", 99, func() { oldCancelled = true }) {
+		t.Fatal("register prior-generation listener")
+	}
+	if err := kernelcapture.ApplySeccompPolicy(d.seccompPolicy, "replacement-registration", kernelcapture.DaemonApplyPolicyRequest{
+		SessionID: "replacement-registration",
+		OpPolicies: []kernelcapture.DaemonOpPolicy{{
+			Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+		}},
+	}); err != nil {
+		t.Fatalf("seed prior-generation seccomp policy: %v", err)
+	}
+	const peerStartTicks = 12345678
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+		ProcessStartTimeTicks: peerStartTicks,
+		Authorization: kernelcapture.DaemonPeerAuthorization{
+			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+			UID:                   uint32(os.Getuid()),
+			PID:                   uint32(os.Getpid()),
+			ProcessStartTimeTicks: peerStartTicks,
+		},
+	}
+	request := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "replacement-registration",
+			RootPID:      50,
+			CgroupID:     17,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   120,
+		},
+	}
+	response := d.handleAuthorizedRequest(context.Background(), request, handshake)
+	if !response.OK {
+		t.Fatalf("replacement registration response = %+v", response)
+	}
+	if !oldCancelled {
+		t.Fatal("accepted replacement registration did not cancel prior-generation listener")
+	}
+	if d.seccompListenerAttached(request.RegisterSession.SessionID) {
+		t.Fatal("accepted replacement registration retained prior-generation listener")
+	}
+	if decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, request.RegisterSession.SessionID, net.ParseIP("192.0.2.10")); decision.HasPolicy {
+		t.Fatalf("accepted replacement registration inherited prior-generation policy: %+v", decision)
+	}
+}
+
+func TestApplyPolicyLifecycleLeasePreventsPublicationAcrossReplacement(t *testing.T) {
+	d := newTestDaemon(t)
+	d.activeTier = daemonTierSeccomp
+	const peerStartTicks = 12345678
+	handshake := kernelcapture.DaemonProtocolPeerHandshake{
+		ProtocolVersion:       kernelcapture.DaemonProtocolVersion,
+		Method:                kernelcapture.DaemonProtocolMethodRegisterSession,
+		CredentialSource:      kernelcapture.DaemonPeerCredentialSourceLinuxSOPeerCred,
+		ProcessStartTimeTicks: peerStartTicks,
+		Authorization: kernelcapture.DaemonPeerAuthorization{
+			Verdict:               kernelcapture.DaemonPeerAuthorizationVerdictAllow,
+			UID:                   uint32(os.Getuid()),
+			PID:                   uint32(os.Getpid()),
+			ProcessStartTimeTicks: peerStartTicks,
+		},
+	}
+	register := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    "apply-replacement-barrier",
+			RootPID:      50,
+			CgroupID:     17,
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   120,
+		},
+	}
+	if response := d.handleAuthorizedRequest(context.Background(), register, handshake); !response.OK {
+		t.Fatalf("initial register response = %+v", response)
+	}
+	apply := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+			SessionID:   register.RegisterSession.SessionID,
+			Generation:  1,
+			EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{{
+				Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			}},
+		},
+	}
+
+	d.applyMu.Lock()
+	applyDone := make(chan kernelcapture.DaemonProtocolResponse, 1)
+	go func() { applyDone <- d.handleAuthorizedRequest(context.Background(), apply, handshake) }()
+	deadline := time.Now().Add(5 * time.Second)
+	for d.seccompSessionMu.TryLock() {
+		d.seccompSessionMu.Unlock()
+		if time.Now().After(deadline) {
+			d.applyMu.Unlock()
+			t.Fatal("apply_policy did not acquire lifecycle read lease")
+		}
+		runtime.Gosched()
+	}
+	end := kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodEndSession,
+		EndSession:      &kernelcapture.DaemonEndSessionRequest{SessionID: register.RegisterSession.SessionID},
+	}
+	endDone := make(chan kernelcapture.DaemonProtocolResponse, 1)
+	go func() { endDone <- d.handleAuthorizedRequest(context.Background(), end, handshake) }()
+	select {
+	case response := <-endDone:
+		d.applyMu.Unlock()
+		t.Fatalf("end/replacement lifecycle crossed stalled apply: %+v", response)
+	case <-time.After(50 * time.Millisecond):
+	}
+	d.applyMu.Unlock()
+
+	if response := <-applyDone; !response.OK {
+		t.Fatalf("stalled apply response = %+v", response)
+	}
+	if response := <-endDone; !response.OK {
+		t.Fatalf("end response = %+v", response)
+	}
+	if decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, register.RegisterSession.SessionID, net.ParseIP("192.0.2.10")); decision.HasPolicy {
+		t.Fatalf("ended generation retained stalled apply policy: %+v", decision)
+	}
+	if response := d.handleAuthorizedRequest(context.Background(), register, handshake); !response.OK {
+		t.Fatalf("replacement register response = %+v", response)
+	}
+	if decision := kernelcapture.EvaluateSeccompConnect(d.seccompPolicy, register.RegisterSession.SessionID, net.ParseIP("192.0.2.10")); decision.HasPolicy {
+		t.Fatalf("replacement registration inherited prior policy: %+v", decision)
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -190,10 +190,15 @@ type daemon struct {
 	// (if ever) a seccomp listener attaches for it. Non-nil on every
 	// platform; on non-Linux it simply never gets a listener to serve.
 	seccompPolicy *kernelcapture.SeccompPolicyStore
-	// seccompListeners tracks the cancel func for each session's seccomp
-	// supervisor goroutine (Linux only; always empty elsewhere), keyed by
-	// session_id and guarded by mu like the other session-scoped maps above.
-	seccompListeners map[string]context.CancelFunc
+	// seccompListeners tracks each session's supervisor together with the
+	// immutable registry generation that installed it (Linux only; always empty
+	// elsewhere). Keyed by session_id and guarded by mu.
+	seccompListeners map[string]seccompListenerRegistration
+	// seccompSessionMu makes handoff/notification reads atomic against
+	// register/end/expiry lifecycle writes. Supervisors may read concurrently;
+	// replacement cannot publish new session state while a prior-generation
+	// notification or handoff is being decided.
+	seccompSessionMu sync.RWMutex
 
 	// activeTier is decided once at startup (see main(): "prefer BPF-LSM
 	// when active, fall back to seccomp when it isn't") and advertised on
@@ -227,7 +232,7 @@ type daemon struct {
 	// cgroupVerifier gates register_session on the peer owning the claimed
 	// cgroup/root_pid. Injected so tests (which register synthetic PIDs) can
 	// substitute a no-op; production wires verifyRegisterSessionCgroup.
-	cgroupVerifier func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) error
+	cgroupVerifier func(kernelcapture.DaemonProtocolPeerHandshake, *kernelcapture.DaemonRegisterSessionRequest, *slog.Logger) (uint64, error)
 }
 
 // appliedAllowRecord is the last allowlist set written for a session.
@@ -239,6 +244,11 @@ type appliedAllowRecord struct {
 	bootstrapFiles map[bootstrapFileObject]kernelcapture.BootstrapFile
 	trustedRoot    bool
 	controlPlane   *kernelcapture.DaemonControlPlaneEndpoint
+}
+
+type seccompListenerRegistration struct {
+	registrationGeneration uint64
+	cancel                 context.CancelFunc
 }
 
 type bootstrapFileObject struct {
@@ -307,7 +317,7 @@ func newDaemon(log *slog.Logger, socketPath, evidenceDir, stateDir string, owner
 		fs:                        osEvidenceFS{},
 		tamperChain:               kernelcapture.NewTamperReceiptChain(),
 		seccompPolicy:             kernelcapture.NewSeccompPolicyStore(),
-		seccompListeners:          make(map[string]context.CancelFunc),
+		seccompListeners:          make(map[string]seccompListenerRegistration),
 		activeTier:                daemonTierNone,
 		appliedAllow:              make(map[string]*appliedAllowRecord),
 		cgroupVerifier:            verifyRegisterSessionCgroup,
@@ -374,25 +384,36 @@ func (d *daemon) observeAgentLaunch(evt kernelcapture.ProcessEvent) {
 // supervisor, returning false (without recording anything) if one is already
 // registered — callers must treat false as "reject this handoff," not as a
 // signal to replace the existing listener.
-func (d *daemon) registerSeccompListener(sessionID string, cancel context.CancelFunc) bool {
+func (d *daemon) registerSeccompListener(sessionID string, registrationGeneration uint64, cancel context.CancelFunc) bool {
+	if registrationGeneration == 0 {
+		return false
+	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, exists := d.seccompListeners[sessionID]; exists {
 		return false
 	}
-	d.seccompListeners[sessionID] = cancel
+	d.seccompListeners[sessionID] = seccompListenerRegistration{
+		registrationGeneration: registrationGeneration,
+		cancel:                 cancel,
+	}
 	return true
 }
 
-// unregisterSeccompListener stops (if still running) and forgets sessionID's
-// seccomp supervisor. Safe to call even if no listener was ever registered.
-func (d *daemon) unregisterSeccompListener(sessionID string) {
+// unregisterSeccompListener stops and forgets sessionID's supervisor only if
+// it still belongs to registrationGeneration. A late defer from generation A
+// must never remove generation B's replacement listener.
+func (d *daemon) unregisterSeccompListener(sessionID string, registrationGeneration uint64) {
 	d.mu.Lock()
-	cancel, ok := d.seccompListeners[sessionID]
-	delete(d.seccompListeners, sessionID)
+	listener, ok := d.seccompListeners[sessionID]
+	if ok && listener.registrationGeneration == registrationGeneration {
+		delete(d.seccompListeners, sessionID)
+	} else {
+		ok = false
+	}
 	d.mu.Unlock()
-	if ok && cancel != nil {
-		cancel()
+	if ok && listener.cancel != nil {
+		listener.cancel()
 	}
 }
 
@@ -437,15 +458,40 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 	// to another workload.
 	lifecycleFilterAdded := false
 	if req.Method == kernelcapture.DaemonProtocolMethodRegisterSession && req.RegisterSession != nil {
-		if err := d.cgroupVerifier(handshake, req.RegisterSession, d.log); err != nil {
+		// Work on a private copy: the root-process identity below is daemon
+		// evidence and must not mutate or be supplied by caller-owned request
+		// memory.
+		register := *req.RegisterSession
+		req.RegisterSession = &register
+		if err := kernelcapture.ValidateDaemonProtocolRequest(req); err != nil {
+			return kernelcapture.DaemonProtocolResponse{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          req.Method,
+				SessionID:       register.SessionID,
+				OK:              false,
+				Error:           fmt.Sprintf("invalid register_session request: %v", err),
+			}
+		}
+		rootProcessStartTimeTicks, verifyErr := d.cgroupVerifier(handshake, req.RegisterSession, d.log)
+		if verifyErr != nil {
 			return kernelcapture.DaemonProtocolResponse{
 				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
 				Method:          req.Method,
 				SessionID:       req.RegisterSession.SessionID,
 				OK:              false,
-				Error:           fmt.Sprintf("register_session cgroup ownership check failed: %v", err),
+				Error:           fmt.Sprintf("register_session cgroup ownership check failed: %v", verifyErr),
 			}
 		}
+		if registerSessionRootProcessStartTimeRequired && rootProcessStartTimeTicks == 0 {
+			return kernelcapture.DaemonProtocolResponse{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          req.Method,
+				SessionID:       register.SessionID,
+				OK:              false,
+				Error:           "register_session root process identity was not verified",
+			}
+		}
+		register.RootProcessStartTimeTicks = rootProcessStartTimeTicks
 		// #119 collision guard: even a claim that passes ownership verification
 		// must not be allowed to bind a cgroup_id that another live session
 		// already holds — two sessions must never be able to govern the same
@@ -473,6 +519,11 @@ func (d *daemon) handleAuthorizedRequest(ctx context.Context, req kernelcapture.
 		}
 	}
 
+	serializesSeccompLifecycle := req.Method == kernelcapture.DaemonProtocolMethodRegisterSession || req.Method == kernelcapture.DaemonProtocolMethodEndSession
+	if serializesSeccompLifecycle {
+		d.seccompSessionMu.Lock()
+		defer d.seccompSessionMu.Unlock()
+	}
 	resp := d.registry.HandleAuthorizedRequest(ctx, req, handshake)
 	if !resp.OK {
 		if lifecycleFilterAdded {
@@ -708,6 +759,11 @@ func (d *daemon) degradeGuardTier(cause error, log *slog.Logger) {
 // the policy into the BPF enforcement maps.
 func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, handshake kernelcapture.DaemonProtocolPeerHandshake) kernelcapture.DaemonProtocolResponse {
 	ap := req.ApplyPolicy
+	// Keep the owner/generation lookup and every policy publication atomic with
+	// register/end/expiry transitions. Lock order is seccompSessionMu then
+	// applyMu, matching lifecycle cleanup below.
+	d.seccompSessionMu.RLock()
+	defer d.seccompSessionMu.RUnlock()
 	errResp := func(msg string) kernelcapture.DaemonProtocolResponse {
 		return kernelcapture.DaemonProtocolResponse{
 			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
@@ -1107,10 +1163,21 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 	if sessionID == "" || reg == nil {
 		return
 	}
+	// Policies are keyed by session_id, which is reusable after end/expiry.
+	// Every accepted registration starts empty so generation B can never inherit
+	// generation A's seccomp decision state.
+	kernelcapture.RemoveSeccompPolicy(d.seccompPolicy, sessionID)
 	producerCounterGap := d.lifecycleProducerCounterEvidenceGapActive()
 	d.tamperWriteMu.Lock()
 	defer d.tamperWriteMu.Unlock()
 	d.mu.Lock()
+	var replacedSeccompCancel context.CancelFunc
+	if record, ok := d.registry.Session(sessionID); ok && record.RegistrationGeneration != 0 {
+		if listener, attached := d.seccompListeners[sessionID]; attached && listener.registrationGeneration != record.RegistrationGeneration {
+			delete(d.seccompListeners, sessionID)
+			replacedSeccompCancel = listener.cancel
+		}
+	}
 
 	if reg.CgroupID != 0 {
 		d.cgroupIndex[reg.CgroupID] = sessionID
@@ -1149,6 +1216,9 @@ func (d *daemon) onSessionRegistered(reg *kernelcapture.DaemonRegisterSessionReq
 		"ttl_s", reg.TTLSeconds,
 	)
 	d.mu.Unlock()
+	if replacedSeccompCancel != nil {
+		replacedSeccompCancel()
+	}
 
 	// Close the transition window between the first counter-state snapshot and
 	// publishing the new summary. A failure recorded before publication cannot
@@ -1211,7 +1281,7 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	// same lock as the map deletes above; call it below, outside the lock,
 	// since the supervisor goroutine it stops may itself try to touch
 	// d.mu-guarded state on its way out.
-	seccompCancel, hadSeccompListener := d.seccompListeners[sessionID]
+	seccompListener, hadSeccompListener := d.seccompListeners[sessionID]
 	delete(d.seccompListeners, sessionID)
 	d.mu.Unlock()
 	if err := d.lifecycleFilter.remove(sessionID); err != nil {
@@ -1220,8 +1290,8 @@ func (d *daemon) onSessionEnded(sessionID string) {
 	}
 
 	kernelcapture.RemoveSeccompPolicy(d.seccompPolicy, sessionID)
-	if hadSeccompListener && seccompCancel != nil {
-		seccompCancel()
+	if hadSeccompListener && seccompListener.cancel != nil {
+		seccompListener.cancel()
 	}
 
 	d.log.Info("session ended", "session_id", sessionID)
@@ -1651,6 +1721,8 @@ func (d *daemon) observabilityGapSummaryForSession(sessionID string) (kernelcapt
 // pruneExpiredSessions removes sessions that the registry has expired so the
 // cgroup index does not leak indefinitely.
 func (d *daemon) pruneExpiredSessions() {
+	d.seccompSessionMu.Lock()
+	defer d.seccompSessionMu.Unlock()
 	type expiredPolicy struct {
 		cgroupID       uint64
 		rootPID        uint32
@@ -1687,8 +1759,8 @@ func (d *daemon) pruneExpiredSessions() {
 			delete(d.enforceSummaries, sid)
 			delete(d.lifecycleCaptureSummaries, sid)
 			delete(d.observabilityGaps, sid)
-			if cancel, ok := d.seccompListeners[sid]; ok {
-				expiredSeccompCancels = append(expiredSeccompCancels, cancel)
+			if listener, ok := d.seccompListeners[sid]; ok {
+				expiredSeccompCancels = append(expiredSeccompCancels, listener.cancel)
 				delete(d.seccompListeners, sid)
 			}
 			expiredSessionIDs = append(expiredSessionIDs, sid)

--- a/go/cmd/ardur-seccomp-smoke/main.go
+++ b/go/cmd/ardur-seccomp-smoke/main.go
@@ -42,6 +42,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -101,7 +102,7 @@ func runProbe(addr string) {
 	fmt.Printf("OTHER_ERROR:%v\n", err)
 }
 
-func run(daemonBin, shimBin string) error {
+func run(daemonBin, shimBin string) (runErr error) {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve own executable path (needed to re-exec as the connect probe): %w", err)
@@ -134,6 +135,15 @@ func run(daemonBin, shimBin string) error {
 		return fmt.Errorf("create daemon log file: %w", err)
 	}
 	defer daemonLog.Close()
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		_ = daemonLog.Sync()
+		if data, err := os.ReadFile(daemonLog.Name()); err == nil {
+			fmt.Fprintf(os.Stderr, "--- ardur-kernelcaptured log ---\n%s\n--- end daemon log ---\n", data)
+		}
+	}()
 
 	daemonCmd := exec.Command(daemonBin,
 		"--socket", sockPath,
@@ -173,41 +183,9 @@ func run(daemonBin, shimBin string) error {
 	}
 	fmt.Println("daemon started, seccomp tier active")
 
-	const sessionID = "seccomp-smoke"
-	if err := daemonCall(sockPath, kernelcapture.DaemonProtocolRequest{
-		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
-		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
-		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
-			SessionID:    sessionID,
-			RootPID:      1,
-			CgroupID:     1,
-			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
-			TTLSeconds:   300,
-		},
-	}); err != nil {
-		return fmt.Errorf("register_session: %w", err)
-	}
-
 	const allowedIP = "127.0.0.2"
-	if err := daemonCall(sockPath, kernelcapture.DaemonProtocolRequest{
-		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
-		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
-		ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
-			SessionID:   sessionID,
-			Generation:  1,
-			EnforceMode: kernelcapture.BpfEnforceModeEnforce,
-			OpPolicies: []kernelcapture.DaemonOpPolicy{
-				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
-			},
-			NetAllow: []string{allowedIP + "/32"},
-		},
-	}); err != nil {
-		return fmt.Errorf("apply_policy: %w", err)
-	}
-	fmt.Println("policy applied: allow only " + allowedIP + "/32")
-
 	deniedTarget := "127.0.0.3:19999" // not in the allowlist
-	deniedOut, err := runShimProbe(shimBin, seccompSockPath, sessionID, self, deniedTarget)
+	deniedOut, err := runShimProbe(sockPath, shimBin, seccompSockPath, "seccomp-smoke-denied", self, deniedTarget, allowedIP)
 	if err != nil {
 		return fmt.Errorf("run shim against denied target: %w", err)
 	}
@@ -217,14 +195,14 @@ func run(daemonBin, shimBin string) error {
 	fmt.Println("denied target correctly got EPERM:", deniedOut)
 
 	allowedTarget := allowedIP + ":19999" // in the allowlist, nothing listening
-	allowedOut, err := runShimProbe(shimBin, seccompSockPath, sessionID, self, allowedTarget)
+	allowedOut, err := runShimProbe(sockPath, shimBin, seccompSockPath, "seccomp-smoke-allowed", self, allowedTarget, allowedIP)
 	if err != nil {
 		return fmt.Errorf("run shim against allowed target: %w", err)
 	}
-	if allowedOut == "ERRNO:1:operation not permitted" {
-		return fmt.Errorf("allowed target %s: probe got EPERM, want the syscall to reach the kernel's real connect handling", allowedTarget)
+	if allowedOut != "ERRNO:111:connection refused" {
+		return fmt.Errorf("allowed target %s: probe reported %q, want ECONNREFUSED proving the syscall reached the kernel", allowedTarget, allowedOut)
 	}
-	fmt.Println("allowed target correctly reached the kernel (not EPERM):", allowedOut)
+	fmt.Println("allowed target correctly reached the kernel with ECONNREFUSED:", allowedOut)
 
 	return nil
 }
@@ -309,21 +287,72 @@ func daemonRequest(sockPath string, req kernelcapture.DaemonProtocolRequest) (ke
 	return resp, nil
 }
 
-// runShimProbe runs shimBin against self (re-exec'd via --probe-connect
-// target) under sessionID's seccomp policy, and returns the probe's single
-// line of stdout output.
-func runShimProbe(shimBin, seccompSockPath, sessionID, self, target string) (string, error) {
+// runShimProbe starts the real shim behind its production ready-file gate,
+// registers that live child PID as the session root, applies the policy, and
+// only then releases the shim to transfer its real listener and exec the
+// connect probe. One session per probe keeps the delegated root identity exact.
+func runShimProbe(daemonSockPath, shimBin, seccompSockPath, sessionID, self, target, allowedIP string) (string, error) {
+	readyFile := filepath.Join(filepath.Dir(seccompSockPath), sessionID+".ready")
+	defer os.Remove(readyFile)
 	cmd := exec.Command(shimBin,
 		"--session-id", sessionID,
 		"--seccomp-socket", seccompSockPath,
+		"--ready-file", readyFile,
 		"--",
 		self, "--probe-connect", target,
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("%w (output: %s)", err, string(out))
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("start shim: %w", err)
 	}
-	line := string(out)
+	defer func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
+	if err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID: sessionID,
+			RootPID:   uint32(cmd.Process.Pid),
+			// This CI smoke runs as root and exercises the seccomp tier, which is
+			// process/filter scoped rather than cgroup enforced. Use the live root
+			// PID as a unique non-zero registry key so the two independent probe
+			// sessions cannot collide on the old placeholder cgroup_id=1.
+			CgroupID:     uint64(cmd.Process.Pid),
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   300,
+		},
+	}); err != nil {
+		return "", fmt.Errorf("register_session: %w", err)
+	}
+	if err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+			SessionID:   sessionID,
+			Generation:  1,
+			EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+			NetAllow: []string{allowedIP + "/32"},
+		},
+	}); err != nil {
+		return "", fmt.Errorf("apply_policy: %w", err)
+	}
+	if err := os.WriteFile(readyFile, []byte("ready\n"), 0o600); err != nil {
+		return "", fmt.Errorf("release shim ready gate: %w", err)
+	}
+	err := cmd.Wait()
+	if err != nil {
+		return "", fmt.Errorf("%w (output: %s)", err, output.String())
+	}
+	line := output.String()
 	for len(line) > 0 && (line[len(line)-1] == '\n' || line[len(line)-1] == '\r') {
 		line = line[:len(line)-1]
 	}

--- a/go/pkg/kernelcapture/daemon_peer_credentials_linux.go
+++ b/go/pkg/kernelcapture/daemon_peer_credentials_linux.go
@@ -69,6 +69,14 @@ func ObserveLinuxUnixPeerCredentials(conn *net.UnixConn, socketPath string) (Dae
 	}, nil
 }
 
+// ObserveLinuxProcessStartTimeTicks reads the kernel's process start-time
+// identity for pid from /proc/<pid>/stat. Callers use it to bind a numeric PID
+// to one process lifetime instead of accepting a later process that reused the
+// same PID.
+func ObserveLinuxProcessStartTimeTicks(pid uint32) (uint64, error) {
+	return readLinuxProcProcessStartTimeTicks(pid)
+}
+
 func readLinuxProcProcessStartTimeTicks(pid uint32) (uint64, error) {
 	if pid == 0 {
 		return 0, fmt.Errorf("%w: observed peer pid is required", ErrDaemonPeerCredentialRetrieval)

--- a/go/pkg/kernelcapture/daemon_peer_credentials_unsupported.go
+++ b/go/pkg/kernelcapture/daemon_peer_credentials_unsupported.go
@@ -13,3 +13,9 @@ import (
 func ObserveLinuxUnixPeerCredentials(_ *net.UnixConn, _ string) (DaemonSocketPeerObservation, error) {
 	return DaemonSocketPeerObservation{}, fmt.Errorf("%w: linux SO_PEERCRED is not supported on %s", ErrDaemonPeerCredentialRetrieval, runtime.GOOS)
 }
+
+// ObserveLinuxProcessStartTimeTicks is unavailable outside Linux because the
+// process lifetime identity is read from Linux /proc/<pid>/stat.
+func ObserveLinuxProcessStartTimeTicks(_ uint32) (uint64, error) {
+	return 0, fmt.Errorf("%w: linux proc process identity is not supported on %s", ErrDaemonPeerCredentialRetrieval, runtime.GOOS)
+}

--- a/go/pkg/kernelcapture/daemon_peer_credentials_unsupported_test.go
+++ b/go/pkg/kernelcapture/daemon_peer_credentials_unsupported_test.go
@@ -18,3 +18,15 @@ func TestObserveLinuxUnixPeerCredentialsUnsupportedPlatformsFailClosed(t *testin
 		t.Fatalf("expected ErrDaemonPeerCredentialRetrieval, got %v", err)
 	}
 }
+
+func TestObserveLinuxProcessStartTimeTicksUnsupportedPlatformsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, err := ObserveLinuxProcessStartTimeTicks(1)
+	if err == nil {
+		t.Fatalf("expected unsupported-platform error")
+	}
+	if !errors.Is(err, ErrDaemonPeerCredentialRetrieval) {
+		t.Fatalf("expected ErrDaemonPeerCredentialRetrieval, got %v", err)
+	}
+}

--- a/go/pkg/kernelcapture/daemon_protocol.go
+++ b/go/pkg/kernelcapture/daemon_protocol.go
@@ -135,6 +135,9 @@ type DaemonRegisterSessionRequest struct {
 	EventClasses    []string       `json:"event_classes"`
 	TTLSeconds      int64          `json:"ttl_seconds"`
 	HandoffMetadata map[string]any `json:"handoff_metadata,omitempty"`
+	// RootProcessStartTimeTicks is stamped from daemon-observed /proc identity
+	// after cgroup/ancestry verification. It is never accepted from JSON.
+	RootProcessStartTimeTicks uint64 `json:"-"`
 }
 
 // DaemonRegisterReceiptRequest reports one governance receipt to the daemon

--- a/go/pkg/kernelcapture/daemon_session_registry.go
+++ b/go/pkg/kernelcapture/daemon_session_registry.go
@@ -30,14 +30,22 @@ type DaemonSessionClock func() time.Time
 // It is intentionally metadata-only: it does not claim cgroup creation, BPF map
 // mutation, process execution, or live kernel enforcement.
 type DaemonSessionRecord struct {
-	SessionID       string
-	MissionID       string
-	TraceID         string
-	RootPID         uint32
-	PIDNamespaceID  uint32
-	CgroupID        uint64
-	EventClasses    []string
-	HandoffMetadata map[string]any
+	SessionID string
+	MissionID string
+	TraceID   string
+	// RegistrationGeneration is a daemon-local monotonic identity for this
+	// specific registration lifetime. Session IDs may be reused after end or
+	// expiry, so the string alone cannot prove two lookups saw the same record.
+	RegistrationGeneration uint64
+	RootPID                uint32
+	// RootProcessStartTimeTicks binds RootPID to the process lifetime the
+	// daemon observed while accepting register_session. It is distinct from
+	// PeerProcessStartTimeTicks because the launcher registers its child.
+	RootProcessStartTimeTicks uint64
+	PIDNamespaceID            uint32
+	CgroupID                  uint64
+	EventClasses              []string
+	HandoffMetadata           map[string]any
 
 	RegisteredAt time.Time
 	ExpiresAt    time.Time
@@ -65,10 +73,11 @@ func (r DaemonSessionRecord) Status(now time.Time) string {
 // authorized daemon protocol requests. It deliberately performs no privileged
 // filesystem, cgroup, BPF, service-lifecycle, or process-management work.
 type DaemonSessionRegistry struct {
-	mu          sync.RWMutex
-	sessions    map[string]DaemonSessionRecord
-	now         DaemonSessionClock
-	maxSessions int
+	mu                         sync.RWMutex
+	sessions                   map[string]DaemonSessionRecord
+	now                        DaemonSessionClock
+	maxSessions                int
+	nextRegistrationGeneration uint64
 }
 
 func NewDaemonSessionRegistry() *DaemonSessionRegistry {
@@ -125,6 +134,58 @@ func (r *DaemonSessionRegistry) ActiveSessionForPeer(sessionID string, handshake
 	}
 	if !daemonSessionRegistryPeerOwnsRecord(record, handshake) {
 		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q is owned by a different peer", ErrDaemonSessionRegistry, sessionID)
+	}
+	return record, nil
+}
+
+// ActiveSessionForDelegatedRootPeer resolves an active session only when an
+// independently authorized socket peer is the exact root process the session
+// owner registered. The launcher owns the control-plane session, while its
+// exec shim is a different process that legitimately transfers the seccomp
+// listener; this delegated gate preserves that split without reducing it to
+// daemon-wide UID/GID authorization.
+func (r *DaemonSessionRegistry) ActiveSessionForDelegatedRootPeer(sessionID string, observation DaemonSocketPeerObservation, authorization DaemonPeerAuthorization) (DaemonSessionRecord, error) {
+	record, _, err := r.lookupActiveSession(sessionID, r.currentTime())
+	if err != nil {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: %v", ErrDaemonSessionRegistry, err)
+	}
+	if !daemonSessionRegistryDelegatedRootPeerOwnsRecord(record, observation, authorization) {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q root process is owned by a different peer", ErrDaemonSessionRegistry, sessionID)
+	}
+	return record, nil
+}
+
+// ActiveSessionForDelegatedRootPeerGeneration revalidates that the delegated
+// root still owns the same registration lifetime observed earlier. Session IDs
+// are reusable after end or expiry; accepting a replacement record here could
+// attach an in-flight listener using metadata from the prior registration.
+func (r *DaemonSessionRegistry) ActiveSessionForDelegatedRootPeerGeneration(sessionID string, observation DaemonSocketPeerObservation, authorization DaemonPeerAuthorization, registrationGeneration uint64) (DaemonSessionRecord, error) {
+	if registrationGeneration == 0 {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q registration generation is required", ErrDaemonSessionRegistry, sessionID)
+	}
+	record, err := r.ActiveSessionForDelegatedRootPeer(sessionID, observation, authorization)
+	if err != nil {
+		return DaemonSessionRecord{}, err
+	}
+	if record.RegistrationGeneration != registrationGeneration {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q registration was replaced", ErrDaemonSessionRegistry, sessionID)
+	}
+	return record, nil
+}
+
+// ActiveSessionGeneration resolves an active session only if it is still the
+// same registration lifetime. Long-lived daemon work uses this to fail closed
+// after a session ID is ended or expired and then reused.
+func (r *DaemonSessionRegistry) ActiveSessionGeneration(sessionID string, registrationGeneration uint64) (DaemonSessionRecord, error) {
+	if registrationGeneration == 0 {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q registration generation is required", ErrDaemonSessionRegistry, sessionID)
+	}
+	record, err := r.ActiveSession(sessionID)
+	if err != nil {
+		return DaemonSessionRecord{}, err
+	}
+	if record.RegistrationGeneration != registrationGeneration {
+		return DaemonSessionRecord{}, fmt.Errorf("%w: session %q registration was replaced", ErrDaemonSessionRegistry, sessionID)
 	}
 	return record, nil
 }
@@ -201,12 +262,18 @@ func (r *DaemonSessionRegistry) handleRegisterSession(req DaemonProtocolRequest,
 			return daemonSessionRegistryErrorResponse(req, DaemonSessionStatusCapacityExceeded, "session registry capacity exceeded: max active sessions is %d", r.effectiveMaxSessions())
 		}
 	}
+	if r.nextRegistrationGeneration == ^uint64(0) {
+		return daemonSessionRegistryErrorResponse(req, DaemonSessionStatusCapacityExceeded, "session registration generation space exhausted")
+	}
+	r.nextRegistrationGeneration++
 
 	record := DaemonSessionRecord{
 		SessionID:                 sessionID,
 		MissionID:                 strings.TrimSpace(register.MissionID),
 		TraceID:                   strings.TrimSpace(register.TraceID),
+		RegistrationGeneration:    r.nextRegistrationGeneration,
 		RootPID:                   register.RootPID,
+		RootProcessStartTimeTicks: register.RootProcessStartTimeTicks,
 		PIDNamespaceID:            register.PIDNamespaceID,
 		CgroupID:                  register.CgroupID,
 		EventClasses:              append([]string(nil), register.EventClasses...),
@@ -285,6 +352,25 @@ func daemonSessionRegistryPeerOwnsRecord(record DaemonSessionRecord, handshake D
 		record.PeerProcessStartTimeTicks == handshake.ProcessStartTimeTicks &&
 		record.PeerProcessStartTimeTicks == handshake.Authorization.ProcessStartTimeTicks &&
 		record.CredentialSource == handshake.CredentialSource
+}
+
+func daemonSessionRegistryDelegatedRootPeerOwnsRecord(record DaemonSessionRecord, observation DaemonSocketPeerObservation, authorization DaemonPeerAuthorization) bool {
+	credentials := observation.Credentials
+	if authorization.Verdict != DaemonPeerAuthorizationVerdictAllow ||
+		record.RootProcessStartTimeTicks == 0 ||
+		credentials.ProcessStartTimeTicks == 0 ||
+		authorization.ProcessStartTimeTicks == 0 {
+		return false
+	}
+	if credentials.UID != authorization.UID ||
+		credentials.GID != authorization.GID ||
+		credentials.PID != authorization.PID ||
+		credentials.ProcessStartTimeTicks != authorization.ProcessStartTimeTicks {
+		return false
+	}
+	return record.RootPID == authorization.PID &&
+		record.RootProcessStartTimeTicks == authorization.ProcessStartTimeTicks &&
+		record.CredentialSource == observation.CredentialSource
 }
 
 func (r *DaemonSessionRegistry) currentTime() time.Time {

--- a/go/pkg/kernelcapture/daemon_session_registry_test.go
+++ b/go/pkg/kernelcapture/daemon_session_registry_test.go
@@ -37,7 +37,7 @@ func TestDaemonSessionRegistryRegistersStatusesAndEndsSession(t *testing.T) {
 	if record.SessionID != "session-1" || record.MissionID != "mission-1" || record.TraceID != "trace-1" {
 		t.Fatalf("record identity = %#v", record)
 	}
-	if record.RootPID != 1234 || record.PIDNamespaceID != 42 || record.CgroupID != 99 {
+	if record.RootPID != 1234 || record.RootProcessStartTimeTicks != 800001 || record.PIDNamespaceID != 42 || record.CgroupID != 99 {
 		t.Fatalf("record process identity = %#v", record)
 	}
 	if len(record.EventClasses) != 1 || record.EventClasses[0] != DaemonProtocolEventProcessLifecycle {
@@ -243,6 +243,155 @@ func TestDaemonSessionRegistryRejectsEndSessionBySamePIDDifferentProcessStartTim
 	ended := registry.HandleAuthorizedRequest(context.Background(), daemonEndSessionRequest("session-end-pid-reuse"), owner)
 	if !ended.OK || ended.Status != DaemonSessionStatusEnded {
 		t.Fatalf("owner end response = %#v", ended)
+	}
+}
+
+func TestDaemonSessionRegistryDelegatesOnlyToRegisteredRootProcessIdentity(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDaemonSessionRegistry()
+	owner := daemonSessionRegistryTestHandshake("session-delegated-root")
+	register := daemonRegisterSessionRequest("session-delegated-root", 7777, 60)
+	register.RegisterSession.RootProcessStartTimeTicks = 700001
+	if response := registry.HandleAuthorizedRequest(context.Background(), register, owner); !response.OK {
+		t.Fatalf("register response = %#v", response)
+	}
+
+	observation := DaemonSocketPeerObservation{
+		Credentials: DaemonObservedPeerCredentials{
+			UID:                   owner.Authorization.UID,
+			GID:                   owner.Authorization.GID,
+			PID:                   7777,
+			ProcessStartTimeTicks: 700001,
+		},
+		CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+		SocketPath:       "/run/ardur/kernelcapture/seccomp.sock",
+	}
+	authorization := DaemonPeerAuthorization{
+		Verdict:               DaemonPeerAuthorizationVerdictAllow,
+		Reason:                "observed peer uid is explicitly allowed",
+		UID:                   observation.Credentials.UID,
+		GID:                   observation.Credentials.GID,
+		PID:                   observation.Credentials.PID,
+		ProcessStartTimeTicks: observation.Credentials.ProcessStartTimeTicks,
+		Matched:               "uid",
+	}
+	if _, err := registry.ActiveSessionForDelegatedRootPeer("session-delegated-root", observation, authorization); err != nil {
+		t.Fatalf("registered delegated root peer rejected: %v", err)
+	}
+	setIDObservation := observation
+	setIDObservation.Credentials.UID = 0
+	setIDObservation.Credentials.GID = 0
+	setIDAuthorization := authorization
+	setIDAuthorization.UID = 0
+	setIDAuthorization.GID = 0
+	setIDAuthorization.Reason = "set-ID root process is independently allowed"
+	if _, err := registry.ActiveSessionForDelegatedRootPeer("session-delegated-root", setIDObservation, setIDAuthorization); err != nil {
+		t.Fatalf("independently authorized set-ID root peer rejected: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*DaemonSocketPeerObservation, *DaemonPeerAuthorization)
+	}{
+		{name: "sibling pid", mutate: func(obs *DaemonSocketPeerObservation, auth *DaemonPeerAuthorization) {
+			obs.Credentials.PID++
+			auth.PID++
+		}},
+		{name: "reused root pid", mutate: func(obs *DaemonSocketPeerObservation, auth *DaemonPeerAuthorization) {
+			obs.Credentials.ProcessStartTimeTicks++
+			auth.ProcessStartTimeTicks++
+		}},
+		{name: "different credential source", mutate: func(obs *DaemonSocketPeerObservation, _ *DaemonPeerAuthorization) {
+			obs.CredentialSource = "client_claim"
+		}},
+		{name: "observation authorization mismatch", mutate: func(_ *DaemonSocketPeerObservation, auth *DaemonPeerAuthorization) {
+			auth.PID++
+		}},
+		{name: "denied authorization", mutate: func(_ *DaemonSocketPeerObservation, auth *DaemonPeerAuthorization) {
+			auth.Verdict = DaemonPeerAuthorizationVerdictDeny
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changedObservation := observation
+			changedAuthorization := authorization
+			tc.mutate(&changedObservation, &changedAuthorization)
+			if _, err := registry.ActiveSessionForDelegatedRootPeer("session-delegated-root", changedObservation, changedAuthorization); err == nil {
+				t.Fatal("different delegated root identity accepted")
+			}
+		})
+	}
+}
+
+func TestDaemonSessionRegistryDelegatedRootRevalidationRejectsReplacementRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDaemonSessionRegistry()
+	owner := daemonSessionRegistryTestHandshake("session-replaced-during-handoff")
+	register := daemonRegisterSessionRequest("session-replaced-during-handoff", 7777, 60)
+	register.RegisterSession.RootProcessStartTimeTicks = 700001
+	register.RegisterSession.CgroupID = 9001
+	if response := registry.HandleAuthorizedRequest(context.Background(), register, owner); !response.OK {
+		t.Fatalf("initial register response = %#v", response)
+	}
+
+	observation := DaemonSocketPeerObservation{
+		Credentials: DaemonObservedPeerCredentials{
+			UID:                   owner.Authorization.UID,
+			GID:                   owner.Authorization.GID,
+			PID:                   7777,
+			ProcessStartTimeTicks: 700001,
+		},
+		CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+		SocketPath:       "/run/ardur/kernelcapture/seccomp.sock",
+	}
+	authorization := DaemonPeerAuthorization{
+		Verdict:               DaemonPeerAuthorizationVerdictAllow,
+		UID:                   observation.Credentials.UID,
+		GID:                   observation.Credentials.GID,
+		PID:                   observation.Credentials.PID,
+		ProcessStartTimeTicks: observation.Credentials.ProcessStartTimeTicks,
+		Matched:               "uid",
+	}
+	first, err := registry.ActiveSessionForDelegatedRootPeer(register.RegisterSession.SessionID, observation, authorization)
+	if err != nil {
+		t.Fatalf("initial delegated root lookup: %v", err)
+	}
+	if first.RegistrationGeneration == 0 {
+		t.Fatal("initial registration generation is zero")
+	}
+
+	if response := registry.HandleAuthorizedRequest(context.Background(), daemonEndSessionRequest(register.RegisterSession.SessionID), owner); !response.OK {
+		t.Fatalf("end initial registration response = %#v", response)
+	}
+	replacement := daemonRegisterSessionRequest(register.RegisterSession.SessionID, 7777, 60)
+	replacement.RegisterSession.RootProcessStartTimeTicks = 700001
+	replacement.RegisterSession.CgroupID = 9002
+	if response := registry.HandleAuthorizedRequest(context.Background(), replacement, owner); !response.OK {
+		t.Fatalf("replacement register response = %#v", response)
+	}
+	second, err := registry.ActiveSessionForDelegatedRootPeer(replacement.RegisterSession.SessionID, observation, authorization)
+	if err != nil {
+		t.Fatalf("replacement delegated root lookup: %v", err)
+	}
+	if second.RegistrationGeneration == first.RegistrationGeneration {
+		t.Fatalf("replacement registration generation = %d, want distinct from %d", second.RegistrationGeneration, first.RegistrationGeneration)
+	}
+	if second.CgroupID == first.CgroupID {
+		t.Fatalf("replacement cgroup = %d, want distinct from stale cgroup %d", second.CgroupID, first.CgroupID)
+	}
+
+	if _, err := registry.ActiveSessionForDelegatedRootPeerGeneration(replacement.RegisterSession.SessionID, observation, authorization, first.RegistrationGeneration); err == nil {
+		t.Fatal("stale handoff generation accepted replacement registration")
+	}
+	if _, err := registry.ActiveSessionForDelegatedRootPeerGeneration(replacement.RegisterSession.SessionID, observation, authorization, second.RegistrationGeneration); err != nil {
+		t.Fatalf("current handoff generation rejected: %v", err)
+	}
+	if _, err := registry.ActiveSessionGeneration(replacement.RegisterSession.SessionID, first.RegistrationGeneration); err == nil {
+		t.Fatal("stale long-lived work generation accepted replacement registration")
+	}
+	if _, err := registry.ActiveSessionGeneration(replacement.RegisterSession.SessionID, second.RegistrationGeneration); err != nil {
+		t.Fatalf("current long-lived work generation rejected: %v", err)
 	}
 }
 
@@ -475,11 +624,12 @@ func daemonRegisterSessionRequest(sessionID string, rootPID uint32, ttlSeconds i
 		ProtocolVersion: DaemonProtocolVersion,
 		Method:          DaemonProtocolMethodRegisterSession,
 		RegisterSession: &DaemonRegisterSessionRequest{
-			SessionID:    sessionID,
-			RootPID:      rootPID,
-			CgroupID:     9001,
-			EventClasses: []string{DaemonProtocolEventProcessLifecycle},
-			TTLSeconds:   ttlSeconds,
+			SessionID:                 sessionID,
+			RootPID:                   rootPID,
+			RootProcessStartTimeTicks: 800001,
+			CgroupID:                  9001,
+			EventClasses:              []string{DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:                ttlSeconds,
 		},
 	}
 }

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "17e8b18547dd9b50dbec283c6e562606d1cdb17d7cc591247ba720845e2db9d3"
+source_sha256: "260f8866016abcb956db38cd9ecd87bdd8f6a15dcdc0a5eedca44ccb080a0e1f"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -22,6 +22,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Bind each seccomp listener handoff to the registered root process's
+  daemon-observed PID/start-time identity instead of accepting any peer on the
+  daemon-wide UID/GID allowlist
 - Serialize the Linux daemon's BPF policy-map handle lifetime so startup,
   health, in-flight mutations, tier withdrawal, and close cannot race
 - Make the Linux cgroup-ownership verifier independently fail closed when a

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "f042c10a9495d5f353843d0f40540a919e7496b020e14547c0d0bef8b3fdc9e6"
+source_sha256: "e0e4e0dd5c641878bfbebbe8a98a98208a9b2fdc89e5850598aa69d3325fc521"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -150,6 +150,28 @@ its clients (normally the host/ancestor namespace, with a matching procfs
 mount). A topology that cannot map the peer PID is rejected rather than granted
 unverified cgroup-enforcement rights; there is no implicit cross-namespace
 bypass.
+
+For non-root registration, the daemon also reads `root_pid`'s process start time
+from `/proc/<root_pid>/stat` before and after those ownership checks and retains
+the stable value; the already-privileged root path records one such observation.
+This is distinct from the control-socket owner: the launcher registers the
+session, then its PID-preserving child execs into `ardur-exec-shim`. The seccomp
+handoff therefore requires the independently authorized handoff peer's
+`SO_PEERCRED` PID and separately observed `/proc` start time to match that
+registered root identity before the daemon acknowledges or supervises the
+transferred listener. PID plus clock-tick start time hardens numeric PID reuse
+but is not a pidfd task handle. `SCM_RIGHTS` transfers the listener reference;
+it does not by itself establish Ardur session ownership. Immediately after
+reserving the listener, the daemon revalidates both that root identity and an
+immutable daemon-local registration generation, so an ended session cannot be
+silently replaced under the same `session_id` while a handoff is in flight. A
+shared lifecycle barrier also keeps register, end, and expiry transitions from
+interleaving with handoff acknowledgement or notification decisions. Listener
+entries and cleanup carry that generation, so a late supervisor exit from an
+older registration cannot remove a replacement listener. Each accepted
+registration also clears the reusable session ID's prior seccomp policy, and
+policy publication holds the same lifecycle read barrier, preventing an
+in-flight apply from crossing into a replacement generation.
 
 If startup reconciliation itself fails, the daemon leaves filtering disabled
 and continues the prior permissive capture behavior rather than enabling a


### PR DESCRIPTION
## Summary

- bind seccomp listener handoff to the independently authorized, daemon-observed registered root process rather than the registering launcher or daemon-wide UID/GID membership alone
- capture root PID start-time identity during registration and preserve an immutable daemon-local registration generation
- serialize handoff, notification evidence, policy publication, register, end, and expiry transitions so reused session IDs cannot inherit stale listeners, policy, cgroup attribution, or cleanup
- reject truncated/multi-FD ancillary handoffs and preserve the exported process observer on unsupported platforms
- make the privileged smoke use real live shim roots and require exact ECONNREFUSED for the allowed control

## Corrected ownership model

The issue's original `ActiveSessionForPeer` suggestion would reject production: the Python launcher registers the session, while its PID-preserving child execs into `ardur-exec-shim` and transfers the listener. The shim is the registered `RootPID`, not the registry owner.

The implemented gate therefore requires the authorized handoff observation to match the daemon-captured root PID, `/proc/<pid>/stat` start ticks, and credential source. UID/GID equality with the registrar is intentionally not required, preserving a separately authorized set-ID shim.

Impact is conditional: an already allowed local peer must know a live session ID and win the pre-handoff race. Under the default allowlist this is logical cross-tenant isolation between runs sharing an authorized OS identity, not arbitrary cross-user access.

Primary sources:

- Linux [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html) for `SO_PEERCRED`, `SCM_RIGHTS`, and ancillary truncation semantics
- kernel [seccomp user-notification documentation](https://docs.kernel.org/userspace-api/seccomp_filter.html) for listener/filter scope
- Linux [`proc_pid_stat(5)`](https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html) for process start-time field 22
- Linux [`pid_namespaces(7)`](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html) for daemon-view PID identity constraints

Decision record: https://app.notion.com/p/39b2637edb07811ba91dfd13bff48ff8

## Organic regression coverage

- real authorized sibling process + real seccomp filter + real `SCM_RIGHTS` is rejected for another session
- exact registered live root process is accepted
- PID reuse, credential-source mismatch, observation/authorization mismatch, and denied authorization reject
- same-ID/same-root replacement with different cgroup receives a new registration generation; stale generation rejects
- stale supervisor cleanup cannot delete a replacement-generation listener
- replacement registration clears prior-generation listener and session-ID policy state
- stalled prior-generation policy apply cannot cross end/replacement
- bounded real handoff receive blocks lifecycle writers through rejection/response
- real trapped TCP notification blocks actual `end_session` until kernel response and evidence handling complete
- multi-FD `SCM_RIGHTS` rejects and closes received descriptors; `MSG_CTRUNC` rejects

## Verification

- Linux Go 1.26.5: `go test -race -count=1 ./...`, `go vet ./...`, `go build ./...`
- focused daemon/registry race tests as UID 65534; final real-notification test passed 10 consecutive review iterations
- Darwin arm64 and amd64 compile-only daemon/registry tests
- fresh Python 3.13 suite: 1,770 passed, 33 skipped
- final privileged seccomp smoke: 20 consecutive runs, exact EPERM deny and ECONNREFUSED allow; earlier implementation loops also passed
- fresh full `ardur run` seccomp E2E: enforce one denial, permissive zero denied verdicts, both chains intact and attestation digests matched
- 112 source pages/mirrors, 10 claim checks, quick publication hygiene, Hugo 282 pages / 115 static files
- Lychee 494 links / 0 errors; Gitleaks 8.30.1 scanned 506 commits / 13.52 MB with no leaks
- `govulncheck` 1.1.4: zero called/imported-package vulnerabilities; one required-module advisory is unreachable
- two final independent adversarial reviews: clean

Docker Desktop does not expose `/dev/kvm`; the native BPF-LSM kernel smoke remains a required CI merge gate. CodeRabbit CLI is unavailable, so review was manual. Semgrep was not used.

The separately reproduced numeric-FD cancellation double-close remains scoped to #278.

Closes #260
