### PR TITLE
docs(aat): define empty constraint semantics

### DIFF
--- a/docs/specs/aat-draft-01-migration-decision.md
+++ b/docs/specs/aat-draft-01-migration-decision.md
@@ -75,7 +75,8 @@ draft-01 migration choice. The v0.1 verifier therefore also:
 - treats token `iat` skew as a one-sided future tolerance while retaining a
   bilateral PoP replay window;
 - validates root issuer URI shape;
-- enforces exact closed-world argument-key preservation;
+- enforces exact closed-world argument-key preservation beneath non-empty
+  parent maps while preserving the draft's unrestricted `{}` semantics;
 - rejects duplicate JSON member names, malformed constraint objects, and
   non-integral delegation depths without parsing full claims before signature
   verification;

--- a/docs/specs/delegation-grant-profile-v0.1.md
+++ b/docs/specs/delegation-grant-profile-v0.1.md
@@ -144,6 +144,19 @@ This profile normatively depends on the following parts of the AAT draft:
 12. Appendix D only for the boundary that an interoperable CWT encoding is
     not defined by this profile.
 
+### 2.5. Empty Constraint Maps
+
+This profile preserves draft-00 Sections 3.3 and 7 semantics for tool argument
+maps. A tool mapped to `{}` is authorized without argument restrictions. A
+non-empty map is closed-world: every invocation argument MUST be named, and
+every named constraint MUST have a matching argument. A child MAY introduce
+constraints beneath an empty parent map because doing so narrows unrestricted
+authority. Once the parent map is non-empty, children MUST preserve its exact
+argument-key set and may only narrow the corresponding constraints.
+
+Issuers that require a fixed argument shape while allowing arbitrary values
+MUST name each permitted argument with an explicit `wildcard` constraint.
+
 ## 3. The `mission_ref` Claim
 
 ### 3.1. Purpose

--- a/docs/specs/delegation-grant-profile-v0.2.md
+++ b/docs/specs/delegation-grant-profile-v0.2.md
@@ -56,6 +56,20 @@ The draft-00 `pattern`, `regex`, `cel`, and `not` types are rejected under this
 profile. They are not treated as draft-01 core constraints and no extension
 registry is enabled by v0.2.
 
+Constraint-map shape follows draft-01 Sections 3.3 and 7 exactly:
+
+- a tool mapped to `{}` authorizes that tool without argument restrictions;
+- a non-empty constraint map is closed-world: every invocation argument MUST
+  be named and every named constraint MUST have a matching argument;
+- a child MAY add any argument-key set beneath an empty parent map, which
+  narrows previously unrestricted authority; and
+- beneath a non-empty parent map, the child MUST preserve the exact argument
+  keys and may only narrow their constraints.
+
+`{}` is therefore a deliberate wildcard boundary, not a deny-by-default empty
+schema. Issuers that need a closed argument shape with unrestricted values MUST
+list every permitted argument with an explicit `wildcard` constraint.
+
 ## 5. Audience-Bound Proof of Possession
 
 The v0.2 proof-of-possession JWT MUST contain a non-empty `aat_aud`. The

--- a/go/pkg/aat/chain_verify.go
+++ b/go/pkg/aat/chain_verify.go
@@ -698,7 +698,8 @@ func verifyLeafInvocation(leaf *Token, tool string, args map[string]interface{})
 		}
 	}
 
-	// Check for unknown args in closed-world mode (if toolConstraints is non-empty)
+	// AAT §3.3 defines an empty map as unrestricted arguments. Once any
+	// constraint is present, the map becomes a closed-world invocation shape.
 	if len(toolConstraints) > 0 {
 		for argName := range args {
 			if _, ok := toolConstraints[argName]; !ok {
@@ -727,7 +728,8 @@ func verifyCapabilityMonotonicity(parent, child *Token) error {
 			return fmt.Errorf("%w: child tool %q not in parent", ErrDenyStep4Q1ToolExpansion, childTool)
 		}
 
-		// 4q2: closed-world shape — if parent has constraints, child must constrain same args
+		// 4q2: a non-empty parent map fixes the closed-world argument shape.
+		// An empty parent map is unrestricted, so a child may add constraints.
 		if len(parentArgMap) > 0 && len(childArgMap) != len(parentArgMap) {
 			return fmt.Errorf("%w: parent and child argument keys differ for tool %q", ErrDenyStep4Q2ArgumentShape, childTool)
 		}

--- a/go/pkg/aat/revision_contract_test.go
+++ b/go/pkg/aat/revision_contract_test.go
@@ -564,6 +564,47 @@ func TestEmptyIntermediateCapabilityIsValidBottomElement(t *testing.T) {
 	}
 }
 
+func TestEmptyToolConstraintMapAuthorizesArbitraryArguments(t *testing.T) {
+	leaf := &Token{
+		TokenType:     AATTypeExecution,
+		Authorization: simpleAuthorization(wildcardToolMap("read_file")),
+	}
+	args := map[string]interface{}{
+		"path":       "/data/report.pdf",
+		"audit_mode": true,
+	}
+	if err := verifyLeafInvocation(leaf, "read_file", args); err != nil {
+		t.Fatalf("empty tool constraint map rejected unrestricted arguments: %v", err)
+	}
+
+	constrainedLeaf := &Token{
+		TokenType: AATTypeExecution,
+		Authorization: simpleAuthorization(ToolMap{
+			"read_file": {
+				"path": {ConstraintType: ConstraintTypeWildcard},
+			},
+		}),
+	}
+	if err := verifyLeafInvocation(constrainedLeaf, "read_file", args); !errors.Is(err, ErrDenyStep6BLeafUnknownArgument) {
+		t.Fatalf("non-empty tool constraint map error = %v, want unknown-argument denial", err)
+	}
+}
+
+func TestEmptyParentConstraintMapMayBeNarrowedByChild(t *testing.T) {
+	parent := &Token{Authorization: simpleAuthorization(wildcardToolMap("read_file"))}
+	child := &Token{Authorization: simpleAuthorization(ToolMap{
+		"read_file": {
+			"path": {ConstraintType: ConstraintTypeExact, Value: "/data/report.pdf"},
+		},
+	})}
+	if err := verifyCapabilityMonotonicity(parent, child); err != nil {
+		t.Fatalf("child constraints below unrestricted parent rejected: %v", err)
+	}
+	if err := verifyCapabilityMonotonicity(child, parent); !errors.Is(err, ErrDenyStep4Q2ArgumentShape) {
+		t.Fatalf("constraint removal below non-empty parent error = %v, want shape denial", err)
+	}
+}
+
 func TestDuplicateToolIdentifierWireIsRejected(t *testing.T) {
 	anchorPublic, anchorPrivate := newKeyPair()
 	holderPublic, _ := newKeyPair()

--- a/go/pkg/aat/types.go
+++ b/go/pkg/aat/types.go
@@ -131,7 +131,8 @@ type ToolMap map[string]ArgumentConstraintMap
 
 // ArgumentConstraintMap maps an argument name to its governing constraint.
 //
-// Closed-world semantics apply when the map is non-empty (AAT §3.3).
+// An empty map authorizes the tool without argument restrictions. Closed-world
+// semantics apply when the map is non-empty (AAT §3.3).
 type ArgumentConstraintMap map[string]*Constraint
 
 // Constraint is the wire-format union for all core AAT argument constraints

--- a/site/content/source/docs/specs/aat-draft-01-migration-decision.md
+++ b/site/content/source/docs/specs/aat-draft-01-migration-decision.md
@@ -2,7 +2,7 @@
 title: "AAT draft-01 Migration Decision"
 description: "**Reviewed 2026-07-11.** Ardur preserves the existing"
 source_path: "docs/specs/aat-draft-01-migration-decision.md"
-source_sha256: "7c9a2f67c5350c1a90fda185fb6c0984744cf0ba00bcee73a888c2f4c42ac31b"
+source_sha256: "6b6612e8f555826b144d151956e4f6798c33cccb1762afdc8d634a06cec19e7a"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["protocol-spec"]
@@ -92,7 +92,8 @@ draft-01 migration choice. The v0.1 verifier therefore also:
 - treats token `iat` skew as a one-sided future tolerance while retaining a
   bilateral PoP replay window;
 - validates root issuer URI shape;
-- enforces exact closed-world argument-key preservation;
+- enforces exact closed-world argument-key preservation beneath non-empty
+  parent maps while preserving the draft's unrestricted `{}` semantics;
 - rejects duplicate JSON member names, malformed constraint objects, and
   non-integral delegation depths without parsing full claims before signature
   verification;

--- a/site/content/source/docs/specs/delegation-grant-profile-v0.1.md
+++ b/site/content/source/docs/specs/delegation-grant-profile-v0.1.md
@@ -2,7 +2,7 @@
 title: "Delegation Grant (DG) Profile of Attenuating Authorization Tokens (AAT) v0.1"
 description: "This document defines version `v0.1` of the Delegation Grant (DG) profile for"
 source_path: "docs/specs/delegation-grant-profile-v0.1.md"
-source_sha256: "54911292268a57c47f9244fc4df61cdbc008fff65ef4f24885371ec17ddd5b92"
+source_sha256: "61da0e94e1aed2bcf61cf2cc3aa321b3978c8b42767ec0d81b21d31155250285"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["protocol-spec"]
@@ -160,6 +160,19 @@ This profile normatively depends on the following parts of the AAT draft:
 11. Section 9.1 for the JWT-claims registration template; and
 12. Appendix D only for the boundary that an interoperable CWT encoding is
     not defined by this profile.
+
+### 2.5. Empty Constraint Maps
+
+This profile preserves draft-00 Sections 3.3 and 7 semantics for tool argument
+maps. A tool mapped to `{}` is authorized without argument restrictions. A
+non-empty map is closed-world: every invocation argument MUST be named, and
+every named constraint MUST have a matching argument. A child MAY introduce
+constraints beneath an empty parent map because doing so narrows unrestricted
+authority. Once the parent map is non-empty, children MUST preserve its exact
+argument-key set and may only narrow the corresponding constraints.
+
+Issuers that require a fixed argument shape while allowing arbitrary values
+MUST name each permitted argument with an explicit `wildcard` constraint.
 
 ## 3. The `mission_ref` Claim
 

--- a/site/content/source/docs/specs/delegation-grant-profile-v0.2.md
+++ b/site/content/source/docs/specs/delegation-grant-profile-v0.2.md
@@ -2,7 +2,7 @@
 title: "Ardur Delegation Grant Profile v0.2 for AAT Draft-01"
 description: "This document defines the Ardur profile identifier"
 source_path: "docs/specs/delegation-grant-profile-v0.2.md"
-source_sha256: "5ed89a67c7a498b2f2548f8146061fd6b19b88c0e7aea6a288cbe611bf17183c"
+source_sha256: "eb963c7c05e04844394f21fffa755a421abb6bf649501757b221b4d56855907c"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["protocol-spec"]
@@ -72,6 +72,20 @@ The supported draft-01 core constraint types are `exact`, `range`, `one_of`,
 The draft-00 `pattern`, `regex`, `cel`, and `not` types are rejected under this
 profile. They are not treated as draft-01 core constraints and no extension
 registry is enabled by v0.2.
+
+Constraint-map shape follows draft-01 Sections 3.3 and 7 exactly:
+
+- a tool mapped to `{}` authorizes that tool without argument restrictions;
+- a non-empty constraint map is closed-world: every invocation argument MUST
+  be named and every named constraint MUST have a matching argument;
+- a child MAY add any argument-key set beneath an empty parent map, which
+  narrows previously unrestricted authority; and
+- beneath a non-empty parent map, the child MUST preserve the exact argument
+  keys and may only narrow their constraints.
+
+`{}` is therefore a deliberate wildcard boundary, not a deny-by-default empty
+schema. Issuers that need a closed argument shape with unrestricted values MUST
+list every permitted argument with an explicit `wildcard` constraint.
 
 ## 5. Audience-Bound Proof of Possession
 


### PR DESCRIPTION
Closes #270.

## Outcome

Confirms the current behavior is normative for both pinned AAT revisions: a tool mapped to `{}` is authorized without argument restrictions, while any non-empty map is closed-world. A child may add constraints beneath an empty parent map because that is attenuation from unrestricted authority.

## Changes

- document the wildcard/closed-world boundary in DG v0.1 and v0.2
- clarify the draft-01 migration record and Go type/verifier comments
- add characterization tests for unrestricted leaf arguments, closed-world rejection, and child narrowing
- regenerate source-backed Hugo mirrors

## Primary sources

- [AAT draft-00 Section 3.3](https://datatracker.ietf.org/doc/html/draft-niyikiza-oauth-attenuating-agent-tokens-00#section-3.3)
- [AAT draft-01 Section 3.3](https://datatracker.ietf.org/doc/html/draft-niyikiza-oauth-attenuating-agent-tokens-01#section-3.3)
- [AAT draft-01 Section 7](https://datatracker.ietf.org/doc/html/draft-niyikiza-oauth-attenuating-agent-tokens-01#section-7)

## Validation

- targeted AAT tests: PASS
- `go test ./... -count=1`: PASS
- `go vet ./...`: PASS
- Python 3.13: `1806 passed, 34 skipped`
- Python sdist/wheel build: PASS
- Hugo source sync/check, claim validation, build, links, provenance: PASS
- `git diff --check`: PASS
