### PR TITLE
fix: canonicalize local workspace scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,10 @@ It gives three bounded paths:
   it shows one local `ASK` outcome (Claude Code's normal permission flow stays
   in charge), three pre-dispatch denials for outside-workspace, secret-like,
   and network requests, and four verified signed receipt summaries without an
-  API key or retained demo state;
+  API key or retained demo state. Absolute local scope paths are canonicalized
+  before a permit so a symlinked path cannot redirect outside the workspace;
+  this hook-only check does not prove hard-link identity or prevent a path from
+  changing between the decision and the tool's later filesystem operation;
 - a **60-second deliberate deny proof** using
   `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
   adapter, verifies a signed violation receipt, checks an unchanged canary, and

--- a/docs/guides/ardur-personal-hub.md
+++ b/docs/guides/ardur-personal-hub.md
@@ -82,7 +82,9 @@ complete release artifact.
 
 - `personal-firewall`: allows reads and edits inside the protected folder,
   denies shell and external network tools, blocks common secret-like argument
-  markers, and caps the signed session at 40 governed tool calls.
+  markers, and caps the signed session at 40 governed tool calls. Absolute local
+  paths are canonicalized before the scope decision, so an in-folder symlink
+  that resolves outside is denied.
 - `read-only`: review code without editing files or running commands.
 - `safe-coding`: edit files inside the protected folder, but block shell
   commands.
@@ -98,7 +100,9 @@ The personal session cap is an action budget, not a provider-billing estimate.
 A dollar-denominated cap requires trusted signed cost telemetry from the
 provider adapter. Secret markers are conservative patterns, not universal data
 loss prevention, and allowed actions still pass through the agent's native
-permission flow.
+permission flow. The scope receipt is pre-dispatch path evidence: it cannot
+distinguish a hard-link alias or prevent a path component from being replaced
+between the check and Claude Code's later filesystem operation.
 
 For source installs, `pip install -e python/` installs Ardur's required Python
 dependencies from `python/pyproject.toml`. The development Homebrew formula is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -882,6 +882,13 @@ the agent's native permission flow (`ASK`), while an outside-workspace write, a
 secret-like argument, and external network access are denied. It then verifies
 the four signed receipts as one hash-linked chain and removes temporary state.
 
+For absolute local scope roots, the pre-dispatch resource check canonicalizes
+the candidate and scope root before permitting the action. This rejects an
+in-workspace symbolic-link path that resolves outside the protected folder,
+including a symbolic-link parent of a not-yet-created output. The hook does not
+perform the eventual filesystem operation, so hard-link aliases and a path
+component changed after the check remain outside this evidence boundary.
+
 The JSON result includes readable decisions, receipt counts, verification
 guidance, and an explicit cost boundary. The enforced session budget is measured
 in governed tool calls. `monetary_cost` is

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -142,7 +142,10 @@ profile is a friendly layer over the same capabilities, not a replacement.
 1. `PreToolUse` fires.
 2. Ardur maps the Claude Code tool input into declared telemetry.
 3. Ardur checks the active Mission Passport: allowed tools, forbidden tools,
-   resource scope, cwd, and relevant policy backends.
+   resource scope, cwd, and relevant policy backends. Absolute local scope
+   paths are canonicalized so an in-scope symlink that resolves outside is
+   denied. This pre-dispatch check cannot distinguish hard-link aliases or
+   prevent path replacement before the tool's later filesystem operation.
 4. If permitted, Ardur appends a compliant receipt and lets Claude Code continue
    its normal permission flow.
 5. If denied, Ardur appends a violation receipt and returns

--- a/python/README.md
+++ b/python/README.md
@@ -49,7 +49,10 @@ The provider-free demo preserves the agent's normal permission prompt for a
 safe workspace read, denies outside-workspace writes, secret-like arguments,
 and external network access, then verifies the signed receipt chain. Its
 session cap is measured in governed tool calls; monetary cost remains unknown
-unless an adapter supplies trusted signed cost telemetry.
+unless an adapter supplies trusted signed cost telemetry. Absolute local scope
+paths are canonicalized before a permit, which rejects symlink escapes; the
+pre-dispatch hook still cannot prove hard-link identity or prevent post-check
+path replacement before the tool opens the path.
 
 Every durable receipt sink also queues an idempotent local transparency-anchor
 sidecar. Network submission is a separate `ardur anchor` operation, and

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -112,6 +112,55 @@ def test_direct_hook_enforces_cumulative_signed_tool_call_budget(tmp_path, monke
     )
 
 
+def test_direct_hook_denies_workspace_symlink_escape_and_signs_violation(
+    tmp_path, monkeypatch
+):
+    from vibap.claude_code_hook import handle_pre_tool_use
+    from vibap.claude_code_report import build_claude_code_report
+
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (workspace / "escape").symlink_to(outside, target_is_directory=True)
+    keys = tmp_path / "keys"
+    private_key, _public_key = generate_keypair(keys_dir=keys)
+    mission = MissionPassport(
+        agent_id="personal-scope",
+        mission="keep writes inside the configured workspace",
+        allowed_tools=["Write"],
+        resource_scope=[str(workspace), f"{workspace}/*"],
+        cwd=str(workspace),
+        max_tool_calls=10,
+        max_duration_s=600,
+    )
+    token = issue_passport(mission, private_key, ttl_s=600)
+    chain_dir = tmp_path / "chains"
+    monkeypatch.setenv("ARDUR_MISSION_PASSPORT", token)
+    monkeypatch.setenv("ARDUR_CC_HOOK_DIR", str(chain_dir))
+    monkeypatch.setenv("ARDUR_TRACE_ID", "personal-scope")
+
+    output = handle_pre_tool_use(
+        _pre_hook_input(
+            tool_name="Write",
+            tool_input={
+                "file_path": str(workspace / "escape" / "stolen.txt"),
+                "content": "must stay local\n",
+            },
+            suffix="symlink-escape",
+        ),
+        keys_dir=keys,
+    )
+
+    assert "resolves outside resource_scope" in _deny_reason(output)
+    assert not (outside / "stolen.txt").exists()
+    report = build_claude_code_report(chain_dir=chain_dir, keys_dir=keys)
+    assert report["totals"]["verdicts"] == {"violation": 1}
+    assert report["chains"][0]["actions"][0]["policies"] == [
+        {"backend": "native", "decision": "Deny"}
+    ]
+
+
 def test_direct_hook_composes_signed_forbid_rules_policy(tmp_path, monkeypatch):
     from vibap.claude_code_hook import handle_pre_tool_use
     from vibap.claude_code_report import build_claude_code_report

--- a/python/tests/test_personal_firewall.py
+++ b/python/tests/test_personal_firewall.py
@@ -29,6 +29,9 @@ def test_provider_free_personal_firewall_demo_is_verified_and_private(
         "unavailable_without_signed_adapter_data"
     )
     assert result["temporary_state_removed"] is True
+    assert "canonical path checking" in result["evidence_boundary"]
+    assert "hard-link aliases" in result["evidence_boundary"]
+    assert "post-check filesystem races" in result["evidence_boundary"]
     assert str(tmp_path) not in json.dumps(result, sort_keys=True)
     assert list(tmp_path.iterdir()) == []
 

--- a/python/tests/test_proxy.py
+++ b/python/tests/test_proxy.py
@@ -16,6 +16,85 @@ from vibap.proxy import Decision, _check_resource_scope, _sanitize_value
 
 
 class TestResourceScopeSecurity:
+    def test_existing_symlink_escape_is_rejected_after_lexical_match(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        (workspace / "escape").symlink_to(outside, target_is_directory=True)
+
+        ok, reason = _check_resource_scope(
+            {"file_path": str(workspace / "escape" / "stolen.txt")},
+            resource_scope=[str(workspace), f"{workspace}/*"],
+            cwd=str(workspace),
+        )
+
+        assert not ok
+        assert "resolves outside resource_scope" in reason
+
+    def test_relative_symlink_escape_is_rejected_against_declared_cwd(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        (workspace / "escape").symlink_to(outside, target_is_directory=True)
+
+        ok, reason = _check_resource_scope(
+            {"file_path": "escape/stolen.txt"},
+            resource_scope=[str(workspace), f"{workspace}/*"],
+            cwd=str(workspace),
+        )
+
+        assert not ok
+        assert "resolves outside resource_scope" in reason
+
+    def test_dangling_symlink_escape_is_rejected_for_future_output(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "escape").symlink_to(
+            tmp_path / "outside" / "missing", target_is_directory=True
+        )
+
+        ok, reason = _check_resource_scope(
+            {"file_path": str(workspace / "escape" / "future.txt")},
+            resource_scope=[str(workspace), f"{workspace}/*"],
+            cwd=str(workspace),
+        )
+
+        assert not ok
+        assert "resolves outside resource_scope" in reason
+
+    def test_symlink_loop_fails_closed_after_lexical_match(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "loop").symlink_to(
+            workspace / "loop", target_is_directory=True
+        )
+
+        ok, reason = _check_resource_scope(
+            {"file_path": str(workspace / "loop" / "future.txt")},
+            resource_scope=[str(workspace), f"{workspace}/*"],
+            cwd=str(workspace),
+        )
+
+        assert not ok
+        assert "canonical path resolution failed" in reason
+
+    def test_symlink_that_resolves_within_scope_remains_permitted(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        target = workspace / "target"
+        target.mkdir(parents=True)
+        (workspace / "alias").symlink_to(target, target_is_directory=True)
+
+        ok, reason = _check_resource_scope(
+            {"file_path": str(workspace / "alias" / "future.txt")},
+            resource_scope=[str(workspace), f"{workspace}/*"],
+            cwd=str(workspace),
+        )
+
+        assert ok
+        assert reason == ""
+
     def test_path_hint_list_wrapped_bare_value_is_scope_checked(self):
         ok, reason = _check_resource_scope(
             {"directory": ["hr"]},

--- a/python/vibap/personal_firewall.py
+++ b/python/vibap/personal_firewall.py
@@ -352,7 +352,9 @@ def run_personal_firewall_demo(
         "verification": report["verification"],
         "temporary_state_removed": True,
         "evidence_boundary": (
-            "configured local Claude Code tool-boundary proof; not provider-hidden, "
+            "configured local Claude Code pre-dispatch tool-boundary proof with "
+            "canonical path checking; hard-link aliases and post-check filesystem "
+            "races remain outside this hook-only evidence, which is not provider-hidden, "
             "kernel, universal secret-detection, or monetary-cost evidence"
         ),
     }

--- a/python/vibap/proxy.py
+++ b/python/vibap/proxy.py
@@ -959,6 +959,18 @@ def _check_resource_scope(
        any relative pattern → strip leading ``/``). Coerced forms still go
        through escape-check via re-sanitization so coercion can never mask
        traversal.
+    4. **Local filesystem canonicalization** — after a lexical match, absolute
+       POSIX candidates matched by a simple absolute scope root (an exact path
+       or ``ROOT/*``) are resolved with ``realpath`` and compared with the
+       resolved root. This rejects existing and dangling symlink-parent escapes
+       while leaving URL, Windows-path, and intentionally generic glob
+       semantics unchanged.
+
+    Canonical pathname comparison is a pre-dispatch check, not an inode-bound
+    filesystem operation. It cannot distinguish hard-link aliases or prevent a
+    path component from being swapped after this check and before the tool
+    opens it. Callers must disclose that residual boundary rather than treating
+    a PERMIT as kernel-enforced containment.
     """
     if not resource_scope:
         # No scope declared — legacy "unrestricted" semantics. PERMIT.
@@ -1008,6 +1020,80 @@ def _check_resource_scope(
     def _matches_any(candidate: str) -> bool:
         return any(fnmatch.fnmatchcase(candidate, pat) for pat in nfc_patterns)
 
+    def _simple_local_scope_pattern(pattern: str) -> tuple[str, bool] | None:
+        """Return ``(root, includes_descendants)`` for canonicalizable patterns.
+
+        Scope values also support URLs, Windows paths, relative strings, and
+        arbitrary globs. ``realpath`` is meaningful only for absolute local
+        POSIX roots, so canonical enforcement is deliberately limited to the
+        exact-root and ``ROOT/*`` shapes emitted by the personal-firewall and
+        governed-run setup paths.
+        """
+
+        if not pattern.startswith("/") or _URL_SCHEME_RE.match(pattern):
+            return None
+        includes_descendants = pattern == "/*" or pattern.endswith("/*")
+        root = pattern[:-2] if includes_descendants else pattern
+        root = root or "/"
+        if any(char in root for char in "*?["):
+            return None
+        return root, includes_descendants
+
+    def _canonical_local_path(path: str) -> str:
+        """Resolve links while allowing only genuinely missing path suffixes.
+
+        ``realpath`` without ``strict`` can also suppress permission, loop, and
+        non-directory errors, potentially returning a path that still contains
+        links. Strict resolution fails closed on those conditions. A missing
+        output is expected for write tools, so only ``FileNotFoundError`` gets
+        the non-strict fallback that resolves every existing prefix.
+        """
+
+        try:
+            return os.path.realpath(path, strict=True)
+        except FileNotFoundError:
+            return os.path.realpath(path)
+
+    local_scope_patterns = [
+        (pattern, parsed)
+        for pattern in nfc_patterns
+        if (parsed := _simple_local_scope_pattern(pattern)) is not None
+    ]
+    resolved_scope_roots: dict[str, str] = {}
+
+    def _resolved_local_match(candidate: str) -> tuple[bool, str | None]:
+        """Re-check a lexical local-path match against canonical scope roots."""
+
+        if not candidate.startswith("/") or _URL_SCHEME_RE.match(candidate):
+            return True, None
+        matched_local_patterns = [
+            (pattern, parsed)
+            for pattern, parsed in local_scope_patterns
+            if fnmatch.fnmatchcase(candidate, pattern)
+        ]
+        if not matched_local_patterns:
+            return True, None
+        try:
+            resolved_candidate = _canonical_local_path(candidate)
+        except (OSError, ValueError) as exc:
+            return False, f"canonical path resolution failed: {exc}"
+
+        for _pattern, (root, includes_descendants) in matched_local_patterns:
+            resolved_root = resolved_scope_roots.get(root)
+            if resolved_root is None:
+                try:
+                    resolved_root = _canonical_local_path(root)
+                except (OSError, ValueError) as exc:
+                    return False, f"scope root resolution failed: {exc}"
+                resolved_scope_roots[root] = resolved_root
+            if resolved_candidate == resolved_root:
+                return True, None
+            if includes_descendants and resolved_candidate.startswith(
+                resolved_root.rstrip("/") + "/"
+            ):
+                return True, None
+        return False, "resolves outside resource_scope after canonical path checking"
+
     def _preview(s: str) -> str:
         return s if len(s) <= 120 else s[:117] + "..."
 
@@ -1047,23 +1133,26 @@ def _check_resource_scope(
                     f"resource '{_preview(token)}' rejected: {error_reason}"
                 )
 
-            if _matches_any(normalized):
-                continue
-
             token_is_absolute = (
                 normalized.startswith("/")
                 or bool(_URL_SCHEME_RE.match(normalized))
                 or bool(_WINDOWS_DRIVE_RE.match(normalized))
             )
 
-            matched = False
+            matched_candidate: str | None = (
+                normalized if _matches_any(normalized) else None
+            )
 
             # cwd resolution (C8): if a cwd is declared and the candidate is
             # relative, resolve against cwd and re-sanitize. We run the join
             # through _sanitize_value so a '..' in the candidate cannot
             # silently escape cwd (posixpath.join('/workspace', '../etc')
             # would normalize to '/etc' without the check).
-            if cwd_anchor is not None and not token_is_absolute:
+            if (
+                matched_candidate is None
+                and cwd_anchor is not None
+                and not token_is_absolute
+            ):
                 joined_raw = posixpath.join(cwd_anchor, normalized)
                 joined, join_err = _sanitize_value(joined_raw)
                 if join_err is None:
@@ -1073,7 +1162,7 @@ def _check_resource_scope(
                     # depth against any future helper change.
                     if joined == cwd_anchor or joined.startswith(cwd_anchor.rstrip("/") + "/"):
                         if _matches_any(joined):
-                            matched = True
+                            matched_candidate = joined
 
             # Fallback: two-way absolute/relative coercion (partial CC-2 fix).
             # Claude Code and similar clients sometimes send './in_scope/file'
@@ -1082,22 +1171,33 @@ def _check_resource_scope(
             # original value (already denied above) cannot sneak through,
             # and more importantly the sanitizer's invariants hold on the
             # shape we're actually matching.
-            if not matched and not token_is_absolute and any_absolute:
+            if matched_candidate is None and not token_is_absolute and any_absolute:
                 coerced_raw = "/" + normalized
                 coerced, coerce_err = _sanitize_value(coerced_raw)
                 if coerce_err is None and _matches_any(coerced):
-                    matched = True
+                    matched_candidate = coerced
 
-            if not matched and token_is_absolute and any_relative and normalized.startswith("/"):
+            if (
+                matched_candidate is None
+                and token_is_absolute
+                and any_relative
+                and normalized.startswith("/")
+            ):
                 coerced_raw = normalized.lstrip("/")
                 if coerced_raw:
                     coerced, coerce_err = _sanitize_value(coerced_raw)
                     if coerce_err is None and _matches_any(coerced):
-                        matched = True
+                        matched_candidate = coerced
 
-            if not matched:
+            if matched_candidate is None:
                 return False, (
                     f"resource '{_preview(token)}' is outside resource_scope {patterns}"
+                )
+
+            resolved_ok, resolved_reason = _resolved_local_match(matched_candidate)
+            if not resolved_ok:
+                return False, (
+                    f"resource '{_preview(token)}' rejected: {resolved_reason}"
                 )
 
     if exhausted["v"]:

--- a/site/content/source/README.md
+++ b/site/content/source/README.md
@@ -2,7 +2,7 @@
 title: "Ardur"
 description: "Ardur governs AI-agent tool calls that pass through a configured adapter or"
 source_path: "README.md"
-source_sha256: "ebbf908d76d9586cf8c8b6d6e397d44b1b35ad9c10c7e8f2ac13b469aa9ab4d9"
+source_sha256: "e6f03443561870522c580dcb95d8f9a799c3189cbaea3e8ebc64eff4cae3cb69"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["orientation", "runtime-boundary"]
@@ -167,7 +167,10 @@ It gives three bounded paths:
   it shows one local `ASK` outcome (Claude Code's normal permission flow stays
   in charge), three pre-dispatch denials for outside-workspace, secret-like,
   and network requests, and four verified signed receipt summaries without an
-  API key or retained demo state;
+  API key or retained demo state. Absolute local scope paths are canonicalized
+  before a permit so a symlinked path cannot redirect outside the workspace;
+  this hook-only check does not prove hard-link identity or prevent a path from
+  changing between the decision and the tool's later filesystem operation;
 - a **60-second deliberate deny proof** using
   `python3 scripts/run-claude-deny-demo.py`; it exercises the real local hook
   adapter, verifies a signed violation receipt, checks an unchanged canary, and

--- a/site/content/source/docs/guides/ardur-personal-hub.md
+++ b/site/content/source/docs/guides/ardur-personal-hub.md
@@ -2,7 +2,7 @@
 title: "Ardur Personal Hub"
 description: "Ardur Personal is the local product shape for regular users. It protects local"
 source_path: "docs/guides/ardur-personal-hub.md"
-source_sha256: "490b533e71e496575c11120e0066134d6438ad64242df718e2cda033ca6dc1b3"
+source_sha256: "a9620e5a0b61553cf4340f1c3a2b38c96b26e9e383311376a12d6b224b8b1610"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -99,7 +99,9 @@ complete release artifact.
 
 - `personal-firewall`: allows reads and edits inside the protected folder,
   denies shell and external network tools, blocks common secret-like argument
-  markers, and caps the signed session at 40 governed tool calls.
+  markers, and caps the signed session at 40 governed tool calls. Absolute local
+  paths are canonicalized before the scope decision, so an in-folder symlink
+  that resolves outside is denied.
 - `read-only`: review code without editing files or running commands.
 - `safe-coding`: edit files inside the protected folder, but block shell
   commands.
@@ -115,7 +117,9 @@ The personal session cap is an action budget, not a provider-billing estimate.
 A dollar-denominated cap requires trusted signed cost telemetry from the
 provider adapter. Secret markers are conservative patterns, not universal data
 loss prevention, and allowed actions still pass through the agent's native
-permission flow.
+permission flow. The scope receipt is pre-dispatch path evidence: it cannot
+distinguish a hard-link alias or prevent a path component from being replaced
+between the check and Claude Code's later filesystem operation.
 
 For source installs, `pip install -e python/` installs Ardur's required Python
 dependencies from `python/pyproject.toml`. The development Homebrew formula is

--- a/site/content/source/docs/reference/cli.md
+++ b/site/content/source/docs/reference/cli.md
@@ -2,7 +2,7 @@
 title: "ardur` CLI Reference"
 description: "The `ardur` console entry point ships with the Python package. After"
 source_path: "docs/reference/cli.md"
-source_sha256: "073492c0669bd41c70361454562c4f2b650dac95273a3d1c08b71f4a5e79852c"
+source_sha256: "f7050ff1acf488b557e62eaeb77b4a1bc267545a138949009f4d8479883d0649"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -898,6 +898,13 @@ state. It proves four pre-action decisions: a workspace read remains subject to
 the agent's native permission flow (`ASK`), while an outside-workspace write, a
 secret-like argument, and external network access are denied. It then verifies
 the four signed receipts as one hash-linked chain and removes temporary state.
+
+For absolute local scope roots, the pre-dispatch resource check canonicalizes
+the candidate and scope root before permitting the action. This rejects an
+in-workspace symbolic-link path that resolves outside the protected folder,
+including a symbolic-link parent of a not-yet-created output. The hook does not
+perform the eventual filesystem operation, so hard-link aliases and a path
+component changed after the check remain outside this evidence boundary.
 
 The JSON result includes readable decisions, receipt counts, verification
 guidance, and an explicit cost boundary. The enforced session budget is measured

--- a/site/content/source/plugins/claude-code/README.md
+++ b/site/content/source/plugins/claude-code/README.md
@@ -2,7 +2,7 @@
 title: "Ardur Claude Code Plugin"
 description: "This plugin protects Claude Code at the local tool boundary. `PreToolUse` runs"
 source_path: "plugins/claude-code/README.md"
-source_sha256: "3861b480f43df0140bf783bb1c266aec4da76ffb3d15b25b3ddf7543458564de"
+source_sha256: "6b2409fc4a2922a12845c00cb61695025f712585d0be751327fa59a4de77e484"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -159,7 +159,10 @@ profile is a friendly layer over the same capabilities, not a replacement.
 1. `PreToolUse` fires.
 2. Ardur maps the Claude Code tool input into declared telemetry.
 3. Ardur checks the active Mission Passport: allowed tools, forbidden tools,
-   resource scope, cwd, and relevant policy backends.
+   resource scope, cwd, and relevant policy backends. Absolute local scope
+   paths are canonicalized so an in-scope symlink that resolves outside is
+   denied. This pre-dispatch check cannot distinguish hard-link aliases or
+   prevent path replacement before the tool's later filesystem operation.
 4. If permitted, Ardur appends a compliant receipt and lets Claude Code continue
    its normal permission flow.
 5. If denied, Ardur appends a violation receipt and returns

--- a/site/content/source/python/README.md
+++ b/site/content/source/python/README.md
@@ -2,7 +2,7 @@
 title: "Ardur — Python Reference Implementation"
 description: "The public Python runtime for Ardur lives here: a runtime governance and evidence layer for AI agents that issues signed mission passports, enforces them at execution time, and rec"
 source_path: "python/README.md"
-source_sha256: "f02999af282102ee963ff382e238870502a9e416a62c6af3c578a5e8bd61595c"
+source_sha256: "fb1e7413963f946bc28dc657804c0ba860d6009d2079252bd2f2b2e19254bc47"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -66,7 +66,10 @@ The provider-free demo preserves the agent's normal permission prompt for a
 safe workspace read, denies outside-workspace writes, secret-like arguments,
 and external network access, then verifies the signed receipt chain. Its
 session cap is measured in governed tool calls; monetary cost remains unknown
-unless an adapter supplies trusted signed cost telemetry.
+unless an adapter supplies trusted signed cost telemetry. Absolute local scope
+paths are canonicalized before a permit, which rejects symlink escapes; the
+pre-dispatch hook still cannot prove hard-link identity or prevent post-check
+path replacement before the tool opens the path.
 
 Every durable receipt sink also queues an idempotent local transparency-anchor
 sidecar. Network submission is a separate `ardur anchor` operation, and


### PR DESCRIPTION
Closes #261.

## Summary
- canonicalize absolute POSIX candidates after the existing lexical scope match for the exact-root and ROOT/* forms emitted by personal-firewall and governed-run setup
- fail closed on symlink loops, permission errors, and non-directory resolution failures while preserving legitimate not-yet-created in-scope outputs
- record a native signed violation when an absolute or cwd-relative in-workspace symlink resolves outside the configured workspace
- keep URL, normalized Windows-path, relative-only, and arbitrary-glob semantics unchanged
- disclose the remaining hard-link alias and post-check filesystem race boundary across the demo, README, guide, CLI reference, plugin, and Python package docs

## Researched boundary
Python documents that default non-strict realpath can retain links after resolution errors, so the implementation uses strict resolution first and falls back only for FileNotFoundError: https://docs.python.org/3.13/library/os.path.html#os.path.realpath

Linux link(2) states that hard-linked names are indistinguishable aliases of the same file, so pathname canonicalization cannot prove hard-link containment: https://man7.org/linux/man-pages/man2/link.2.html

Operation-time race resistance would require the eventual opener to use controls such as openat2 RESOLVE_BENEATH/RESOLVE_NO_MAGICLINKS; this pre-tool hook does not own that open: https://man7.org/linux/man-pages/man2/openat2.2.html

Decision record: https://app.notion.com/p/39b2637edb07819daea6e2fba00db491

## Validation
- red proof: direct scope check and real Claude Code PreToolUse initially permitted the symlink-parent escape
- Python 3.10.20: 1,776 passed, 33 skipped
- Python 3.13.3: 1,776 passed, 33 skipped, 83% aggregate coverage
- focused proxy/hook/firewall: 106 passed; 11-case security matrix green on both supported Python versions
- cross-consumer HTTP/governed-run/Codex/Gemini/mission binding: 182 passed, 1 skipped
- Go 1.26.5: full tests, vet, and build passed
- source sync: 112 pages and 112 mirrors; all 10 public claims passed
- Hugo 0.161.1: 282 pages and 115 static files; rendered documentation links passed
- Lychee: 494 links, 0 errors
- Gitleaks 8.30.1: 507 commits / 13.57 MB, 0 leaks
- govulncheck 1.1.4: 0 called/imported-package vulnerabilities
- two clean final adversarial review passes; CodeRabbit CLI unavailable

Semgrep was not used. main and PR #17 were not touched.