### PR TITLE
test(claude): isolate stalled-daemon timeout signal

### DIFF
--- a/plugins/claude-code/hooks/pre_tool_use
+++ b/plugins/claude-code/hooks/pre_tool_use
@@ -102,64 +102,33 @@ if [ "$daemon_enabled" -eq 1 ] && [ "$native_attempted" -eq 0 ]; then
     # unavailable. Keep this helper out of the top-level wrapper parse path to
     # minimize healthy native-fast-path startup overhead.
     daemon_response="$(
-      HOOK_INPUT="$hook_input" "$daemon_python" -c '
+      HOOK_INPUT="$hook_input" \
+      ARDUR_CC_HOOK_DAEMON_SOCKET="$daemon_socket" \
+      ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS="$daemon_timeout_ms" \
+      "$daemon_python" -c '
 import json
 import os
-import socket
 import sys
 
-from vibap.claude_code_daemon import extract_valid_pre_tool_use_output
+from vibap.claude_code_daemon_client import dispatch_pre_tool_use
 
-
-def _timeout_seconds() -> float:
-    raw = os.environ.get("ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS", "").strip()
-    if not raw:
-        return 0.005
-    try:
-        return max(0.001, float(raw) / 1000.0)
-    except ValueError:
-        return 0.005
-
-
-socket_path = sys.argv[1]
 raw_input = os.environ.get("HOOK_INPUT", "")
 if not raw_input:
     raise SystemExit(1)
 
-request = raw_input if raw_input.endswith("\n") else raw_input + "\n"
-with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conn:
-    conn.settimeout(_timeout_seconds())
-    conn.connect(socket_path)
-    conn.sendall(request.encode("utf-8"))
-
-    chunks: list[bytes] = []
-    total = 0
-    while True:
-        chunk = conn.recv(8192)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        total += len(chunk)
-        if total > 1_000_000:
-            raise ValueError("daemon response exceeded max_bytes")
-        if b"\n" in chunk:
-            break
-
-raw_response = b"".join(chunks)
-line = raw_response.splitlines()[0] if raw_response else b""
-if not line:
+try:
+    hook_input = json.loads(raw_input)
+except (TypeError, ValueError):
+    raise SystemExit(1)
+if not isinstance(hook_input, dict):
     raise SystemExit(1)
 
-response = json.loads(line.decode("utf-8"))
-if not isinstance(response, dict):
-    raise SystemExit(1)
-
-output = extract_valid_pre_tool_use_output(response)
+output = dispatch_pre_tool_use(hook_input)
 if output is None:
     raise SystemExit(1)
 
 sys.stdout.write(json.dumps(output, separators=(",", ":")) + "\n")
-' "$daemon_socket" 2>/dev/null || true
+' 2>/dev/null || true
     )"
     if [ -n "$daemon_response" ]; then
       printf '%s\n' "$daemon_response"

--- a/python/tests/test_claude_code_hook.py
+++ b/python/tests/test_claude_code_hook.py
@@ -2872,20 +2872,17 @@ def test_wrapper_local_fallback_still_denies_forbidden_tool_after_malformed_daem
             socket_parent.rmdir()
 
 
-def test_wrapper_stalled_daemon_socket_respects_millisecond_timeout(tmp_path):
+def test_stalled_daemon_socket_reports_configured_timeout_outcome(monkeypatch):
     import os
     import socket
-    import subprocess
-    import sys
     import threading
-    import time
     import uuid
 
-    token, _ = _issue_test_passport(tmp_path)
-    repo_root = Path(__file__).resolve().parents[2]
-    wrapper = repo_root / "plugins" / "claude-code" / "hooks" / "pre_tool_use"
+    from vibap import claude_code_daemon_client as daemon_client_module
 
-    socket_parent = Path(f"/tmp/ardur-wrapper-stall-{os.getpid()}-{uuid.uuid4().hex[:8]}")
+    socket_parent = Path(
+        f"/tmp/ardur-daemon-client-stall-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    )
     socket_parent.mkdir(mode=0o700)
     socket_path = socket_parent / "hook.sock"
 
@@ -2898,24 +2895,18 @@ def test_wrapper_stalled_daemon_socket_respects_millisecond_timeout(tmp_path):
         try:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
                 server.bind(str(socket_path))
-                server.listen(2)
-                # Wrapper invocation includes shell + Python startup overhead;
-                # keep accept timeout comfortably above typical client latency.
+                server.listen(1)
                 server.settimeout(_FAKE_DAEMON_ACCEPT_TIMEOUT_S)
                 ready.set()
-                while observed["requests"] < 1:
-                    try:
-                        conn, _ = server.accept()
-                    except TimeoutError:
-                        break
-                    with conn:
-                        _ = conn.recv(8192)
-                        observed["requests"] += 1
-                        if observed["requests"] == 1:
-                            # Simulate a daemon that stalls before sending a line.
-                            release.wait(timeout=2)
-                        else:
-                            conn.sendall(b'{"ok":false,"error":"unexpected second daemon attempt"}\\n')
+                conn, _ = server.accept()
+                with conn:
+                    _ = conn.recv(8192)
+                    observed["requests"] += 1
+                    # Keep the real connection open without a response. The
+                    # client must report its configured socket timeout before
+                    # the server is released; no subprocess wall clock is part
+                    # of the decisive assertion.
+                    release.wait(timeout=_FAKE_DAEMON_ACCEPT_TIMEOUT_S)
         except Exception as exc:  # pragma: no cover - surfaced via assertion
             failures.append(exc)
 
@@ -2923,68 +2914,29 @@ def test_wrapper_stalled_daemon_socket_respects_millisecond_timeout(tmp_path):
     thread.start()
 
     try:
-        assert ready.wait(timeout=2)
-        env = {**os.environ}
-        env["ARDUR_MISSION_PASSPORT"] = token
-        env["VIBAP_HOME"] = str(tmp_path)
-        env["VIBAP_KEYS_DIR"] = str(tmp_path)
-        env["ARDUR_CC_HOOK_DIR"] = str(tmp_path / "chain")
-        env["ARDUR_CC_HOOK_DAEMON"] = "1"
-        env["ARDUR_CC_HOOK_DAEMON_SOCKET"] = str(socket_path)
-        env["ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS"] = "50"
-        env["ARDUR_HOOK_PYTHON"] = sys.executable
-        env["PYTHONPATH"] = (
-            str(repo_root / "python")
-            if not env.get("PYTHONPATH")
-            else str(repo_root / "python") + os.pathsep + env["PYTHONPATH"]
-        )
+        assert ready.wait(timeout=_FAKE_DAEMON_ACCEPT_TIMEOUT_S)
+        monkeypatch.setenv("ARDUR_CC_HOOK_DAEMON", "1")
+        monkeypatch.setenv("ARDUR_CC_HOOK_DAEMON_SOCKET", str(socket_path))
+        monkeypatch.setenv("ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS", "50")
 
-        hook_input = json.dumps(
+        result = daemon_client_module._dispatch_pre_tool_use_with_result(
             {
-                "session_id": "wrapper-stall-session",
+                "session_id": "daemon-client-stall-session",
                 "hook_event_name": "PreToolUse",
                 "tool_name": "Read",
-                "tool_input": {"file_path": "/tmp/wrapper-stall.txt"},
-                "tool_use_id": "wrapper-stall-call",
-            }
+                "tool_input": {"file_path": "/tmp/daemon-client-stall.txt"},
+                "tool_use_id": "daemon-client-stall-call",
+            },
         )
-
-        baseline_env = {**env, "ARDUR_CC_HOOK_DAEMON": "0"}
-        baseline_started = time.perf_counter()
-        baseline_result = subprocess.run(
-            [str(wrapper)],
-            input=hook_input,
-            capture_output=True,
-            text=True,
-            env=baseline_env,
-            check=False,
-        )
-        baseline_elapsed_ms = (time.perf_counter() - baseline_started) * 1000.0
-        assert baseline_result.returncode == 0, baseline_result.stderr
-
-        started = time.perf_counter()
-        result = subprocess.run(
-            [str(wrapper)],
-            input=hook_input,
-            capture_output=True,
-            text=True,
-            env=env,
-            check=False,
-        )
-        elapsed_ms = (time.perf_counter() - started) * 1000.0
 
         release.set()
-        thread.join(timeout=3)
+        thread.join(timeout=_FAKE_DAEMON_ACCEPT_TIMEOUT_S)
 
         assert not failures
+        assert not thread.is_alive()
         assert observed["requests"] == 1
-        assert result.returncode == 0, result.stderr
-        output = json.loads(result.stdout)
-        assert output.get("continue") is True
-        assert elapsed_ms < baseline_elapsed_ms + 1000, (
-            "stalled daemon fallback added too much overhead: "
-            f"baseline={baseline_elapsed_ms:.2f}ms stalled={elapsed_ms:.2f}ms"
-        )
+        assert result.output is None
+        assert result.outcome is daemon_client_module._DaemonDispatchOutcome.TIMED_OUT
     finally:
         release.set()
         if socket_path.exists():

--- a/python/vibap/_plugins/claude-code/hooks/pre_tool_use
+++ b/python/vibap/_plugins/claude-code/hooks/pre_tool_use
@@ -102,64 +102,33 @@ if [ "$daemon_enabled" -eq 1 ] && [ "$native_attempted" -eq 0 ]; then
     # unavailable. Keep this helper out of the top-level wrapper parse path to
     # minimize healthy native-fast-path startup overhead.
     daemon_response="$(
-      HOOK_INPUT="$hook_input" "$daemon_python" -c '
+      HOOK_INPUT="$hook_input" \
+      ARDUR_CC_HOOK_DAEMON_SOCKET="$daemon_socket" \
+      ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS="$daemon_timeout_ms" \
+      "$daemon_python" -c '
 import json
 import os
-import socket
 import sys
 
-from vibap.claude_code_daemon import extract_valid_pre_tool_use_output
+from vibap.claude_code_daemon_client import dispatch_pre_tool_use
 
-
-def _timeout_seconds() -> float:
-    raw = os.environ.get("ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS", "").strip()
-    if not raw:
-        return 0.005
-    try:
-        return max(0.001, float(raw) / 1000.0)
-    except ValueError:
-        return 0.005
-
-
-socket_path = sys.argv[1]
 raw_input = os.environ.get("HOOK_INPUT", "")
 if not raw_input:
     raise SystemExit(1)
 
-request = raw_input if raw_input.endswith("\n") else raw_input + "\n"
-with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conn:
-    conn.settimeout(_timeout_seconds())
-    conn.connect(socket_path)
-    conn.sendall(request.encode("utf-8"))
-
-    chunks: list[bytes] = []
-    total = 0
-    while True:
-        chunk = conn.recv(8192)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        total += len(chunk)
-        if total > 1_000_000:
-            raise ValueError("daemon response exceeded max_bytes")
-        if b"\n" in chunk:
-            break
-
-raw_response = b"".join(chunks)
-line = raw_response.splitlines()[0] if raw_response else b""
-if not line:
+try:
+    hook_input = json.loads(raw_input)
+except (TypeError, ValueError):
+    raise SystemExit(1)
+if not isinstance(hook_input, dict):
     raise SystemExit(1)
 
-response = json.loads(line.decode("utf-8"))
-if not isinstance(response, dict):
-    raise SystemExit(1)
-
-output = extract_valid_pre_tool_use_output(response)
+output = dispatch_pre_tool_use(hook_input)
 if output is None:
     raise SystemExit(1)
 
 sys.stdout.write(json.dumps(output, separators=(",", ":")) + "\n")
-' "$daemon_socket" 2>/dev/null || true
+' 2>/dev/null || true
     )"
     if [ -n "$daemon_response" ]; then
       printf '%s\n' "$daemon_response"

--- a/python/vibap/claude_code_daemon_client.py
+++ b/python/vibap/claude_code_daemon_client.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import os
 import socket
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,20 @@ DAEMON_TIMEOUT_MS_ENV_VAR = "ARDUR_CC_HOOK_DAEMON_TIMEOUT_MS"
 _DEFAULT_DAEMON_TIMEOUT_MS = 5.0
 _DEFAULT_SOCKET_BASENAME = "claude-code-hook-daemon.sock"
 _DEFAULT_SOCKET_DIRNAME = "daemon"
+
+
+class _DaemonDispatchOutcome(Enum):
+    DISABLED = "disabled"
+    UNAVAILABLE = "unavailable"
+    TIMED_OUT = "timed_out"
+    INVALID_RESPONSE = "invalid_response"
+    SUCCEEDED = "succeeded"
+
+
+@dataclass(frozen=True)
+class _DaemonDispatchResult:
+    output: dict[str, Any] | None
+    outcome: _DaemonDispatchOutcome
 
 
 def _vibap_home_dir() -> Path:
@@ -127,19 +143,19 @@ def extract_valid_pre_tool_use_output(response: dict[str, Any]) -> dict[str, Any
     return dict(output)
 
 
-def dispatch_pre_tool_use(
+def _dispatch_pre_tool_use_with_result(
     hook_input: dict[str, Any],
     *,
     keys_dir: Path | None = None,
-) -> dict[str, Any] | None:
-    """Try daemon-backed PreToolUse handling.
+) -> _DaemonDispatchResult:
+    """Try daemon-backed PreToolUse handling and retain the fallback reason.
 
-    Returns a hook output dict when daemon dispatch succeeds.
-    Returns None when daemon mode is disabled, unavailable, or yields an
-    invalid response so callers can safely fall back to local handling.
+    The structured result is internal observability for tests and diagnostics;
+    callers should continue to use :func:`dispatch_pre_tool_use` so daemon
+    failures remain a transparent local-fallback boundary.
     """
     if not daemon_enabled():
-        return None
+        return _DaemonDispatchResult(None, _DaemonDispatchOutcome.DISABLED)
 
     payload = {
         "phase": "pre",
@@ -155,7 +171,29 @@ def dispatch_pre_tool_use(
             conn.connect(str(socket_path))
             _write_json_line(conn, payload)
             response = _read_json_line(conn)
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, ValueError, TypeError, json.JSONDecodeError):
-        return None
+    except TimeoutError:
+        return _DaemonDispatchResult(None, _DaemonDispatchOutcome.TIMED_OUT)
+    except OSError:
+        return _DaemonDispatchResult(None, _DaemonDispatchOutcome.UNAVAILABLE)
+    except (ValueError, TypeError):
+        return _DaemonDispatchResult(None, _DaemonDispatchOutcome.INVALID_RESPONSE)
 
-    return extract_valid_pre_tool_use_output(response)
+    output = extract_valid_pre_tool_use_output(response)
+    if output is None:
+        return _DaemonDispatchResult(None, _DaemonDispatchOutcome.INVALID_RESPONSE)
+    return _DaemonDispatchResult(output, _DaemonDispatchOutcome.SUCCEEDED)
+
+
+def dispatch_pre_tool_use(
+    hook_input: dict[str, Any],
+    *,
+    keys_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """Try daemon-backed PreToolUse handling with transparent local fallback.
+
+    Returns a hook output dict when daemon dispatch succeeds. Returns ``None``
+    when daemon mode is disabled, unavailable, timed out, or yields an invalid
+    response so callers can safely fall back to local handling.
+    """
+
+    return _dispatch_pre_tool_use_with_result(hook_input, keys_dir=keys_dir).output


### PR DESCRIPTION
Closes #287\n\n## Outcome\n\nThe stalled-daemon regression now asserts the actual socket-timeout event instead of comparing two complete shell/Python subprocess durations.\n\n- the shared daemon client returns an internal typed dispatch outcome while preserving the public output-or-None fallback API\n- a real stalled AF_UNIX server produces the explicit TIMED_OUT outcome with the configured 50ms timeout\n- the regression contains no subprocess wall-clock upper bound\n- the wrapper Python fallback now reuses the shared client instead of duplicating socket/JSON/timeout logic inline\n- the native fast path, public fallback contract, and production 5ms default are unchanged\n\n## Why this boundary\n\nPython documents that a non-zero socket settimeout causes an incomplete blocking operation to raise TimeoutError, and Python 3.10 made socket.timeout an alias of TimeoutError:\n- https://docs.python.org/3.10/library/socket.html#socket.timeout\n- https://docs.python.org/3.10/library/socket.html#socket.socket.settimeout\n\nPython also documents that initial subprocess creation cannot be interrupted reliably on many platform APIs:\n- https://docs.python.org/3/library/subprocess.html#subprocess.run\n\nTherefore process-level elapsed time is not a valid assertion for a 50ms socket contract under host contention. The test now synchronizes a real server/client transition and asserts the instrumented timeout outcome.\n\n## Verification\n\n- corrected exact regression: PASS\n- repetitions: 10/10 normal and 10/10 with six sustained CPU burners\n- complete Claude hook file: 70 passed\n- wrapper/client compatibility selection: 10 passed\n- full Python suite: 1,811 passed, 33 skipped\n- package build and distribution validation: PASS\n- wrapper Bash syntax and source/package mirror identity: PASS\n- shared client Ruff: PASS\n- scripts/check-local.sh --quick: PASS\n- source-site sync and public-claims validation: PASS\n- git diff --check: PASS\n- README/plugin README reviewed; no contract update required\n\n## Risk and rollback\n\nThe public dispatch return shape and fallback policy are unchanged. The Python fallback now sends the existing envelope protocol rather than the legacy passthrough shape; the daemon already supports both, and the full wrapper/client suite covers the transition. Reverting this single commit restores the previous duplicate inline client and timing-based test.