### PR TITLE
fix(kernelcapture): drain daemon work before teardown

### DIFF
--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -28,6 +28,22 @@ consumer. A healthy socket in this mode proves control-plane liveness only; it
 does not prove that a governed process is observed or constrained below the
 tool-call boundary.
 
+## Control-plane shutdown and handler drain
+
+On SIGINT or SIGTERM, the daemon stops accepting control-socket connections,
+cancels the request context, and closes accepted Unix connections so blocked
+reads and writes return. It tracks every accepted handler and waits up to five
+seconds for those handlers to return. A handler already inside a bounded map or
+evidence operation may finish that operation; a request that has not begun its
+authorized mutation observes cancellation and stops.
+
+BPF policy maps and guard handles remain live until the handler drain is
+proven. If a non-cooperative handler outlives the five-second deadline, the
+daemon logs `control socket handler drain timed out` and deliberately skips
+explicit guard-handle teardown. Process exit then owns cleanup. This avoids
+closing a live map handle underneath the stuck handler while keeping shutdown
+bounded; it is a fail-safe exit path, not evidence that the request completed.
+
 ## Seccomp governance endpoint
 
 On a seccomp-tier `ardur run`, the network policy also traps the agent's TCP
@@ -120,10 +136,13 @@ enter Ardur's lifecycle ringbuf when no governed session exists.
 For each `register_session`, the daemon adds the verified nonzero cgroup before
 the registry can return success and before the launch gate is released. A map
 update failure rejects that registration so the enabled producer cannot omit
-the new session. Session end and TTL expiry first retire the userspace route and
-wait for already-matched evidence work, then remove the cgroup. Multiple active
-sessions retain independent entries. The BPF allowlist capacity is 4,096,
-matching the daemon session registry's active-session limit.
+the new session. Session end and TTL expiry retire the userspace route after any
+already-matched event finishes mutable correlation, then remove the cgroup;
+they do not hold the daemon-wide routing lock behind evidence `fsync`. A stable
+per-session append shard preserves JSONL order across a reused session ID while
+the old append completes. Multiple active sessions retain independent entries.
+The BPF allowlist capacity is 4,096, matching the daemon session registry's
+active-session limit.
 
 For non-root socket peers, registration also fails closed unless the daemon can
 resolve the kernel-supplied `SO_PEERCRED` PID in its `/proc` view, verify that

--- a/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_guard_linux.go
@@ -88,9 +88,17 @@ func runGuardConsumer(ctx context.Context, d *daemon, log *slog.Logger, ready ch
 	defer func() {
 		if ctx.Err() == nil {
 			d.degradeGuardTier(retErr, log)
-		} else {
-			d.deactivatePolicyMaps()
+			handles.Close()
+			return
 		}
+		if !d.waitForControlHandlerDrain() {
+			// A non-cooperative handler outlived the bounded server drain. Keep
+			// policyMaps and their backing handles live until process exit instead
+			// of explicitly closing them underneath that goroutine.
+			log.Error("control handlers did not drain; leaving BPF guard handles to process-exit cleanup")
+			return
+		}
+		d.deactivatePolicyMaps()
 		handles.Close()
 	}()
 	if err := kernelcapture.ClearBootstrapFileObservations(handles); err != nil {

--- a/go/cmd/ardur-kernelcaptured/daemon_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,6 +52,34 @@ func (s *stubEvidenceFS) AppendFile(path string, data []byte, _ fs.FileMode) err
 	}
 	s.appends[path] = append(s.appends[path], data...)
 	return nil
+}
+
+type blockingEvidenceFS struct {
+	*stubEvidenceFS
+	appendCalls   atomic.Int32
+	firstEntered  chan struct{}
+	secondEntered chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func newBlockingEvidenceFS() *blockingEvidenceFS {
+	return &blockingEvidenceFS{
+		stubEvidenceFS: newStubFS(),
+		firstEntered:   make(chan struct{}),
+		secondEntered:  make(chan struct{}),
+		releaseFirst:   make(chan struct{}),
+	}
+}
+
+func (s *blockingEvidenceFS) AppendFile(path string, data []byte, perm fs.FileMode) error {
+	switch s.appendCalls.Add(1) {
+	case 1:
+		close(s.firstEntered)
+		<-s.releaseFirst
+	case 2:
+		close(s.secondEntered)
+	}
+	return s.stubEvidenceFS.AppendFile(path, data, perm)
 }
 
 // newTestDaemon returns a daemon wired with an in-memory (stub) filesystem.
@@ -681,6 +711,116 @@ func TestSessionRouteRetirementWaitsForMatchedEvent(t *testing.T) {
 	if sid, correlator := d.routeEvent(&probe); sid != "" || correlator != nil {
 		t.Fatalf("retired route matched as (%q, %v)", sid, correlator)
 	}
+}
+
+func TestProcessKernelEventReleasesRouteBeforeEvidenceAppendAndPreservesGenerationOrder(t *testing.T) {
+	d := newTestDaemon(t)
+	fsys := newBlockingEvidenceFS()
+	d.fs = fsys
+	const sessionID = "slow-evidence-session"
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: sessionID, RootPID: 100, CgroupID: 42,
+	}, sessionID)
+
+	firstDone := make(chan struct{})
+	go func() {
+		d.processKernelEvent(kernelcapture.ProcessEvent{PID: 100, CgroupID: 42, Type: kernelcapture.ProcessEventExec})
+		close(firstDone)
+	}()
+	select {
+	case <-fsys.firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first event did not reach the evidence append boundary")
+	}
+
+	var releaseOnce sync.Once
+	releaseFirst := func() { releaseOnce.Do(func() { close(fsys.releaseFirst) }) }
+	defer releaseFirst()
+
+	ended := make(chan struct{})
+	go func() {
+		d.onSessionEnded(sessionID)
+		close(ended)
+	}()
+	select {
+	case <-ended:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("session retirement remained blocked by the in-flight evidence append")
+	}
+
+	// A replacement generation may publish while the old generation's append is
+	// still blocked, but it must not overtake that already-correlated evidence.
+	d.onSessionRegistered(&kernelcapture.DaemonRegisterSessionRequest{
+		SessionID: sessionID, RootPID: 200, CgroupID: 42,
+	}, sessionID)
+	secondDone := make(chan struct{})
+	go func() {
+		d.processKernelEvent(kernelcapture.ProcessEvent{PID: 200, CgroupID: 42, Type: kernelcapture.ProcessEventExec})
+		close(secondDone)
+	}()
+	select {
+	case <-fsys.secondEntered:
+		t.Fatal("replacement generation overtook the prior generation's evidence append")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseFirst()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first event did not finish after releasing evidence append")
+	}
+	select {
+	case <-fsys.secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("replacement event did not reach evidence append after prior generation finished")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("replacement event did not finish")
+	}
+
+	path := filepath.Join(d.evidenceDir, sessionID, "kernel_receipts.jsonl")
+	fsys.mu.Lock()
+	data := append([]byte(nil), fsys.appends[path]...)
+	fsys.mu.Unlock()
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var first, second KernelReceiptEntry
+	if err := decoder.Decode(&first); err != nil {
+		t.Fatalf("decode first receipt: %v", err)
+	}
+	if err := decoder.Decode(&second); err != nil {
+		t.Fatalf("decode second receipt: %v", err)
+	}
+	if first.Event.PID != 100 || second.Event.PID != 200 {
+		t.Fatalf("receipt order = [%d, %d], want [100, 200]", first.Event.PID, second.Event.PID)
+	}
+}
+
+func TestControlHandlerDrainGatesPolicyTeardown(t *testing.T) {
+	t.Run("actual drain permits teardown", func(t *testing.T) {
+		d := newTestDaemon(t)
+		drained := make(chan struct{})
+		serveDone := make(chan struct{})
+		d.setControlHandlerDrain(drained, serveDone)
+		close(drained)
+		close(serveDone)
+		if !d.waitForControlHandlerDrain() {
+			t.Fatal("completed handler drain was not accepted")
+		}
+	})
+
+	t.Run("server timeout rejects explicit teardown", func(t *testing.T) {
+		d := newTestDaemon(t)
+		drained := make(chan struct{})
+		serveDone := make(chan struct{})
+		d.setControlHandlerDrain(drained, serveDone)
+		close(serveDone)
+		if d.waitForControlHandlerDrain() {
+			t.Fatal("server return without a completed handler drain permitted teardown")
+		}
+	})
 }
 
 func TestProcessKernelEventReleasesRouteWithNilCorrelator(t *testing.T) {

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -54,6 +54,7 @@ const (
 	defaultStateDir          = "/var/lib/ardur/kernelcapture/state"
 	defaultSocketMode        = fs.FileMode(0o660)
 	KernelReceiptSchema      = "ardur.kernel.receipt.v1"
+	evidenceAppendShardCount = 256
 )
 
 // KernelReceiptEntry is the JSONL record appended to
@@ -68,11 +69,14 @@ type KernelReceiptEntry struct {
 }
 
 // sessionRoute owns mutable process-tree routing state for one session. Its
-// identity and correlator are immutable after publication. A successful
-// lockIfMatches leaves mu locked so the caller can hold a route lease through
-// correlation and evidence append; callers must invoke unlock afterward.
+// identity and correlator are immutable after publication. appendMu points at a
+// stable daemon-owned shard shared by replacement generations of the same
+// session ID. A successful lockIfMatches holds appendMu and mu: callers release
+// mu after correlation, retain appendMu through the evidence append, then
+// release appendMu. Retirement only takes mu, so a slow fsync cannot hold d.mu.
 type sessionRoute struct {
 	mu               sync.Mutex
+	appendMu         *sync.Mutex
 	sessionID        string
 	scope            *kernelcapture.ProcessTreeScope
 	correlator       *kernelcapture.Correlator
@@ -82,6 +86,7 @@ type sessionRoute struct {
 
 func newSessionRoute(sessionID string, scope *kernelcapture.ProcessTreeScope, correlator *kernelcapture.Correlator, gap *kernelcapture.ObservabilityGapAccumulator) *sessionRoute {
 	return &sessionRoute{
+		appendMu:         &sync.Mutex{},
 		sessionID:        sessionID,
 		scope:            scope,
 		correlator:       correlator,
@@ -94,9 +99,11 @@ func (r *sessionRoute) lockIfMatches(evt *kernelcapture.ProcessEvent) bool {
 	if r == nil || evt == nil {
 		return false
 	}
+	r.appendMu.Lock()
 	r.mu.Lock()
 	if !r.active || r.scope == nil || !r.scope.MatchesAndTrack(*evt) {
 		r.mu.Unlock()
+		r.appendMu.Unlock()
 		return false
 	}
 	evt.SessionID = r.sessionID
@@ -106,6 +113,19 @@ func (r *sessionRoute) lockIfMatches(evt *kernelcapture.ProcessEvent) bool {
 func (r *sessionRoute) unlock() {
 	if r != nil {
 		r.mu.Unlock()
+		r.appendMu.Unlock()
+	}
+}
+
+func (r *sessionRoute) releaseRouteForAppend() {
+	if r != nil {
+		r.mu.Unlock()
+	}
+}
+
+func (r *sessionRoute) finishAppend() {
+	if r != nil {
+		r.appendMu.Unlock()
 	}
 }
 
@@ -121,13 +141,19 @@ type daemon struct {
 	// route pointers; mutable ProcessTreeScope state is protected by each
 	// route's own mutex. fallbackRoutes is copy-on-write and contains only
 	// zero-cgroup test/replay scopes, since nonzero scopes reject cgroup escape.
-	// Lock order is lifecycleDropMu -> mu -> sessionRoute.mu.
+	// Lock order is lifecycleDropMu -> mu -> sessionRoute.mu. Event routing uses
+	// evidenceAppendMu shard -> sessionRoute.mu and never acquires d.mu while the
+	// append shard is held.
 	mu             sync.RWMutex
 	cgroupIndex    map[uint64]string
 	treeScopes     map[string]*kernelcapture.ProcessTreeScope
 	correlators    map[string]*kernelcapture.Correlator
 	routeIndex     map[string]*sessionRoute
 	fallbackRoutes []*sessionRoute
+	// evidenceAppendMu serializes per-session evidence ordering without holding
+	// route.mu through filesystem sync. Fixed shards avoid an unbounded lock map;
+	// collisions may serialize unrelated sessions but never block d.mu.
+	evidenceAppendMu [evidenceAppendShardCount]sync.Mutex
 
 	// enforce_events state, maintained under mu (session-scoped) plus two
 	// daemon-lifetime singletons for events that cannot be attributed to any
@@ -163,6 +189,13 @@ type daemon struct {
 
 	// OS filesystem for JSONL append (interface for test injection).
 	fs evidenceFS
+
+	// The guard teardown waits for the control server to either drain every
+	// accepted handler or report that its bounded drain expired. When a drain
+	// expires, explicit map/handle teardown is skipped and process exit owns
+	// cleanup, avoiding a user-space use-after-close against a stuck handler.
+	controlHandlersDrained <-chan struct{}
+	controlServerDone      <-chan struct{}
 
 	// policyMaps holds the writable BPF map handles for the process_guard
 	// enforcement program. On non-Linux platforms PolicyMaps is a zero struct and
@@ -685,6 +718,35 @@ func (d *daemon) deactivatePolicyMaps() bool {
 	}
 	d.policyMaps = kernelcapture.PolicyMaps{}
 	return wasActive
+}
+
+func (d *daemon) setControlHandlerDrain(drained, serveDone <-chan struct{}) {
+	d.controlHandlersDrained = drained
+	d.controlServerDone = serveDone
+}
+
+// waitForControlHandlerDrain blocks guard teardown until the control server has
+// drained every accepted handler. If Serve reaches its bounded drain deadline,
+// serveDone closes while drained remains open and this returns false. The caller
+// must then leave live handles to process-exit cleanup rather than closing them
+// underneath a handler that may still be using policyMaps.
+func (d *daemon) waitForControlHandlerDrain() bool {
+	if d == nil || d.controlHandlersDrained == nil {
+		return true
+	}
+	select {
+	case <-d.controlHandlersDrained:
+		return true
+	case <-d.controlServerDone:
+		// Both channels may become ready together. Prefer proof of an actual drain
+		// over the server-return signal before declaring teardown unsafe.
+		select {
+		case <-d.controlHandlersDrained:
+			return true
+		default:
+			return false
+		}
+	}
 }
 
 // getActiveTier returns the current activeTier under mu. See activeTier's
@@ -1305,6 +1367,7 @@ func (d *daemon) publishSessionRouteLocked(route *sessionRoute) {
 		return
 	}
 	d.retireSessionRouteLocked(route.sessionID)
+	route.appendMu = d.evidenceAppendMutex(route.sessionID)
 	if d.routeIndex == nil {
 		d.routeIndex = make(map[string]*sessionRoute)
 	}
@@ -1317,9 +1380,27 @@ func (d *daemon) publishSessionRouteLocked(route *sessionRoute) {
 	}
 }
 
+func (d *daemon) evidenceAppendMutex(sessionID string) *sync.Mutex {
+	// FNV-1a is sufficient for lock striping: this is not an identity or security
+	// hash. The same session ID deterministically reaches the same shard across
+	// route replacement, preserving already-correlated evidence order.
+	const (
+		offset64 = uint64(14695981039346656037)
+		prime64  = uint64(1099511628211)
+	)
+	hash := offset64
+	for index := range len(sessionID) {
+		hash ^= uint64(sessionID[index])
+		hash *= prime64
+	}
+	return &d.evidenceAppendMu[hash%evidenceAppendShardCount]
+}
+
 // retireSessionRouteLocked marks one route inactive and removes it from future
 // lookups while d.mu is held. Taking route.mu waits for an already-matched
-// event to finish correlation and evidence append before teardown continues.
+// event to finish mutable correlation before teardown continues. Evidence append
+// ordering is retained separately by the stable append shard and never blocks
+// this d.mu-held retirement path.
 func (d *daemon) retireSessionRouteLocked(sessionID string) {
 	route := d.routeIndex[sessionID]
 	if route == nil {
@@ -1342,8 +1423,9 @@ func (d *daemon) retireSessionRouteLocked(sessionID string) {
 	d.fallbackRoutes = next
 }
 
-// lockRouteEvent finds and locks the route for evt. A non-nil result owns the
-// route mutex; the caller must invoke route.unlock().
+// lockRouteEvent finds and locks the route for evt. A non-nil result owns both
+// its append shard and route mutex; the caller must either invoke route.unlock()
+// or releaseRouteForAppend followed by finishAppend.
 func (d *daemon) lockRouteEvent(evt *kernelcapture.ProcessEvent) *sessionRoute {
 	if evt == nil {
 		return nil
@@ -1377,7 +1459,8 @@ func (d *daemon) lockRouteEvent(evt *kernelcapture.ProcessEvent) *sessionRoute {
 }
 
 // routeEvent is the lookup-only test seam. Production event processing uses
-// lockRouteEvent directly and holds the route lease through evidence append.
+// lockRouteEvent directly, releases route.mu after correlation, and retains
+// only the append shard through evidence persistence.
 func (d *daemon) routeEvent(evt *kernelcapture.ProcessEvent) (string, *kernelcapture.Correlator) {
 	route := d.lockRouteEvent(evt)
 	if route == nil {
@@ -1527,8 +1610,8 @@ func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent) {
 	if route == nil {
 		return
 	}
-	defer route.unlock()
 	if route.correlator == nil {
+		route.unlock()
 		return
 	}
 	sid, correlator := route.sessionID, route.correlator
@@ -1537,6 +1620,12 @@ func (d *daemon) processKernelEvent(evt kernelcapture.ProcessEvent) {
 	if route.observabilityGap != nil {
 		route.observabilityGap.RecordEffect(receipt)
 	}
+	// Correlation and mutable process-tree tracking are complete. Keep only the
+	// stable append shard while writing evidence so session retirement can mark
+	// the route inactive without holding d.mu behind a disk sync. Replacement
+	// generations share this shard and therefore cannot overtake this append.
+	route.releaseRouteForAppend()
+	defer route.finishAppend()
 
 	d.log.Debug("kernel event",
 		"session_id", sid,
@@ -2051,6 +2140,7 @@ func main() {
 		log.Error("bind control socket", "socket", *socketPath, "error", err)
 		os.Exit(1)
 	}
+	d.setControlHandlerDrain(svr.HandlersDrained(), svr.ServeDone())
 	log.Info("control socket listening", "socket", svr.SocketPath())
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -2065,8 +2155,12 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := svr.Serve(ctx); err != nil && ctx.Err() == nil {
-			log.Error("control socket serve", "error", err)
+		if err := svr.Serve(ctx); err != nil {
+			if errors.Is(err, kernelcapture.ErrDaemonSocketServerShutdownTimeout) {
+				log.Error("control socket handler drain timed out; explicit guard teardown will be skipped", "error", err)
+			} else if ctx.Err() == nil {
+				log.Error("control socket serve", "error", err)
+			}
 		}
 	}()
 

--- a/go/pkg/kernelcapture/daemon_socket_server.go
+++ b/go/pkg/kernelcapture/daemon_socket_server.go
@@ -14,9 +14,14 @@ import (
 	"time"
 )
 
-const DefaultDaemonUnixSocketMode fs.FileMode = 0o660
+const (
+	DefaultDaemonUnixSocketMode        fs.FileMode = 0o660
+	DefaultDaemonServerShutdownTimeout             = 5 * time.Second
+	MaxDaemonServerShutdownTimeout                 = time.Minute
+)
 
 var ErrDaemonSocketServer = errors.New("kernelcapture: daemon socket server failed")
+var ErrDaemonSocketServerShutdownTimeout = fmt.Errorf("%w: handler drain timed out", ErrDaemonSocketServer)
 
 type DaemonPeerCredentialObserver func(*net.UnixConn, string) (DaemonSocketPeerObservation, error)
 
@@ -35,6 +40,7 @@ type DaemonUnixSocketServerConfig struct {
 	MaxRequestBytes          int64
 	ReadTimeout              time.Duration
 	MaxConcurrentConnections int
+	ShutdownTimeout          time.Duration
 
 	ObservePeerCredentials  DaemonPeerCredentialObserver
 	HandleAuthorizedRequest DaemonAuthorizedProtocolHandler
@@ -52,6 +58,15 @@ type DaemonUnixSocketServer struct {
 	listener   *net.UnixListener
 	socketPath string
 	semaphore  chan struct{}
+	handlerWG  sync.WaitGroup
+	handlersMu sync.Mutex
+	handlers   map[*net.UnixConn]struct{}
+
+	handlersDrained chan struct{}
+	serveDone       chan struct{}
+	drainOnce       sync.Once
+	serveDoneOnce   sync.Once
+	serveStarted    atomic.Bool
 
 	closed    atomic.Bool
 	closeMu   sync.Mutex
@@ -67,6 +82,7 @@ func DefaultDaemonUnixSocketServerConfig(plan DaemonCustodyPlan, policy DaemonPe
 		MaxRequestBytes:          DefaultDaemonAcceptLoopMaxRequestBytes,
 		ReadTimeout:              DefaultDaemonAcceptLoopReadTimeout,
 		MaxConcurrentConnections: DefaultDaemonAcceptLoopMaxConcurrentConnections,
+		ShutdownTimeout:          DefaultDaemonServerShutdownTimeout,
 		ObservePeerCredentials:   ObserveLinuxUnixPeerCredentials,
 		HandleAuthorizedRequest:  defaultDaemonAuthorizedProtocolHandler,
 	}
@@ -90,10 +106,13 @@ func ListenDaemonUnixSocketServer(cfg DaemonUnixSocketServerConfig) (*DaemonUnix
 	}
 
 	return &DaemonUnixSocketServer{
-		cfg:        cfg,
-		listener:   listener,
-		socketPath: bindPath,
-		semaphore:  make(chan struct{}, cfg.MaxConcurrentConnections),
+		cfg:             cfg,
+		listener:        listener,
+		socketPath:      bindPath,
+		semaphore:       make(chan struct{}, cfg.MaxConcurrentConnections),
+		handlers:        make(map[*net.UnixConn]struct{}),
+		handlersDrained: make(chan struct{}),
+		serveDone:       make(chan struct{}),
 	}, nil
 }
 
@@ -104,13 +123,35 @@ func (s *DaemonUnixSocketServer) SocketPath() string {
 	return s.socketPath
 }
 
+// HandlersDrained closes only after Serve has stopped accepting and every
+// accepted connection handler has returned. It remains open when the bounded
+// drain deadline expires before handlers finish.
+func (s *DaemonUnixSocketServer) HandlersDrained() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+	return s.handlersDrained
+}
+
+// ServeDone closes when Serve returns, including after a bounded drain timeout.
+func (s *DaemonUnixSocketServer) ServeDone() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+	return s.serveDone
+}
+
 func (s *DaemonUnixSocketServer) Serve(ctx context.Context) error {
 	if s == nil || s.listener == nil {
 		return daemonSocketServerError("server is not listening")
 	}
+	if !s.serveStarted.CompareAndSwap(false, true) {
+		return daemonSocketServerError("Serve may be called only once")
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	defer s.serveDoneOnce.Do(func() { close(s.serveDone) })
 
 	stop := make(chan struct{})
 	go func() {
@@ -122,20 +163,28 @@ func (s *DaemonUnixSocketServer) Serve(ctx context.Context) error {
 	}()
 	defer close(stop)
 
+	var acceptErr error
+acceptLoop:
 	for {
 		conn, err := s.listener.AcceptUnix()
 		if err != nil {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				acceptErr = ctx.Err()
+				break acceptLoop
 			}
 			if s.closed.Load() || isDaemonSocketServerClosedError(err) {
-				return nil
+				break acceptLoop
 			}
-			return daemonSocketServerError("accept unix connection: %v", err)
+			acceptErr = daemonSocketServerError("accept unix connection: %v", err)
+			break acceptLoop
 		}
 
 		select {
 		case s.semaphore <- struct{}{}:
+			s.handlersMu.Lock()
+			s.handlers[conn] = struct{}{}
+			s.handlerWG.Add(1)
+			s.handlersMu.Unlock()
 			go s.handleAcceptedConnection(ctx, conn)
 		default:
 			_ = writeDaemonProtocolResponse(conn, DaemonProtocolResponse{
@@ -146,6 +195,14 @@ func (s *DaemonUnixSocketServer) Serve(ctx context.Context) error {
 			_ = conn.Close()
 		}
 	}
+
+	if ctx.Err() != nil {
+		// Closing accepted connections is the documented way to unblock pending
+		// net.Conn reads/writes. Handlers already inside business logic receive the
+		// canceled ctx and are covered by the bounded WaitGroup drain below.
+		s.closeAcceptedConnections()
+	}
+	return errors.Join(acceptErr, s.drainAcceptedConnections())
 }
 
 func (s *DaemonUnixSocketServer) Close() error {
@@ -190,8 +247,12 @@ func DefaultDaemonAuthorizedProtocolResponse(req DaemonProtocolRequest, handshak
 
 func (s *DaemonUnixSocketServer) handleAcceptedConnection(ctx context.Context, conn *net.UnixConn) {
 	defer func() {
-		<-s.semaphore
 		_ = conn.Close()
+		s.handlersMu.Lock()
+		delete(s.handlers, conn)
+		s.handlersMu.Unlock()
+		<-s.semaphore
+		s.handlerWG.Done()
 	}()
 	// One misbehaving request (e.g. a handler bug reachable only in a
 	// specific degraded state, such as BPF-LSM maps not being loaded) must
@@ -209,15 +270,59 @@ func (s *DaemonUnixSocketServer) handleAcceptedConnection(ctx context.Context, c
 		}
 	}()
 
+	if ctx.Err() != nil {
+		return
+	}
 	req, handshake, err := s.authorizeAcceptedConnection(conn)
 	if err != nil {
 		_ = writeDaemonProtocolResponse(conn, daemonProtocolErrorResponse(req, err))
 		return
 	}
+	if ctx.Err() != nil {
+		return
+	}
 	resp := s.cfg.HandleAuthorizedRequest(ctx, req, handshake)
+	if ctx.Err() != nil {
+		return
+	}
 	resp = normalizeDaemonProtocolResponse(resp, req, handshake)
 	if err := writeDaemonProtocolResponse(conn, resp); err != nil {
 		return
+	}
+}
+
+func (s *DaemonUnixSocketServer) drainAcceptedConnections() error {
+	s.drainOnce.Do(func() {
+		go func() {
+			s.handlerWG.Wait()
+			close(s.handlersDrained)
+		}()
+	})
+	timer := time.NewTimer(s.cfg.ShutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-s.handlersDrained:
+		return nil
+	case <-timer.C:
+		s.closeAcceptedConnections()
+		select {
+		case <-s.handlersDrained:
+			return nil
+		default:
+			return fmt.Errorf("%w after %s", ErrDaemonSocketServerShutdownTimeout, s.cfg.ShutdownTimeout)
+		}
+	}
+}
+
+func (s *DaemonUnixSocketServer) closeAcceptedConnections() {
+	s.handlersMu.Lock()
+	connections := make([]*net.UnixConn, 0, len(s.handlers))
+	for conn := range s.handlers {
+		connections = append(connections, conn)
+	}
+	s.handlersMu.Unlock()
+	for _, conn := range connections {
+		_ = conn.Close()
 	}
 }
 
@@ -290,6 +395,9 @@ func normalizeDaemonUnixSocketServerConfig(cfg DaemonUnixSocketServerConfig) Dae
 	if cfg.MaxConcurrentConnections == 0 {
 		cfg.MaxConcurrentConnections = DefaultDaemonAcceptLoopMaxConcurrentConnections
 	}
+	if cfg.ShutdownTimeout == 0 {
+		cfg.ShutdownTimeout = DefaultDaemonServerShutdownTimeout
+	}
 	if cfg.ObservePeerCredentials == nil {
 		cfg.ObservePeerCredentials = ObserveLinuxUnixPeerCredentials
 	}
@@ -328,6 +436,9 @@ func validateDaemonUnixSocketServerConfig(cfg DaemonUnixSocketServerConfig) erro
 	}
 	if cfg.HandleAuthorizedRequest == nil {
 		return daemonSocketServerError("authorized protocol handler is required")
+	}
+	if cfg.ShutdownTimeout <= 0 || cfg.ShutdownTimeout > MaxDaemonServerShutdownTimeout {
+		return daemonSocketServerError("shutdown timeout must be between 1ns and %s", MaxDaemonServerShutdownTimeout)
 	}
 	return nil
 }

--- a/go/pkg/kernelcapture/daemon_socket_server_test.go
+++ b/go/pkg/kernelcapture/daemon_socket_server_test.go
@@ -8,7 +8,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -153,6 +155,215 @@ func TestDaemonUnixSocketServerEnforcesBoundedConcurrency(t *testing.T) {
 	}
 }
 
+func TestDaemonUnixSocketServerCancellationDrainsInFlightHandlerBeforeServeReturns(t *testing.T) {
+	entered := make(chan struct{})
+	observedCancel := make(chan struct{})
+	allowReturn := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(allowReturn) }) }
+	defer releaseHandler()
+
+	server := listenDaemonUnixSocketServerForTest(t, daemonSocketServerTestOptions{
+		policy: DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{501}},
+		observePeer: func(_ *net.UnixConn, socketPath string) (DaemonSocketPeerObservation, error) {
+			return DaemonSocketPeerObservation{
+				Credentials:      DaemonObservedPeerCredentials{UID: 501, GID: 20, PID: 4321, ProcessStartTimeTicks: 800001},
+				CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+				SocketPath:       socketPath,
+			}, nil
+		},
+		handleAuthorizedRequest: func(ctx context.Context, req DaemonProtocolRequest, handshake DaemonProtocolPeerHandshake) DaemonProtocolResponse {
+			close(entered)
+			<-ctx.Done()
+			close(observedCancel)
+			<-allowReturn
+			return DefaultDaemonAuthorizedProtocolResponse(req, handshake)
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(ctx) }()
+
+	conn := dialDaemonUnixSocket(t, server.SocketPath())
+	defer conn.Close()
+	if _, err := conn.Write(daemonHealthRequest(t)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("authorized handler did not start")
+	}
+	cancel()
+	select {
+	case <-observedCancel:
+	case <-time.After(time.Second):
+		t.Fatal("authorized handler did not observe context cancellation")
+	}
+	select {
+	case err := <-serveErr:
+		t.Fatalf("Serve returned before the in-flight handler drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseHandler()
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve error = %v, want context cancellation after drain", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not return after the in-flight handler drained")
+	}
+}
+
+func TestDaemonUnixSocketServerCancellationUnblocksAndDrainsPartialRequest(t *testing.T) {
+	server := listenDaemonUnixSocketServerForTest(t, daemonSocketServerTestOptions{
+		policy: DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{501}},
+		observePeer: func(_ *net.UnixConn, socketPath string) (DaemonSocketPeerObservation, error) {
+			return DaemonSocketPeerObservation{
+				Credentials:      DaemonObservedPeerCredentials{UID: 501, GID: 20, PID: 4321, ProcessStartTimeTicks: 800001},
+				CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+				SocketPath:       socketPath,
+			}, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(ctx) }()
+
+	conn := dialDaemonUnixSocket(t, server.SocketPath())
+	defer conn.Close()
+	deadline := time.Now().Add(time.Second)
+	for len(server.semaphore) != 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("partial request handler did not acquire its concurrency slot")
+		}
+		runtime.Gosched()
+	}
+	cancel()
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not return after cancellation")
+	}
+	if got := len(server.semaphore); got != 0 {
+		t.Fatalf("active handler slots after Serve returned = %d, want 0", got)
+	}
+}
+
+func TestDaemonUnixSocketServerCancellationBeforeDispatchSkipsAuthorizedMutation(t *testing.T) {
+	observerEntered := make(chan struct{})
+	releaseObserver := make(chan struct{})
+	var handled atomic.Int32
+	server := listenDaemonUnixSocketServerForTest(t, daemonSocketServerTestOptions{
+		policy: DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{501}},
+		observePeer: func(_ *net.UnixConn, socketPath string) (DaemonSocketPeerObservation, error) {
+			close(observerEntered)
+			<-releaseObserver
+			return DaemonSocketPeerObservation{
+				Credentials:      DaemonObservedPeerCredentials{UID: 501, GID: 20, PID: 4321, ProcessStartTimeTicks: 800001},
+				CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+				SocketPath:       socketPath,
+			}, nil
+		},
+		handleAuthorizedRequest: func(_ context.Context, req DaemonProtocolRequest, handshake DaemonProtocolPeerHandshake) DaemonProtocolResponse {
+			handled.Add(1)
+			return DefaultDaemonAuthorizedProtocolResponse(req, handshake)
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(ctx) }()
+	conn := dialDaemonUnixSocket(t, server.SocketPath())
+	defer conn.Close()
+	if _, err := conn.Write(daemonHealthRequest(t)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	select {
+	case <-observerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("peer observer did not start")
+	}
+	cancel()
+	close(releaseObserver)
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not drain after cancellation")
+	}
+	if got := handled.Load(); got != 0 {
+		t.Fatalf("authorized mutations after cancellation = %d, want 0", got)
+	}
+}
+
+func TestDaemonUnixSocketServerReportsBoundedDrainTimeout(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseHandler()
+
+	server := listenDaemonUnixSocketServerForTest(t, daemonSocketServerTestOptions{
+		shutdownTimeout: 50 * time.Millisecond,
+		policy:          DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{501}},
+		observePeer: func(_ *net.UnixConn, socketPath string) (DaemonSocketPeerObservation, error) {
+			return DaemonSocketPeerObservation{
+				Credentials:      DaemonObservedPeerCredentials{UID: 501, GID: 20, PID: 4321, ProcessStartTimeTicks: 800001},
+				CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+				SocketPath:       socketPath,
+			}, nil
+		},
+		handleAuthorizedRequest: func(_ context.Context, req DaemonProtocolRequest, handshake DaemonProtocolPeerHandshake) DaemonProtocolResponse {
+			close(entered)
+			<-release // Deliberately ignore cancellation to exercise the hard deadline.
+			return DefaultDaemonAuthorizedProtocolResponse(req, handshake)
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(ctx) }()
+	conn := dialDaemonUnixSocket(t, server.SocketPath())
+	defer conn.Close()
+	if _, err := conn.Write(daemonHealthRequest(t)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("authorized handler did not start")
+	}
+	cancel()
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, ErrDaemonSocketServerShutdownTimeout) {
+			t.Fatalf("Serve error = %v, want handler-drain timeout", err)
+		}
+		if !errors.Is(err, ErrDaemonSocketServer) {
+			t.Fatalf("Serve error = %v, want generic socket-server classification", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not honor its bounded drain timeout")
+	}
+	select {
+	case <-server.HandlersDrained():
+		t.Fatal("HandlersDrained closed while the non-cooperative handler was still running")
+	default:
+	}
+	releaseHandler()
+	select {
+	case <-server.HandlersDrained():
+	case <-time.After(time.Second):
+		t.Fatal("HandlersDrained did not close after the handler eventually returned")
+	}
+}
+
 func TestDaemonUnixSocketServerRejectsInvalidConfig(t *testing.T) {
 	t.Parallel()
 
@@ -173,30 +384,32 @@ func TestDaemonUnixSocketServerRejectsInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestDaemonUnixSocketServerServeIsSingleUse(t *testing.T) {
+	server, cancel := startDaemonUnixSocketServerForTest(t, daemonSocketServerTestOptions{
+		policy: DaemonPeerAuthorizationPolicy{AllowedUIDs: []uint32{501}},
+		observePeer: func(_ *net.UnixConn, socketPath string) (DaemonSocketPeerObservation, error) {
+			return DaemonSocketPeerObservation{
+				Credentials:      DaemonObservedPeerCredentials{UID: 501, GID: 20, PID: 4321, ProcessStartTimeTicks: 800001},
+				CredentialSource: DaemonPeerCredentialSourceLinuxSOPeerCred,
+				SocketPath:       socketPath,
+			}, nil
+		},
+	})
+	cancel()
+	if err := server.Serve(context.Background()); err == nil || !strings.Contains(err.Error(), "only once") {
+		t.Fatalf("second Serve error = %v, want single-use rejection", err)
+	}
+}
+
 type daemonSocketServerTestOptions struct {
 	policy                   DaemonPeerAuthorizationPolicy
 	observePeer              DaemonPeerCredentialObserver
 	handleAuthorizedRequest  DaemonAuthorizedProtocolHandler
 	maxConcurrentConnections int
+	shutdownTimeout          time.Duration
 }
 
-func shortDaemonSocketPathForTest(t *testing.T) string {
-	t.Helper()
-
-	// Darwin's sockaddr_un path budget is small and t.TempDir includes the full
-	// test name, so keep the bound path intentionally short. The directory is
-	// unique per test and cleaned up after the server removes the socket file.
-	dir, err := os.MkdirTemp("/tmp", "ardur-sock-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
-	return filepath.Join(dir, "s.sock")
-}
-
-func startDaemonUnixSocketServerForTest(t *testing.T, opts daemonSocketServerTestOptions) (*DaemonUnixSocketServer, func()) {
+func listenDaemonUnixSocketServerForTest(t *testing.T, opts daemonSocketServerTestOptions) *DaemonUnixSocketServer {
 	t.Helper()
 
 	plan, err := BuildDaemonCustodyPlan(DefaultDaemonCustodyConfig())
@@ -213,11 +426,40 @@ func startDaemonUnixSocketServerForTest(t *testing.T, opts daemonSocketServerTes
 	if opts.maxConcurrentConnections != 0 {
 		cfg.MaxConcurrentConnections = opts.maxConcurrentConnections
 	}
+	if opts.shutdownTimeout != 0 {
+		cfg.ShutdownTimeout = opts.shutdownTimeout
+	}
 
 	server, err := ListenDaemonUnixSocketServer(cfg)
 	if err != nil {
 		t.Fatalf("ListenDaemonUnixSocketServer returned error: %v", err)
 	}
+	return server
+}
+
+func shortDaemonSocketPathForTest(t *testing.T) string {
+	t.Helper()
+
+	// Darwin's sockaddr_un path budget is small and t.TempDir includes the full
+	// test name, so keep the bound path intentionally short. Local agents may set
+	// ARDUR_TEST_SOCKET_TMPDIR to a short external-volume path; CI keeps /tmp.
+	baseDir := os.Getenv("ARDUR_TEST_SOCKET_TMPDIR")
+	if baseDir == "" {
+		baseDir = "/tmp"
+	}
+	dir, err := os.MkdirTemp(baseDir, "ardur-sock-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return filepath.Join(dir, "s.sock")
+}
+
+func startDaemonUnixSocketServerForTest(t *testing.T, opts daemonSocketServerTestOptions) (*DaemonUnixSocketServer, func()) {
+	t.Helper()
+	server := listenDaemonUnixSocketServerForTest(t, opts)
 	ctx, cancelContext := context.WithCancel(context.Background())
 	serveErrCh := make(chan error, 1)
 	go func() {

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "e0e4e0dd5c641878bfbebbe8a98a98208a9b2fdc89e5850598aa69d3325fc521"
+source_sha256: "e5e4003b98713343970d2d4d42420e844e580de142f13e9de190c35a2f61fb42"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -44,6 +44,22 @@ Do not use `--no-ringbuf` as a production fallback for a failing event
 consumer. A healthy socket in this mode proves control-plane liveness only; it
 does not prove that a governed process is observed or constrained below the
 tool-call boundary.
+
+## Control-plane shutdown and handler drain
+
+On SIGINT or SIGTERM, the daemon stops accepting control-socket connections,
+cancels the request context, and closes accepted Unix connections so blocked
+reads and writes return. It tracks every accepted handler and waits up to five
+seconds for those handlers to return. A handler already inside a bounded map or
+evidence operation may finish that operation; a request that has not begun its
+authorized mutation observes cancellation and stops.
+
+BPF policy maps and guard handles remain live until the handler drain is
+proven. If a non-cooperative handler outlives the five-second deadline, the
+daemon logs `control socket handler drain timed out` and deliberately skips
+explicit guard-handle teardown. Process exit then owns cleanup. This avoids
+closing a live map handle underneath the stuck handler while keeping shutdown
+bounded; it is a fail-safe exit path, not evidence that the request completed.
 
 ## Seccomp governance endpoint
 
@@ -137,10 +153,13 @@ enter Ardur's lifecycle ringbuf when no governed session exists.
 For each `register_session`, the daemon adds the verified nonzero cgroup before
 the registry can return success and before the launch gate is released. A map
 update failure rejects that registration so the enabled producer cannot omit
-the new session. Session end and TTL expiry first retire the userspace route and
-wait for already-matched evidence work, then remove the cgroup. Multiple active
-sessions retain independent entries. The BPF allowlist capacity is 4,096,
-matching the daemon session registry's active-session limit.
+the new session. Session end and TTL expiry retire the userspace route after any
+already-matched event finishes mutable correlation, then remove the cgroup;
+they do not hold the daemon-wide routing lock behind evidence `fsync`. A stable
+per-session append shard preserves JSONL order across a reused session ID while
+the old append completes. Multiple active sessions retain independent entries.
+The BPF allowlist capacity is 4,096, matching the daemon session registry's
+active-session limit.
 
 For non-root socket peers, registration also fails closed unless the daemon can
 resolve the kernel-supplied `SO_PEERCRED` PID in its `/proc` view, verify that


### PR DESCRIPTION
Closes #263.

## Summary

- release `sessionRoute.mu` before kernel-receipt persistence so evidence `fsync` cannot block daemon-wide routing lifecycle operations
- retain a stable 256-shard append serializer through persistence so a reused `session_id` cannot reorder old/new generation evidence
- track accepted Unix-socket handlers and connections, propagate cancellation before dispatch, unblock pending I/O, and enforce a five-second drain deadline
- gate normal BPF policy-map/handle teardown on proof that every control handler drained; on deadline, leave explicit cleanup to process exit rather than closing handles underneath a stuck callback
- document the shutdown and evidence-ordering contract in the kernel-daemon reference and generated site mirror

## Design evidence

The synchronization design follows the Go standard-library contracts for [`sync.WaitGroup`](https://pkg.go.dev/sync#WaitGroup), [`context`](https://pkg.go.dev/context), and [`net.Conn`](https://pkg.go.dev/net#Conn). A plain unlock-before-`fsync` design was rejected because it could allow replacement-generation evidence to overtake an already-correlated append.

The timeout cannot forcibly stop arbitrary Go callback code. If a callback ignores cancellation past the deadline, `Serve` reports a distinct error and the guard skips explicit handle teardown; process exit owns cleanup. This is a bounded fail-safe exit, not a claim that the request completed.

Decision record: https://app.notion.com/p/39b2637edb0781a29635e0996ddc5fe0

## Validation

- organic regressions reproduced both defects before the implementation
- focused concurrency/cancellation regressions: passed
- focused race set: 100 repetitions passed
- cancellation-before-dispatch race case: 20 repetitions passed
- affected packages, shuffled with race detector: 20 repetitions passed
- full Go 1.26.5 suite: passed
- full Go race suite: passed
- `go vet ./...`: passed
- Linux arm64 cross-compilation: passed
- full Python 3.13: `1794 passed, 33 skipped, 6 warnings` (reproduced twice)
- `scripts/check-local.sh --full`: passed
- source mirror: 113 pages / 112 docs verified
- public claims: 10 validated
- Hugo 0.161.1: 283 pages / 115 static files; rendered links and exact-source-SHA provenance passed
- package assets: 7 verified
- Gitleaks 8.18.0: 509 commits, no leaks
- indexed route benchmark: 0 allocations, approximately 126-141 ns/op on the local Apple M4 Max
- two manual review passes: clean; CodeRabbit CLI unavailable

README was reviewed; no change is needed because this operational detail belongs in the kernel-daemon reference. `main` and PR #17 are untouched. Branch/worktree are retained. Semgrep was not used.
