### PR TITLE
fix(kernelcapture): revoke stale allowlists before gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Revoke path and network allowlist entries dropped by a BPF-LSM policy update
+  before publishing its managed-generation gate, and abort the update if a
+  stale entry cannot be removed
 - Scan inline tool `inputSchema` and legacy `parameters` description annotations
   for instruction injection without treating instance defaults/examples as
   schemas or exposing unsafe schema-member names

--- a/docs/reference/kernel-capture-daemon.md
+++ b/docs/reference/kernel-capture-daemon.md
@@ -119,6 +119,28 @@ Any observation, map update, cgroup migration, policy application, or ptrace
 transition failure kills the still-stopped target instead of releasing an
 ungoverned process.
 
+## BPF-LSM policy publication
+
+The daemon serializes policy-map mutations and writes a complete operation
+policy into the inactive `cgroup_op_policy` slot. The path and network
+allowlist maps are shared rather than slot-keyed, so a policy update first
+computes entries present in the last successful apply but absent from the new
+request. It must delete all of those stale entries before publishing the new
+`cgroup_managed` generation and active slot. A failed delete rejects the update
+without flipping the managed gate; the prior generation remains active and may
+be more restrictive if some stale deletes already succeeded. This is an
+intentional fail-closed availability trade-off.
+
+After successful pre-revocation, the daemon writes the requested shared
+allowlist entries and flips `cgroup_managed` last. Therefore an entry revoked
+by the new generation cannot remain effective after that generation becomes
+active. Shared allowlist additions can become visible before the final gate
+write when the prior generation already uses the same allowlist action; the
+update sequence does not claim a general transaction across independent BPF
+maps. Bootstrap-file, trusted-root, and control-plane exceptions carry an
+explicit generation and are cleaned after the flip because stale generations
+are already rejected in the BPF lookup path.
+
 ## Process lifecycle cgroup filter
 
 The production lifecycle consumer pins `filter_control` and `allowed_cgroups`

--- a/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_authz_test.go
@@ -16,34 +16,59 @@ import (
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
 
-// countingPolicyMap is a minimal policyMapReadWriter that records how many
-// Put/Delete calls it received. Lookup always reports "not found" so
-// nextPolicySlot falls back to slot 0 (slot mechanics are covered elsewhere).
-// Its counters are plain ints on purpose: with the daemon's applyMu absent,
-// concurrent apply_policy would write them unsynchronized and `go test -race`
-// would flag it — making the concurrency test non-vacuous.
+// countingPolicyMap is a minimal policyMapReadWriter that records Put/Delete
+// counts and can optionally trace call order or inject a delete failure. Lookup
+// always reports "not found" so nextPolicySlot falls back to slot 0 (slot
+// mechanics are covered elsewhere). Its counters are plain ints on purpose:
+// with the daemon's applyMu absent, concurrent apply_policy would write them
+// unsynchronized and `go test -race` would flag it — making the concurrency
+// test non-vacuous.
 type countingPolicyMap struct {
-	puts    int
-	deletes int
+	name      string
+	events    *[]string
+	puts      int
+	deletes   int
+	deleteErr error
 }
 
 var errCountingNotFound = errors.New("key does not exist")
 
-func (m *countingPolicyMap) Put(_, _ interface{}) error    { m.puts++; return nil }
-func (m *countingPolicyMap) Delete(_ interface{}) error    { m.deletes++; return nil }
+func (m *countingPolicyMap) Put(_, _ interface{}) error {
+	m.puts++
+	if m.events != nil {
+		*m.events = append(*m.events, "put:"+m.name)
+	}
+	return nil
+}
+
+func (m *countingPolicyMap) Delete(_ interface{}) error {
+	m.deletes++
+	if m.events != nil {
+		*m.events = append(*m.events, "delete:"+m.name)
+	}
+	return m.deleteErr
+}
+
 func (m *countingPolicyMap) Lookup(_, _ interface{}) error { return errCountingNotFound }
 
 func countingPolicyMaps() (kernelcapture.PolicyMaps, map[string]*countingPolicyMap) {
-	op := &countingPolicyMap{}
-	path := &countingPolicyMap{}
-	file := &countingPolicyMap{}
-	bootstrapFile := &countingPolicyMap{}
-	bootstrapObservation := &countingPolicyMap{}
-	control := &countingPolicyMap{}
-	trustedRoot := &countingPolicyMap{}
-	net := &countingPolicyMap{}
-	managed := &countingPolicyMap{}
-	kill := &countingPolicyMap{}
+	return countingPolicyMapsWithEvents(nil)
+}
+
+func countingPolicyMapsWithEvents(events *[]string) (kernelcapture.PolicyMaps, map[string]*countingPolicyMap) {
+	newMap := func(name string) *countingPolicyMap {
+		return &countingPolicyMap{name: name, events: events}
+	}
+	op := newMap("op")
+	path := newMap("path")
+	file := newMap("file")
+	bootstrapFile := newMap("bootstrap_file")
+	bootstrapObservation := newMap("bootstrap_observation")
+	control := newMap("control")
+	trustedRoot := newMap("trusted_root")
+	net := newMap("net")
+	managed := newMap("managed")
+	kill := newMap("kill")
 	return kernelcapture.PolicyMaps{
 		CgroupOpPolicy:           op,
 		CgroupPathAllow:          path,
@@ -153,16 +178,21 @@ func TestHandleSetKillSwitch_RequiresRootAdmin(t *testing.T) {
 func TestHandleApplyPolicy_ReapplyRevokesDroppedAllowlist(t *testing.T) {
 	t.Parallel()
 	d := newTestDaemon(t)
-	maps, h := countingPolicyMaps()
+	var events []string
+	maps, h := countingPolicyMapsWithEvents(&events)
 	d.activatePolicyMaps(maps)
 	registerTestSession(t, d, "ses-prune", 5500)
 	owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
 
-	apply := func(gen kernelcapture.BpfPolicyGeneration, paths []string) {
+	apply := func(gen kernelcapture.BpfPolicyGeneration, paths, nets []string) {
 		ap := &kernelcapture.DaemonApplyPolicyRequest{
 			SessionID: "ses-prune", Generation: gen, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
-			OpPolicies: []kernelcapture.DaemonOpPolicy{{Op: kernelcapture.BpfOpFileRead, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce}},
-			PathAllow:  paths,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{
+				{Op: kernelcapture.BpfOpFileRead, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+				{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+			},
+			PathAllow: paths,
+			NetAllow:  nets,
 		}
 		resp := d.handleApplyPolicy(kernelcapture.DaemonProtocolRequest{
 			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
@@ -174,11 +204,30 @@ func TestHandleApplyPolicy_ReapplyRevokesDroppedAllowlist(t *testing.T) {
 		}
 	}
 
-	apply(1, []string{"/tmp/a", "/tmp/b"})
-	before := h["file"].deletes
-	apply(2, []string{"/tmp/a"}) // drops /tmp/b
-	if got := h["file"].deletes - before; got != 1 {
+	apply(1, []string{"/tmp/a", "/tmp/b"}, []string{"10.0.0.0/8", "192.0.2.0/24"})
+	beforeFile := h["file"].deletes
+	beforeNet := h["net"].deletes
+	events = nil
+	apply(2, []string{"/tmp/a"}, []string{"10.0.0.0/8"}) // drops /tmp/b and 192.0.2.0/24
+	if got := h["file"].deletes - beforeFile; got != 1 {
 		t.Fatalf("re-apply dropping /tmp/b: file-allow deletes = %d, want 1 (the dropped entry must be revoked)", got)
+	}
+	if got := h["net"].deletes - beforeNet; got != 1 {
+		t.Fatalf("re-apply dropping 192.0.2.0/24: net-allow deletes = %d, want 1 (the dropped entry must be revoked)", got)
+	}
+	fileDeleteIndex, netDeleteIndex, gateIndex := -1, -1, -1
+	for i, event := range events {
+		switch event {
+		case "delete:file":
+			fileDeleteIndex = i
+		case "delete:net":
+			netDeleteIndex = i
+		case "put:managed":
+			gateIndex = i
+		}
+	}
+	if fileDeleteIndex < 0 || netDeleteIndex < 0 || gateIndex < 0 || fileDeleteIndex >= gateIndex || netDeleteIndex >= gateIndex {
+		t.Fatalf("re-apply event order = %v, want stale file/net deletes before managed generation gate", events)
 	}
 
 	// Session end must release the remaining allowlist entry too.
@@ -186,6 +235,63 @@ func TestHandleApplyPolicy_ReapplyRevokesDroppedAllowlist(t *testing.T) {
 	d.onSessionEnded("ses-prune")
 	if h["file"].deletes <= endDeletes {
 		t.Fatalf("session end: file-allow deletes did not increase (remaining allowlist entry not released)")
+	}
+}
+
+func TestHandleApplyPolicy_StaleAllowlistDeleteFailurePreventsGenerationFlip(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mapName  string
+		oldPaths []string
+		newPaths []string
+		oldNets  []string
+		newNets  []string
+	}{
+		{name: "file hash", mapName: "file", oldPaths: []string{"/tmp/a", "/tmp/b"}, newPaths: []string{"/tmp/a"}},
+		{name: "network LPM", mapName: "net", oldNets: []string{"10.0.0.0/8", "192.0.2.0/24"}, newNets: []string{"10.0.0.0/8"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := newTestDaemon(t)
+			maps, h := countingPolicyMaps()
+			d.activatePolicyMaps(maps)
+			sessionID := "ses-prune-fail-" + tc.mapName
+			registerTestSession(t, d, sessionID, 5501)
+			owner := testPeerHandshake("", kernelcapture.DaemonProtocolMethodApplyPolicy)
+
+			apply := func(gen kernelcapture.BpfPolicyGeneration, paths, nets []string) kernelcapture.DaemonProtocolResponse {
+				return d.handleApplyPolicy(kernelcapture.DaemonProtocolRequest{
+					ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+					Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+					ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+						SessionID: sessionID, Generation: gen, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+						OpPolicies: []kernelcapture.DaemonOpPolicy{
+							{Op: kernelcapture.BpfOpFileRead, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+							{Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce},
+						},
+						PathAllow: paths,
+						NetAllow:  nets,
+					},
+				}, owner)
+			}
+
+			if resp := apply(1, tc.oldPaths, tc.oldNets); !resp.OK {
+				t.Fatalf("initial apply: %+v", resp)
+			}
+			managedPuts := h["managed"].puts
+			h[tc.mapName].deleteErr = errors.New("injected stale-entry delete failure")
+
+			resp := apply(2, tc.newPaths, tc.newNets)
+			if resp.OK {
+				t.Fatalf("re-apply with failed stale revocation returned OK: %+v", resp)
+			}
+			if !strings.Contains(resp.Error, "revoke stale allowlist") {
+				t.Fatalf("re-apply error = %q, want stale-revocation context", resp.Error)
+			}
+			if h["managed"].puts != managedPuts {
+				t.Fatalf("managed gate puts = %d, want %d after failed stale revocation", h["managed"].puts, managedPuts)
+			}
+		})
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/main.go
+++ b/go/cmd/ardur-kernelcaptured/main.go
@@ -895,6 +895,27 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, hand
 		}
 	}
 
+	// cgroup_file_allow and cgroup_net_allow are shared across operation-policy
+	// generations. Revoke entries dropped by this update BEFORE ApplyPolicyMaps
+	// publishes the new cgroup_managed gate; pruning them after the gate leaves a
+	// live over-permit interval where the new generation still accepts an entry
+	// it revoked. A delete failure is fail-closed: leave the old generation
+	// active (possibly with fewer allowed targets) and report the failed update.
+	// The seccomp/degraded paths have no BPF allowlist state to prune.
+	if d.getActiveTier() == daemonTierBPFLSM {
+		stalePaths, staleNets := d.staleSharedAllowlistEntries(ap.SessionID, ap.PathAllow, ap.NetAllow)
+		if len(stalePaths) > 0 || len(staleNets) > 0 {
+			if err := kernelcapture.DeleteAllowlistEntries(d.policyMaps, record.CgroupID, stalePaths, staleNets); err != nil {
+				if len(applied.BootstrapFiles) > 0 {
+					_ = kernelcapture.DeleteBootstrapFileEntries(d.policyMaps, record.CgroupID, applied.BootstrapFiles)
+				}
+				d.log.Error("revoke stale allowlist entries before policy generation flip",
+					"session_id", ap.SessionID, "cgroup_id", record.CgroupID, "error", err)
+				return errResp(fmt.Sprintf("revoke stale allowlist entries before policy generation flip: %v", err))
+			}
+		}
+	}
+
 	if err := kernelcapture.ApplyPolicyMaps(d.policyMaps, record.CgroupID, applied); err != nil {
 		if len(applied.BootstrapFiles) > 0 {
 			_ = kernelcapture.DeleteBootstrapFileEntries(d.policyMaps, record.CgroupID, applied.BootstrapFiles)
@@ -940,11 +961,11 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, hand
 		return errResp(fmt.Sprintf("apply policy maps: %v", err))
 	}
 
-	// Revoke any allowlist entries this session had that the new policy drops,
-	// and record the new set. Runs only on the BPF-write success path (the
-	// degraded/seccomp returns above never reach the cgroup_file_allow /
-	// cgroup_net_allow maps). Under applyMu, so serialized with other applies.
-	d.pruneAndRecordAllowlists(ap.SessionID, record.CgroupID, record.RootPID, ap.PathAllow, ap.NetAllow, applied.BootstrapFiles, len(applied.BootstrapReadAllow) > 0 || ap.ControlPlaneEndpoint != nil, ap.ControlPlaneEndpoint)
+	// Shared path/net entries were revoked before the generation flip. Clean up
+	// the remaining generation-bound runtime exceptions and record the new set.
+	// Runs only on the BPF-write success path; under applyMu, so serialized with
+	// every other apply/remove transition.
+	d.pruneRuntimeAndRecordAllowlists(ap.SessionID, record.CgroupID, record.RootPID, ap.PathAllow, ap.NetAllow, applied.BootstrapFiles, len(applied.BootstrapReadAllow) > 0 || ap.ControlPlaneEndpoint != nil, ap.ControlPlaneEndpoint)
 
 	d.log.Info("policy applied",
 		"session_id", ap.SessionID,
@@ -965,35 +986,52 @@ func (d *daemon) handleApplyPolicy(req kernelcapture.DaemonProtocolRequest, hand
 	}
 }
 
-// pruneAndRecordAllowlists deletes the path/net allowlist entries this session
-// previously wrote that are absent from the new set (revoking them from the BPF
-// maps, which — unlike op_policy — are not double-buffered and would otherwise
-// keep a dropped path/host allowed), then records the new set. Caller holds
-// applyMu; this briefly takes mu for the appliedAllow map.
-func (d *daemon) pruneAndRecordAllowlists(sessionID string, cgroupID uint64, rootPID uint32, newPaths, newNets []string, bootstrapFiles []kernelcapture.BootstrapFile, trustedRoot bool, controlPlane *kernelcapture.DaemonControlPlaneEndpoint) {
+// staleSharedAllowlistEntries returns path/net entries written by the previous
+// successful apply that the requested policy drops. Caller holds applyMu, so
+// the appliedAllow record cannot change while this plan is used.
+func (d *daemon) staleSharedAllowlistEntries(sessionID string, newPaths, newNets []string) ([]string, []string) {
+	newPathSet := stringSet(newPaths)
+	newNetSet := stringSet(newNets)
+
+	d.mu.RLock()
+	prev := d.appliedAllow[sessionID]
+	d.mu.RUnlock()
+	if prev == nil {
+		return nil, nil
+	}
+
+	var stalePaths, staleNets []string
+	for path := range prev.paths {
+		if _, keep := newPathSet[path]; !keep {
+			stalePaths = append(stalePaths, path)
+		}
+	}
+	for network := range prev.nets {
+		if _, keep := newNetSet[network]; !keep {
+			staleNets = append(staleNets, network)
+		}
+	}
+	return stalePaths, staleNets
+}
+
+// pruneRuntimeAndRecordAllowlists deletes stale bootstrap/control-plane
+// exceptions whose BPF lookups are already bound to cgroup_managed.generation,
+// then records the new path/net/runtime set. Shared path/net revocations happen
+// before ApplyPolicyMaps so they cannot outlive the generation flip. Caller
+// holds applyMu; this briefly takes mu for the appliedAllow map.
+func (d *daemon) pruneRuntimeAndRecordAllowlists(sessionID string, cgroupID uint64, rootPID uint32, newPaths, newNets []string, bootstrapFiles []kernelcapture.BootstrapFile, trustedRoot bool, controlPlane *kernelcapture.DaemonControlPlaneEndpoint) {
 	newPathSet := stringSet(newPaths)
 	newNetSet := stringSet(newNets)
 	newBootstrapFiles := bootstrapFileMap(bootstrapFiles)
 
-	d.mu.Lock()
+	d.mu.RLock()
 	prev := d.appliedAllow[sessionID]
-	d.mu.Unlock()
+	d.mu.RUnlock()
 
-	var stalePaths, staleNets []string
 	var staleBootstrapFiles []kernelcapture.BootstrapFile
 	var staleControl *kernelcapture.DaemonControlPlaneEndpoint
 	deleteTrustedRoot := false
 	if prev != nil {
-		for p := range prev.paths {
-			if _, keep := newPathSet[p]; !keep {
-				stalePaths = append(stalePaths, p)
-			}
-		}
-		for n := range prev.nets {
-			if _, keep := newNetSet[n]; !keep {
-				staleNets = append(staleNets, n)
-			}
-		}
 		for object, file := range prev.bootstrapFiles {
 			if _, keep := newBootstrapFiles[object]; !keep {
 				staleBootstrapFiles = append(staleBootstrapFiles, file)
@@ -1004,12 +1042,6 @@ func (d *daemon) pruneAndRecordAllowlists(sessionID string, cgroupID uint64, roo
 			staleControl = &copy
 		}
 		deleteTrustedRoot = prev.trustedRoot && (!trustedRoot || prev.rootPID != rootPID)
-	}
-	if len(stalePaths) > 0 || len(staleNets) > 0 {
-		if err := kernelcapture.DeleteAllowlistEntries(d.policyMaps, cgroupID, stalePaths, staleNets); err != nil {
-			d.log.Warn("prune stale allowlist entries on re-apply",
-				"session_id", sessionID, "cgroup_id", cgroupID, "error", err)
-		}
 	}
 	if len(staleBootstrapFiles) > 0 {
 		if err := kernelcapture.DeleteBootstrapFileEntries(d.policyMaps, cgroupID, staleBootstrapFiles); err != nil {

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "79c39206e9d9bc2a1f40d06beac3d29099d072a3f65a41046c7101a1f3b2858e"
+source_sha256: "9bfd0924d40d0d3fdc928d3b359c6951a2fcd3754f84ff2dd8be49790aea7f7a"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -22,6 +22,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Revoke path and network allowlist entries dropped by a BPF-LSM policy update
+  before publishing its managed-generation gate, and abort the update if a
+  stale entry cannot be removed
 - Scan inline tool `inputSchema` and legacy `parameters` description annotations
   for instruction injection without treating instance defaults/examples as
   schemas or exposing unsafe schema-member names

--- a/site/content/source/docs/reference/kernel-capture-daemon.md
+++ b/site/content/source/docs/reference/kernel-capture-daemon.md
@@ -2,7 +2,7 @@
 title: "Kernel Capture Daemon Operations"
 description: "`ardur-kernelcaptured` is the Linux daemon that owns Ardur's local Unix-socket"
 source_path: "docs/reference/kernel-capture-daemon.md"
-source_sha256: "e5e4003b98713343970d2d4d42420e844e580de142f13e9de190c35a2f61fb42"
+source_sha256: "ac37d68a586ad225f30a3aaacf8b0ac9ca82a468178f9d6f6cacd5404bdeeada"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -135,6 +135,28 @@ so an old complete pin generation cannot be paired with a new userspace ABI.
 Any observation, map update, cgroup migration, policy application, or ptrace
 transition failure kills the still-stopped target instead of releasing an
 ungoverned process.
+
+## BPF-LSM policy publication
+
+The daemon serializes policy-map mutations and writes a complete operation
+policy into the inactive `cgroup_op_policy` slot. The path and network
+allowlist maps are shared rather than slot-keyed, so a policy update first
+computes entries present in the last successful apply but absent from the new
+request. It must delete all of those stale entries before publishing the new
+`cgroup_managed` generation and active slot. A failed delete rejects the update
+without flipping the managed gate; the prior generation remains active and may
+be more restrictive if some stale deletes already succeeded. This is an
+intentional fail-closed availability trade-off.
+
+After successful pre-revocation, the daemon writes the requested shared
+allowlist entries and flips `cgroup_managed` last. Therefore an entry revoked
+by the new generation cannot remain effective after that generation becomes
+active. Shared allowlist additions can become visible before the final gate
+write when the prior generation already uses the same allowlist action; the
+update sequence does not claim a general transaction across independent BPF
+maps. Bootstrap-file, trusted-root, and control-plane exceptions carry an
+explicit generation and are cleaned after the flip because stale generations
+are already rejected in the BPF lookup path.
 
 ## Process lifecycle cgroup filter
 


### PR DESCRIPTION
## Summary

- compute path-hash and network-LPM entries removed by a BPF-LSM policy update
- revoke those shared allowlist entries before publishing the new `cgroup_managed` generation
- fail closed without flipping the gate if either map deletion fails
- document the availability trade-off and the remaining non-transactional cross-map boundary

Closes #266.

## Why this design

Linux BPF map update/delete operations are per-entry operations, not a transaction spanning the operation-policy, allowlist, and managed-gate maps. The prior userspace mutex serialized writers but did not stop BPF readers, so post-flip cleanup left a live over-permit interval. Pre-revocation is the smallest ABI-preserving fix: it avoids a pinned-map migration, and a failure can only make the prior generation more restrictive.

Primary references:
- https://docs.kernel.org/bpf/maps.html
- https://docs.kernel.org/6.0/bpf/map_hash.html
- https://docs.ebpf.io/linux/map-type/BPF_MAP_TYPE_LPM_TRIE/

## Verification

- focused path-hash/network-LPM ordering and injected-delete regression tests: pass
- `go test ./cmd/ardur-kernelcaptured ./pkg/kernelcapture -count=1`: pass
- `go test -race ./cmd/ardur-kernelcaptured -count=1`: pass
- `go test -count=1 ./...`: pass
- `go vet ./...`: pass
- full Python 3.13: `1797 passed, 33 skipped`
- `./scripts/check-local.sh --quick`: pass
- source docs sync/check and claim validation: pass
- Hugo production build: pass (`284` pages, `116` static files)

The first Python run exposed unrelated load sensitivity in an existing hook timeout test; the exact test and a full rerun passed, and follow-up #287 preserves the evidence.

## Process

- Checkpoint: `architect/sessions/issue-266-allowlist-generation/2026-07-12-journal.md`
- E2E-Exempt: bug/security fix; the existing real KVM BPF-LSM enforcement workflow remains the live-kernel E2E gate.
- README/STATUS reviewed; no high-level claim change required.
