### PR TITLE
fix(biscuit): reject holder authority widening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
+  side-effect, budget, time, delegation, lineage-parent, or working-directory
+  authority while preserving valid transitive attenuation
 - Label exported actor/verifier identity as signed receipt claims while
   explicitly reporting that the detached exporter did not verify SPIFFE
   workload identity

--- a/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
+++ b/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
@@ -67,7 +67,9 @@ Failures use the stable prefix
 `attenuation:<dimension>:block <index>:` so callers and tests can identify the
 rejected authority dimension without parsing free-form prose.
 
-`_context_from_blocks` raises `BiscuitVerifyError` on any widening observed.
+`_context_from_blocks` raises `ValueError` on any widening observed, and
+`verify_biscuit_passport` translates it into `BiscuitVerifyError` so callers
+see a single verification-failure type.
 The Python helper `derive_child_biscuit` stays as an
 ergonomic issuance entrypoint; its invariants become redundant
 defence-in-depth rather than the only anchor.

--- a/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
+++ b/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
@@ -1,11 +1,12 @@
-# ADR-017: Biscuit Attenuation Narrowing Semantics (proposed)
+# ADR-017: Biscuit Attenuation Narrowing Semantics
 
 Date: 2026-04-21
 
 ## Status
 
-Proposed. Blocks: the "Biscuit-side fact-merge widening" finding from the
-2026-04-21 adversarial re-review of PR #10.
+Accepted on 2026-07-13. Implemented in
+`python/vibap/biscuit_passport.py` and covered by handcrafted-block
+regressions in `python/tests/test_biscuit_passport.py`.
 
 ## Context
 
@@ -39,24 +40,35 @@ Biscuit with an attenuation-violating block.
 
 ## Decision
 
-Replace wholesale with strictly narrowing semantics in
-`_context_from_blocks`:
+Validate every structured child block against the effective parent before
+committing any of the child's facts to `_context_from_blocks`. A widening is
+rejected; it is not silently intersected or clamped, because accepting and
+rewriting an attacker-authored grant would hide an invalid credential from
+operators.
 
 | Family | Parent → Child rule |
 |---|---|
-| `allowed_tool` | Child = Child ∩ Parent (intersection) |
-| `forbidden_tool` | Child = Child ∪ Parent (union) |
+| `allowed_tool` | Effective usable child tools MUST be a subset of the parent's. Parent `*` is unrestricted and can narrow to an explicit list. |
+| `forbidden_tool` | A present child list MUST retain every parent denial; new denials are allowed. |
 | `resource_scope` | Each child entry must be subpath of SOME parent entry |
-| `allowed_side_effect_class` | Child ⊆ Parent |
-| `max_tool_calls_per_class[k]` | Child[k] = min(Child[k], Parent[k]) |
-| `max_tool_calls` | Child = min(Child, Parent) |
-| `max_duration_s` | Child = min(Child, Parent) |
+| `allowed_side_effect_class` | When the parent list is non-empty, child ⊆ parent. An empty parent list is the existing unrestricted encoding and can narrow to any explicit list. |
+| `max_tool_calls_per_class[k]` | A present child map MUST retain parent caps and each retained value MUST be ≤ its parent value. New finite caps narrow an unbounded class. |
+| `max_tool_calls` | Child MUST be non-negative and ≤ parent. |
+| `max_duration_s` | Child MUST be positive and ≤ parent. |
+| `iat` / `exp` | Child `iat` MUST be ≥ parent `iat`; child `exp` MUST be ≤ parent `exp`, after the child `iat`, and not expired at verification time. |
 | `max_delegation_depth` | Child ≤ Parent − 1 |
-| `delegation_allowed` | Child ⇒ Parent (child can only turn it off) |
+| `delegation_allowed` | A structured child is invalid when the parent disallows delegation. A child may disable delegation; enabling it requires positive remaining depth. |
 | `cwd` | Child is subpath of Parent (same rule as JWT path) |
 
-`_context_from_blocks` will raise `BiscuitVerifyError` on any widening
-observed. The Python helper `derive_child_biscuit` stays as an
+The child `parent_jti` MUST also equal the immediately preceding block's `jti`.
+The verifier enforces child expiry directly against its effective wall clock;
+it does not rely on an untrusted holder to include a Datalog expiry check.
+Failures use the stable prefix
+`attenuation:<dimension>:block <index>:` so callers and tests can identify the
+rejected authority dimension without parsing free-form prose.
+
+`_context_from_blocks` raises `BiscuitVerifyError` on any widening observed.
+The Python helper `derive_child_biscuit` stays as an
 ergonomic issuance entrypoint; its invariants become redundant
 defence-in-depth rather than the only anchor.
 
@@ -65,13 +77,19 @@ defence-in-depth rather than the only anchor.
 - Biscuit first-party attenuation via `Biscuit.append` becomes safe
   regardless of holder intent: widening blocks fail verification
   instead of silently succeeding.
-- A handful of existing tests that rely on the current
-  "omit-to-inherit, one-entry-to-replace" shape will need updating.
-- `_context_from_blocks` grows ~60 LOC of narrowing logic. Budget:
-  one focused PR with unit + property-based tests.
+- Omission still inherits the parent family. Presence still requests a
+  replacement, but the replacement is accepted only after monotonic validation.
+- Handcrafted tests cover each authority family, removal of an existing class
+  cap, the reproduced multi-dimension exploit, wildcard/unrestricted parents,
+  and a valid transitive A→B→C narrowing chain.
 - Callers that want to GRANT authority must go through a key-holding
   issuer (`issue_biscuit_passport` or third-party attenuation with a
   signed block), not through `append`.
+
+## References
+
+- [Biscuit Datalog block scoping](https://doc.biscuitsec.org/reference/datalog.html#block-scoping)
+- [Biscuit specification: append-only blocks and execution scopes](https://doc.biscuitsec.org/reference/specifications)
 
 ## Out of scope (separate ADRs)
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,7 +12,7 @@ ADRs are migrated from the private research repo with the two-pass cleanup appli
 |---|-------|--------|------|
 | 015 | [Production-grade SPIRE deployment design for Kubernetes](./ADR-015-production-spire-deployment.md) | Proposed | 2026-04-19 |
 | 016 | [Delegation lineage hash index](./ADR-016-delegation-lineage-hash-index.md) | Accepted | 2026-04-21 |
-| 017 | [Biscuit attenuation narrowing semantics](./ADR-017-biscuit-attenuation-narrowing-semantics.md) | Proposed | 2026-04-21 |
+| 017 | [Biscuit attenuation narrowing semantics](./ADR-017-biscuit-attenuation-narrowing-semantics.md) | Accepted | 2026-04-21 |
 | 018 | [Delegation lineage hash domain unification](./ADR-018-delegation-lineage-hash-domain-unification.md) | Proposed | 2026-04-21 |
 | 019 | [Parent-token anchors against trusted lineage](./ADR-019-parent-token-anchors-against-trusted-lineage.md) | Proposed | 2026-04-21 |
 | 020 | [Persisted-session reverification on load](./ADR-020-persisted-session-reverification-on-load.md) | Proposed | 2026-04-21 |

--- a/python/tests/test_biscuit_passport.py
+++ b/python/tests/test_biscuit_passport.py
@@ -4,7 +4,14 @@ import hashlib
 from dataclasses import fields
 
 import pytest
-from biscuit_auth import Biscuit, BiscuitValidationError, KeyPair, UnverifiedBiscuit
+from biscuit_auth import (
+    Biscuit,
+    BiscuitValidationError,
+    BlockBuilder,
+    Fact,
+    KeyPair,
+    UnverifiedBiscuit,
+)
 
 from vibap.biscuit_passport import (
     BiscuitAttenuationError,
@@ -57,6 +64,51 @@ def _tamper_token_at_marker(token: bytes, marker: bytes) -> bytes:
         raise AssertionError(f"marker not found in token bytes: {marker!r}")
     raw[index] ^= 0x01
     return bytes(raw)
+
+
+def _append_handcrafted_child(
+    parent: bytes,
+    public_key: object,
+    *,
+    expected_parent_jti: str,
+    **overrides: list[str],
+) -> bytes:
+    """Append a structured child without using the trusted issuance helper."""
+
+    facts_by_name = {
+        "jti": ['jti("handcrafted-child")'],
+        "parent_jti": [f'parent_jti("{expected_parent_jti}")'],
+        "spiffe_id": ['spiffe_id("spiffe://example.org/agent/attacker")'],
+        "iat": ["iat(101)"],
+        "exp": ["exp(301)"],
+        "max_tool_calls": ["max_tool_calls(4)"],
+        "max_duration_s": ["max_duration_s(200)"],
+        "delegation_allowed": ["delegation_allowed(true)"],
+        "max_delegation_depth": ["max_delegation_depth(2)"],
+        "cwd": ['cwd("/workspace/project/reports")'],
+        "allowed_tool": [
+            'allowed_tool("read_file")',
+            'allowed_tool("search")',
+        ],
+        "forbidden_tool": [
+            'forbidden_tool("delete_file")',
+            'forbidden_tool("write_file")',
+        ],
+        "resource_scope": ['resource_scope("/workspace/project/reports")'],
+        "allowed_side_effect_class": [
+            'allowed_side_effect_class("none")',
+            'allowed_side_effect_class("external_send")',
+        ],
+        "max_tool_calls_per_class": [
+            'max_tool_calls_per_class("external_send", 1)'
+        ],
+    }
+    facts_by_name.update(overrides)
+    block = BlockBuilder()
+    for fact_sources in facts_by_name.values():
+        for source in fact_sources:
+            block.add_fact(Fact(source))
+    return bytes(Biscuit.from_bytes(parent, public_key).append(block).to_bytes())
 
 
 def test_issue_emits_valid_biscuit_parseable_by_unverified_biscuit() -> None:
@@ -372,8 +424,6 @@ def test_bounded_parent_can_derive_empty_resource_scope() -> None:
 
 
 def test_verifier_rejects_handcrafted_scope_expansion_from_empty_parent() -> None:
-    from biscuit_auth import BlockBuilder, Fact
-
     keypair = _keypair()
     parent = issue_biscuit_passport(
         _mission(resource_scope=[]),
@@ -400,6 +450,285 @@ def test_verifier_rejects_handcrafted_scope_expansion_from_empty_parent() -> Non
     token = Biscuit.from_bytes(parent, keypair.public_key).append(block).to_bytes()
 
     with pytest.raises(BiscuitVerifyError, match="resource scope expansion"):
+        verify_biscuit_passport(token, keypair.public_key, now=102)
+
+
+@pytest.mark.parametrize(
+    ("dimension", "overrides"),
+    [
+        (
+            "allowed_tool",
+            {
+                "allowed_tool": [
+                    'allowed_tool("read_file")',
+                    'allowed_tool("shell")',
+                ]
+            },
+        ),
+        (
+            "forbidden_tool",
+            {"forbidden_tool": ['forbidden_tool("harmless")']},
+        ),
+        (
+            "resource_scope",
+            {"resource_scope": ['resource_scope("/")']},
+        ),
+        (
+            "allowed_side_effect_class",
+            {
+                "allowed_side_effect_class": [
+                    'allowed_side_effect_class("none")',
+                    'allowed_side_effect_class("state_change")',
+                ]
+            },
+        ),
+        (
+            "max_tool_calls",
+            {"max_tool_calls": ["max_tool_calls(6)"]},
+        ),
+        (
+            "max_tool_calls_per_class",
+            {
+                "max_tool_calls_per_class": [
+                    'max_tool_calls_per_class("external_send", 2)'
+                ]
+            },
+        ),
+        (
+            "max_tool_calls_per_class",
+            {
+                "max_tool_calls_per_class": [
+                    'max_tool_calls_per_class("none", 1)'
+                ]
+            },
+        ),
+        (
+            "max_duration_s",
+            {"max_duration_s": ["max_duration_s(301)"]},
+        ),
+        ("iat", {"iat": ["iat(99)"]}),
+        ("exp", {"exp": ["exp(701)"]}),
+        (
+            "max_delegation_depth",
+            {"max_delegation_depth": ["max_delegation_depth(3)"]},
+        ),
+        ("cwd", {"cwd": ['cwd("/")']}),
+        (
+            "parent_jti",
+            {"parent_jti": ['parent_jti("unrelated-parent")']},
+        ),
+    ],
+)
+def test_verifier_rejects_each_handcrafted_authority_widening(
+    dimension: str,
+    overrides: dict[str, list[str]],
+) -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        **overrides,
+    )
+
+    with pytest.raises(
+        BiscuitVerifyError,
+        match=rf"attenuation:{dimension}:",
+    ):
+        verify_biscuit_passport(token, keypair.public_key, now=102)
+
+
+def test_verifier_accepts_handcrafted_monotonic_narrowing() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+    )
+
+    context = verify_biscuit_passport(token, keypair.public_key, now=102)
+
+    assert context.allowed_tools == ["read_file", "search"]
+    assert context.forbidden_tools == ["delete_file", "write_file"]
+    assert context.resource_scope == ["/workspace/project/reports"]
+    assert context.max_tool_calls == 4
+    assert context.max_duration_s == 200
+    assert context.max_delegation_depth == 2
+    assert context.cwd == "/workspace/project/reports"
+
+
+def test_verifier_accepts_tool_narrowing_from_unrestricted_parent() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(allowed_tools=["*"]),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        allowed_tool=['allowed_tool("read_file")'],
+    )
+
+    context = verify_biscuit_passport(token, keypair.public_key, now=102)
+
+    assert context.allowed_tools == ["read_file"]
+
+
+def test_verifier_accepts_side_effect_narrowing_from_unrestricted_parent() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(
+            allowed_side_effect_classes=[],
+            max_tool_calls_per_class={},
+        ),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        allowed_side_effect_class=['allowed_side_effect_class("none")'],
+        max_tool_calls_per_class=['max_tool_calls_per_class("none", 1)'],
+    )
+
+    context = verify_biscuit_passport(token, keypair.public_key, now=102)
+
+    assert context.allowed_side_effect_classes == ["none"]
+    assert context.max_tool_calls_per_class == {"none": 1}
+
+
+def test_verifier_enforces_handcrafted_child_expiry_without_a_datalog_check() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=100)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        iat=["iat(100)"],
+        exp=["exp(101)"],
+    )
+
+    with pytest.raises(BiscuitVerifyError, match=r"attenuation:exp:"):
+        verify_biscuit_passport(token, keypair.public_key, now=102)
+
+
+def test_verifier_rejects_structured_child_when_parent_disallows_delegation() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(delegation_allowed=False, max_delegation_depth=0),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+    )
+
+    with pytest.raises(
+        BiscuitVerifyError,
+        match=r"attenuation:delegation_allowed:",
+    ):
+        verify_biscuit_passport(token, keypair.public_key, now=102)
+
+
+def test_verifier_rejects_reproduced_holder_authority_widening() -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(
+            allowed_tools=["read_file"],
+            max_tool_calls=1,
+            delegation_allowed=False,
+            max_delegation_depth=0,
+            cwd="/safe",
+        ),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        allowed_tool=['allowed_tool("delete_file")'],
+        forbidden_tool=['forbidden_tool("harmless")'],
+        max_tool_calls=["max_tool_calls(999)"],
+        delegation_allowed=["delegation_allowed(true)"],
+        max_delegation_depth=["max_delegation_depth(99)"],
+        cwd=['cwd("/")'],
+    )
+
+    with pytest.raises(BiscuitVerifyError, match=r"attenuation:"):
+        verify_biscuit_passport(token, keypair.public_key, now=102)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        (
+            {"max_tool_calls": ["max_tool_calls(true)"]},
+            "malformed:max_tool_calls",
+        ),
+        (
+            {
+                "max_tool_calls_per_class": [
+                    'max_tool_calls_per_class("external_send", true)'
+                ]
+            },
+            "malformed:max_tool_calls_per_class",
+        ),
+    ],
+)
+def test_verifier_rejects_boolean_values_for_integer_budgets(
+    overrides: dict[str, list[str]],
+    error: str,
+) -> None:
+    keypair = _keypair()
+    parent = issue_biscuit_passport(
+        _mission(),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    parent_context = verify_biscuit_passport(parent, keypair.public_key, now=101)
+    token = _append_handcrafted_child(
+        parent,
+        keypair.public_key,
+        expected_parent_jti=parent_context.jti,
+        **overrides,
+    )
+
+    with pytest.raises(BiscuitVerifyError, match=error):
         verify_biscuit_passport(token, keypair.public_key, now=102)
 
 
@@ -594,6 +923,52 @@ def test_derive_deeply_nested_chain_verifies() -> None:
     assert len(context.delegation_chain) == 4
     assert context.spiffe_id == "spiffe://example.org/agent/child-3"
     assert context.allowed_tools == ["read_file"]
+
+
+def test_valid_a_to_b_to_c_chain_narrows_every_supported_authority() -> None:
+    keypair = _keypair()
+    root = issue_biscuit_passport(
+        _mission(max_delegation_depth=2),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+    child = derive_child_biscuit(
+        root,
+        keypair.private_key,
+        "spiffe://example.org/agent/child",
+        child_allowed_tools=["read_file", "search"],
+        child_resource_scope=["/workspace/project/reports"],
+        child_max_tool_calls=4,
+        child_max_duration_s=200,
+        child_max_tool_calls_per_class={"external_send": 1},
+        child_cwd="/workspace/project/reports",
+        now=101,
+    )
+    grandchild = derive_child_biscuit(
+        child,
+        keypair.private_key,
+        "spiffe://example.org/agent/grandchild",
+        child_allowed_tools=["read_file"],
+        child_resource_scope=["/workspace/project/reports/q1"],
+        child_max_tool_calls=2,
+        child_max_duration_s=100,
+        child_max_tool_calls_per_class={"external_send": 0},
+        child_cwd="/workspace/project/reports/q1",
+        now=102,
+    )
+
+    context = verify_biscuit_passport(grandchild, keypair.public_key, now=103)
+
+    assert context.delegation_depth == 2
+    assert context.allowed_tools == ["read_file"]
+    assert context.resource_scope == ["/workspace/project/reports/q1"]
+    assert context.max_tool_calls == 2
+    assert context.max_duration_s == 100
+    assert context.max_tool_calls_per_class == {"external_send": 0}
+    assert context.delegation_allowed is False
+    assert context.max_delegation_depth == 0
+    assert context.cwd == "/workspace/project/reports/q1"
 
 
 def test_verify_detects_chain_splice() -> None:

--- a/python/tests/test_biscuit_passport.py
+++ b/python/tests/test_biscuit_passport.py
@@ -969,6 +969,18 @@ def test_valid_a_to_b_to_c_chain_narrows_every_supported_authority() -> None:
     assert context.delegation_allowed is False
     assert context.max_delegation_depth == 0
     assert context.cwd == "/workspace/project/reports/q1"
+    # Denials accrete across the whole chain: the root's own forbidden_tools
+    # plus every tool each hop dropped from allowed_tools (write_file at A→B,
+    # search at B→C). A regression that let a hop forget an ancestor's denial
+    # would still satisfy the allowed_tools subset assertion above.
+    assert context.forbidden_tools == ["delete_file", "search", "write_file"]
+    # Families no hop narrows must survive the chain rather than resetting to
+    # an unrestricted default.
+    assert context.allowed_side_effect_classes == ["external_send", "none"]
+    # Time bounds narrow monotonically down the chain: A expires at 700,
+    # B at 301, C at 202.
+    assert context.issued_at == 102
+    assert context.expires_at == 202
 
 
 def test_verify_detects_chain_splice() -> None:

--- a/python/vibap/biscuit_passport.py
+++ b/python/vibap/biscuit_passport.py
@@ -8,7 +8,7 @@ import json
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NoReturn
 
 from biscuit_auth import (
     AuthorizationError,
@@ -292,7 +292,7 @@ def verify_biscuit_passport(
                 )
 
     try:
-        context = _context_from_blocks(block_facts)
+        context = _context_from_blocks(block_facts, effective_now=effective_now)
     except ValueError as exc:
         raise BiscuitVerifyError(str(exc)) from exc
 
@@ -459,7 +459,11 @@ def decode_biscuit_b64(s: str) -> bytes:
         raise ValueError(f"invalid biscuit base64: {exc}") from exc
 
 
-def _context_from_blocks(blocks: list[dict[str, list[list[Any]]]]) -> PassportContext:
+def _context_from_blocks(
+    blocks: list[dict[str, list[list[Any]]]],
+    *,
+    effective_now: int,
+) -> PassportContext:
     if not blocks:
         raise ValueError("missing authority block")
 
@@ -527,9 +531,231 @@ def _context_from_blocks(blocks: list[dict[str, list[list[Any]]]]) -> PassportCo
     ]
     extra_facts = _unknown_fact_map(root)
 
-    for block in blocks[1:]:
+    for block_index, block in enumerate(blocks[1:], start=1):
         block_jti = _required_single(block, "jti", str)
         block_spiffe_id = _required_single(block, "spiffe_id", str)
+        block_parent_jti = _required_single(block, "parent_jti", str)
+        block_issued_at = _required_single(block, "iat", int)
+        block_expires_at = _required_single(block, "exp", int)
+        block_max_tool_calls = _required_single(block, "max_tool_calls", int)
+        block_max_duration_s = _required_single(block, "max_duration_s", int)
+        block_delegation_allowed = _required_single(
+            block, "delegation_allowed", bool
+        )
+        block_max_delegation_depth = _required_single(
+            block, "max_delegation_depth", int
+        )
+
+        if not effective_delegation_allowed:
+            _reject_attenuation(
+                block_index,
+                "delegation_allowed",
+                "parent passport does not allow a structured child block",
+            )
+        if effective_max_delegation_depth <= 0:
+            _reject_attenuation(
+                block_index,
+                "max_delegation_depth",
+                "parent delegation depth is exhausted",
+            )
+        if block_parent_jti != effective_jti:
+            _reject_attenuation(
+                block_index,
+                "parent_jti",
+                f"expected {effective_jti!r}, got {block_parent_jti!r}",
+            )
+        if block_issued_at < effective_issued_at:
+            _reject_attenuation(
+                block_index,
+                "iat",
+                f"child {block_issued_at} precedes parent {effective_issued_at}",
+            )
+        if block_expires_at > effective_expires_at:
+            _reject_attenuation(
+                block_index,
+                "exp",
+                f"child {block_expires_at} exceeds parent {effective_expires_at}",
+            )
+        if block_expires_at <= block_issued_at:
+            _reject_attenuation(
+                block_index,
+                "exp",
+                f"child expiry {block_expires_at} is not after iat {block_issued_at}",
+            )
+        if effective_now > block_expires_at:
+            _reject_attenuation(
+                block_index,
+                "exp",
+                f"child expired at {block_expires_at}; now is {effective_now}",
+            )
+        if block_max_tool_calls < 0:
+            _reject_attenuation(
+                block_index,
+                "max_tool_calls",
+                f"child budget must be non-negative, got {block_max_tool_calls}",
+            )
+        if block_max_tool_calls > effective_max_tool_calls:
+            _reject_attenuation(
+                block_index,
+                "max_tool_calls",
+                (
+                    f"child {block_max_tool_calls} exceeds parent "
+                    f"{effective_max_tool_calls}"
+                ),
+            )
+        if block_max_duration_s <= 0:
+            _reject_attenuation(
+                block_index,
+                "max_duration_s",
+                f"child duration must be positive, got {block_max_duration_s}",
+            )
+        if block_max_duration_s > effective_max_duration_s:
+            _reject_attenuation(
+                block_index,
+                "max_duration_s",
+                (
+                    f"child {block_max_duration_s} exceeds parent "
+                    f"{effective_max_duration_s}"
+                ),
+            )
+        if block_max_delegation_depth < 0:
+            _reject_attenuation(
+                block_index,
+                "max_delegation_depth",
+                f"child depth must be non-negative, got {block_max_delegation_depth}",
+            )
+        max_child_depth = effective_max_delegation_depth - 1
+        if block_max_delegation_depth > max_child_depth:
+            _reject_attenuation(
+                block_index,
+                "max_delegation_depth",
+                f"child {block_max_delegation_depth} exceeds {max_child_depth}",
+            )
+        if block_delegation_allowed and block_max_delegation_depth == 0:
+            _reject_attenuation(
+                block_index,
+                "delegation_allowed",
+                "child enables delegation with zero remaining depth",
+            )
+
+        requested_forbidden_tools = effective_forbidden_tools
+        if "forbidden_tool" in block:
+            requested_forbidden_tools = _fact_values(block, "forbidden_tool", str)
+            removed_denials = sorted(
+                set(effective_forbidden_tools) - set(requested_forbidden_tools)
+            )
+            if removed_denials:
+                _reject_attenuation(
+                    block_index,
+                    "forbidden_tool",
+                    f"child removed parent denials {removed_denials}",
+                )
+
+        requested_allowed_tools = effective_allowed_tools
+        if "allowed_tool" in block:
+            requested_allowed_tools = _fact_values(block, "allowed_tool", str)
+        parent_allowed = set(effective_allowed_tools)
+        child_allowed = set(requested_allowed_tools)
+        parent_denied = set(effective_forbidden_tools)
+        child_denied = set(requested_forbidden_tools)
+        expanded_tools: set[str] = set()
+        if "*" not in parent_allowed:
+            if "*" in child_allowed:
+                expanded_tools.add("*")
+            else:
+                expanded_tools = (child_allowed - child_denied) - (
+                    parent_allowed - parent_denied
+                )
+        if expanded_tools:
+            _reject_attenuation(
+                block_index,
+                "allowed_tool",
+                f"child added usable tools {sorted(expanded_tools)}",
+            )
+
+        requested_resource_scope = effective_resource_scope
+        child_declared_resource_scope: list[str] | None = None
+        if "resource_scope_empty" in block:
+            if _required_single(block, "resource_scope_empty", bool) is not True:
+                raise ValueError("malformed:resource_scope_empty")
+            if "resource_scope" in block:
+                raise ValueError("conflicting:resource_scope and resource_scope_empty")
+            child_declared_resource_scope = []
+        elif "resource_scope" in block:
+            child_declared_resource_scope = _fact_values(
+                block, "resource_scope", str
+            )
+        if child_declared_resource_scope is not None:
+            try:
+                requested_resource_scope = _derive_resource_scope(
+                    effective_resource_scope,
+                    child_declared_resource_scope,
+                )
+            except BiscuitAttenuationError as exc:
+                _reject_attenuation(block_index, "resource_scope", str(exc))
+
+        requested_side_effect_classes = effective_allowed_side_effect_classes
+        if "allowed_side_effect_class" in block:
+            requested_side_effect_classes = _fact_values(
+                block, "allowed_side_effect_class", str
+            )
+            if effective_allowed_side_effect_classes:
+                expanded_classes = sorted(
+                    set(requested_side_effect_classes)
+                    - set(effective_allowed_side_effect_classes)
+                )
+                if expanded_classes:
+                    _reject_attenuation(
+                        block_index,
+                        "allowed_side_effect_class",
+                        f"child added classes {expanded_classes}",
+                    )
+
+        requested_per_class_budget = effective_max_tool_calls_per_class
+        if "max_tool_calls_per_class" in block:
+            requested_per_class_budget = _pair_values(
+                block, "max_tool_calls_per_class"
+            )
+            removed_caps = sorted(
+                set(effective_max_tool_calls_per_class)
+                - set(requested_per_class_budget)
+            )
+            if removed_caps:
+                _reject_attenuation(
+                    block_index,
+                    "max_tool_calls_per_class",
+                    f"child removed parent caps {removed_caps}",
+                )
+            for side_effect_class, child_budget in requested_per_class_budget.items():
+                if child_budget < 0:
+                    _reject_attenuation(
+                        block_index,
+                        "max_tool_calls_per_class",
+                        f"{side_effect_class!r} budget must be non-negative",
+                    )
+                parent_budget = effective_max_tool_calls_per_class.get(
+                    side_effect_class
+                )
+                if parent_budget is not None and child_budget > parent_budget:
+                    _reject_attenuation(
+                        block_index,
+                        "max_tool_calls_per_class",
+                        (
+                            f"{side_effect_class!r} child {child_budget} "
+                            f"exceeds parent {parent_budget}"
+                        ),
+                    )
+
+        requested_cwd = effective_cwd
+        if "cwd" in block:
+            try:
+                requested_cwd = _derive_child_cwd(
+                    effective_cwd,
+                    _required_single(block, "cwd", str),
+                )
+            except (BiscuitAttenuationError, ValueError) as exc:
+                _reject_attenuation(block_index, "cwd", str(exc))
+
         delegation_chain.append(
             {
                 "jti": block_jti,
@@ -541,48 +767,19 @@ def _context_from_blocks(blocks: list[dict[str, list[list[Any]]]]) -> PassportCo
         )
         effective_jti = block_jti
         effective_spiffe_id = block_spiffe_id
-        effective_issued_at = _required_single(block, "iat", int)
-        effective_expires_at = _required_single(block, "exp", int)
-        effective_parent_jti = _required_single(block, "parent_jti", str)
-        effective_max_tool_calls = _required_single(block, "max_tool_calls", int)
-        effective_max_duration_s = _required_single(block, "max_duration_s", int)
-        effective_delegation_allowed = _required_single(
-            block, "delegation_allowed", bool
-        )
-        effective_max_delegation_depth = _required_single(
-            block, "max_delegation_depth", int
-        )
-        if "cwd" in block:
-            effective_cwd = _required_single(block, "cwd", str)
-        if "allowed_tool" in block:
-            effective_allowed_tools = _fact_values(block, "allowed_tool", str)
-        if "forbidden_tool" in block:
-            effective_forbidden_tools = _fact_values(block, "forbidden_tool", str)
-        requested_resource_scope: list[str] | None = None
-        if "resource_scope_empty" in block:
-            if _required_single(block, "resource_scope_empty", bool) is not True:
-                raise ValueError("malformed:resource_scope_empty")
-            if "resource_scope" in block:
-                raise ValueError("conflicting:resource_scope and resource_scope_empty")
-            requested_resource_scope = []
-        elif "resource_scope" in block:
-            requested_resource_scope = _fact_values(block, "resource_scope", str)
-        if requested_resource_scope is not None:
-            try:
-                effective_resource_scope = _derive_resource_scope(
-                    effective_resource_scope,
-                    requested_resource_scope,
-                )
-            except BiscuitAttenuationError as exc:
-                raise ValueError(str(exc)) from exc
-        if "allowed_side_effect_class" in block:
-            effective_allowed_side_effect_classes = _fact_values(
-                block, "allowed_side_effect_class", str
-            )
-        if "max_tool_calls_per_class" in block:
-            effective_max_tool_calls_per_class = _pair_values(
-                block, "max_tool_calls_per_class"
-            )
+        effective_parent_jti = block_parent_jti
+        effective_issued_at = block_issued_at
+        effective_expires_at = block_expires_at
+        effective_max_tool_calls = block_max_tool_calls
+        effective_max_duration_s = block_max_duration_s
+        effective_delegation_allowed = block_delegation_allowed
+        effective_max_delegation_depth = block_max_delegation_depth
+        effective_cwd = requested_cwd
+        effective_allowed_tools = requested_allowed_tools
+        effective_forbidden_tools = requested_forbidden_tools
+        effective_resource_scope = requested_resource_scope
+        effective_allowed_side_effect_classes = requested_side_effect_classes
+        effective_max_tool_calls_per_class = requested_per_class_budget
         extra_facts.update(_unknown_fact_map(block))
 
     # Canonicalize list-valued fields: sorted output guarantees a
@@ -716,13 +913,26 @@ def _split_block_statements(source: str) -> list[str]:
     return statements
 
 
+def _reject_attenuation(
+    block_index: int,
+    dimension: str,
+    detail: str,
+) -> NoReturn:
+    raise ValueError(f"attenuation:{dimension}:block {block_index}: {detail}")
+
+
 def _required_single(block: dict[str, Any], name: str, expected_type: type[Any]) -> Any:
     values = block.get(name)
     if not values:
         raise ValueError(f"missing:{name}")
-    if len(values[-1]) != 1 or not isinstance(values[-1][0], expected_type):
+    value = values[-1][0] if len(values[-1]) == 1 else None
+    if (
+        len(values[-1]) != 1
+        or not isinstance(value, expected_type)
+        or (expected_type is int and isinstance(value, bool))
+    ):
         raise ValueError(f"malformed:{name}")
-    return values[-1][0]
+    return value
 
 
 def _optional_single(
@@ -756,6 +966,7 @@ def _pair_values(block: dict[str, Any], name: str) -> dict[str, int]:
             len(entry) != 2
             or not isinstance(entry[0], str)
             or not isinstance(entry[1], int)
+            or isinstance(entry[1], bool)
         ):
             raise ValueError(f"malformed:{name}")
         parsed[entry[0]] = entry[1]

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "eb41533a3cc5c0565cb99095c856f181aa490471f46edebe3c111446c73e11eb"
+source_sha256: "e2397852a3cf91e7e1dd6e5c90809ae1bc848c51dabafb7abab220c60514b3c5"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -22,6 +22,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
+  side-effect, budget, time, delegation, lineage-parent, or working-directory
+  authority while preserving valid transitive attenuation
 - Label exported actor/verifier identity as signed receipt claims while
   explicitly reporting that the detached exporter did not verify SPIFFE
   workload identity

--- a/site/content/source/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
+++ b/site/content/source/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
@@ -2,7 +2,7 @@
 title: "ADR-017: Biscuit Attenuation Narrowing Semantics"
 description: "Date: 2026-04-21"
 source_path: "docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md"
-source_sha256: "57176d875cf27f6ea6713f96a852e675052187dd4ce15680618260025dbe9fc4"
+source_sha256: "572c86c509e2e181cff6eda0468b669cd66e36ecc9bc19e4c80ffe3d5b878dd2"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["decision-record"]
@@ -84,7 +84,9 @@ Failures use the stable prefix
 `attenuation:<dimension>:block <index>:` so callers and tests can identify the
 rejected authority dimension without parsing free-form prose.
 
-`_context_from_blocks` raises `BiscuitVerifyError` on any widening observed.
+`_context_from_blocks` raises `ValueError` on any widening observed, and
+`verify_biscuit_passport` translates it into `BiscuitVerifyError` so callers
+see a single verification-failure type.
 The Python helper `derive_child_biscuit` stays as an
 ergonomic issuance entrypoint; its invariants become redundant
 defence-in-depth rather than the only anchor.

--- a/site/content/source/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
+++ b/site/content/source/docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md
@@ -1,8 +1,8 @@
 ---
-title: "ADR-017: Biscuit Attenuation Narrowing Semantics (proposed)"
+title: "ADR-017: Biscuit Attenuation Narrowing Semantics"
 description: "Date: 2026-04-21"
 source_path: "docs/decisions/ADR-017-biscuit-attenuation-narrowing-semantics.md"
-source_sha256: "1648eeab451b80b95b28c68862863308bd726e16f2d781cedeaca6b0868afff7"
+source_sha256: "57176d875cf27f6ea6713f96a852e675052187dd4ce15680618260025dbe9fc4"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["decision-record"]
@@ -21,8 +21,9 @@ Date: 2026-04-21
 
 ## Status
 
-Proposed. Blocks: the "Biscuit-side fact-merge widening" finding from the
-2026-04-21 adversarial re-review of PR #10.
+Accepted on 2026-07-13. Implemented in
+`python/vibap/biscuit_passport.py` and covered by handcrafted-block
+regressions in `python/tests/test_biscuit_passport.py`.
 
 ## Context
 
@@ -56,24 +57,35 @@ Biscuit with an attenuation-violating block.
 
 ## Decision
 
-Replace wholesale with strictly narrowing semantics in
-`_context_from_blocks`:
+Validate every structured child block against the effective parent before
+committing any of the child's facts to `_context_from_blocks`. A widening is
+rejected; it is not silently intersected or clamped, because accepting and
+rewriting an attacker-authored grant would hide an invalid credential from
+operators.
 
 | Family | Parent → Child rule |
 |---|---|
-| `allowed_tool` | Child = Child ∩ Parent (intersection) |
-| `forbidden_tool` | Child = Child ∪ Parent (union) |
+| `allowed_tool` | Effective usable child tools MUST be a subset of the parent's. Parent `*` is unrestricted and can narrow to an explicit list. |
+| `forbidden_tool` | A present child list MUST retain every parent denial; new denials are allowed. |
 | `resource_scope` | Each child entry must be subpath of SOME parent entry |
-| `allowed_side_effect_class` | Child ⊆ Parent |
-| `max_tool_calls_per_class[k]` | Child[k] = min(Child[k], Parent[k]) |
-| `max_tool_calls` | Child = min(Child, Parent) |
-| `max_duration_s` | Child = min(Child, Parent) |
+| `allowed_side_effect_class` | When the parent list is non-empty, child ⊆ parent. An empty parent list is the existing unrestricted encoding and can narrow to any explicit list. |
+| `max_tool_calls_per_class[k]` | A present child map MUST retain parent caps and each retained value MUST be ≤ its parent value. New finite caps narrow an unbounded class. |
+| `max_tool_calls` | Child MUST be non-negative and ≤ parent. |
+| `max_duration_s` | Child MUST be positive and ≤ parent. |
+| `iat` / `exp` | Child `iat` MUST be ≥ parent `iat`; child `exp` MUST be ≤ parent `exp`, after the child `iat`, and not expired at verification time. |
 | `max_delegation_depth` | Child ≤ Parent − 1 |
-| `delegation_allowed` | Child ⇒ Parent (child can only turn it off) |
+| `delegation_allowed` | A structured child is invalid when the parent disallows delegation. A child may disable delegation; enabling it requires positive remaining depth. |
 | `cwd` | Child is subpath of Parent (same rule as JWT path) |
 
-`_context_from_blocks` will raise `BiscuitVerifyError` on any widening
-observed. The Python helper `derive_child_biscuit` stays as an
+The child `parent_jti` MUST also equal the immediately preceding block's `jti`.
+The verifier enforces child expiry directly against its effective wall clock;
+it does not rely on an untrusted holder to include a Datalog expiry check.
+Failures use the stable prefix
+`attenuation:<dimension>:block <index>:` so callers and tests can identify the
+rejected authority dimension without parsing free-form prose.
+
+`_context_from_blocks` raises `BiscuitVerifyError` on any widening observed.
+The Python helper `derive_child_biscuit` stays as an
 ergonomic issuance entrypoint; its invariants become redundant
 defence-in-depth rather than the only anchor.
 
@@ -82,13 +94,19 @@ defence-in-depth rather than the only anchor.
 - Biscuit first-party attenuation via `Biscuit.append` becomes safe
   regardless of holder intent: widening blocks fail verification
   instead of silently succeeding.
-- A handful of existing tests that rely on the current
-  "omit-to-inherit, one-entry-to-replace" shape will need updating.
-- `_context_from_blocks` grows ~60 LOC of narrowing logic. Budget:
-  one focused PR with unit + property-based tests.
+- Omission still inherits the parent family. Presence still requests a
+  replacement, but the replacement is accepted only after monotonic validation.
+- Handcrafted tests cover each authority family, removal of an existing class
+  cap, the reproduced multi-dimension exploit, wildcard/unrestricted parents,
+  and a valid transitive A→B→C narrowing chain.
 - Callers that want to GRANT authority must go through a key-holding
   issuer (`issue_biscuit_passport` or third-party attenuation with a
   signed block), not through `append`.
+
+## References
+
+- [Biscuit Datalog block scoping](https://doc.biscuitsec.org/reference/datalog.html#block-scoping)
+- [Biscuit specification: append-only blocks and execution scopes](https://doc.biscuitsec.org/reference/specifications)
 
 ## Out of scope (separate ADRs)
 

--- a/site/content/source/docs/decisions/README.md
+++ b/site/content/source/docs/decisions/README.md
@@ -2,7 +2,7 @@
 title: "Architecture Decision Records"
 description: "ADRs document load-bearing design decisions behind Ardur's runtime, protocol, and deployment shape. Each record captures the context, the decision, and the trade-offs known at the "
 source_path: "docs/decisions/README.md"
-source_sha256: "ac671dc3a874361f53095034047281169bb03271cac1cc071113bfb00b6ce65d"
+source_sha256: "84309234880b2334351b79faf2ed8d2cb17c4a838141561f8803f12eb0cf1d7d"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["decision-record"]
@@ -29,7 +29,7 @@ ADRs are migrated from the private research repo with the two-pass cleanup appli
 |---|-------|--------|------|
 | 015 | [Production-grade SPIRE deployment design for Kubernetes](/__ardur_internal__/source/docs/decisions/adr-015-production-spire-deployment/) | Proposed | 2026-04-19 |
 | 016 | [Delegation lineage hash index](/__ardur_internal__/source/docs/decisions/adr-016-delegation-lineage-hash-index/) | Accepted | 2026-04-21 |
-| 017 | [Biscuit attenuation narrowing semantics](/__ardur_internal__/source/docs/decisions/adr-017-biscuit-attenuation-narrowing-semantics/) | Proposed | 2026-04-21 |
+| 017 | [Biscuit attenuation narrowing semantics](/__ardur_internal__/source/docs/decisions/adr-017-biscuit-attenuation-narrowing-semantics/) | Accepted | 2026-04-21 |
 | 018 | [Delegation lineage hash domain unification](/__ardur_internal__/source/docs/decisions/adr-018-delegation-lineage-hash-domain-unification/) | Proposed | 2026-04-21 |
 | 019 | [Parent-token anchors against trusted lineage](/__ardur_internal__/source/docs/decisions/adr-019-parent-token-anchors-against-trusted-lineage/) | Proposed | 2026-04-21 |
 | 020 | [Persisted-session reverification on load](/__ardur_internal__/source/docs/decisions/adr-020-persisted-session-reverification-on-load/) | Proposed | 2026-04-21 |


### PR DESCRIPTION
Closes #295

## Root cause

A Biscuit holder can append a first-party block without the issuer private key. The verifier reconstructed effective authority by replacing fields with later block facts, so a handcrafted holder block could drop parent denials or widen tools, resources, budgets, time, delegation, and cwd even though `derive_child_biscuit()` correctly narrowed helper-generated children.

## What changed

- validate every structured child against the already-effective parent before committing any child state
- enforce monotonic usable tools, retained denials, resource scope, side-effect classes, total and per-class budgets, maximum duration, issuance/expiry time, delegation permission/depth, immediate `parent_jti`, and cwd
- reject expired child facts directly against verifier time even when a hostile block omits its own Datalog expiry check
- reject boolean values in integer budget facts
- emit stable `attenuation:<dimension>:block <index>:` failures for authority widening
- preserve existing unrestricted encodings: `allowed_tools=["*"]` and an empty side-effect list may narrow to explicit child authority
- add handcrafted adversarial tests, the reproduced multi-dimension exploit, compatibility cases, and a valid A → B → C narrowing chain
- accept ADR-017, update the changelog and decision index, and synchronize the source-backed Hugo mirrors

ADR-018 whole-credential lineage hash-domain work remains intentionally separate.

## Security reasoning

The verifier is the trust boundary because helper-only checks are bypassable. Child facts are extracted and fully validated before any effective state mutation; widening is rejected rather than silently clamped so invalid credentials remain observable.

Primary references:

- [Biscuit Datalog block scoping](https://doc.biscuitsec.org/reference/datalog.html#block-scoping)
- [Biscuit append-only blocks and execution scopes](https://doc.biscuitsec.org/reference/specifications)

## Validation

- Ruff: clean
- focused Biscuit passport suite: **58 passed**
- full Python suite in a CI-like Python 3.13 environment: **1830 passed, 34 skipped**, exit 0; the final two boolean-budget regressions were then added and passed in the focused suite, with no subsequent production-code change
- all Go packages and vet: passed
- Python package: 7 assets synchronized; wheel and sdist content/metadata validation passed; strict twine checks passed
- installed Python 3.13 wheel: import, `ardur --version`, no-key MVP, profile initialization, and packaged Claude Code protection smoke passed
- source-backed site: 115 pages and 113 documentation mirrors synchronized; 10 public claims validated
- Hugo 0.161.1: 285 pages built; rendered documentation links and build-specific source provenance passed
- `git diff --check`: clean

Local Python 3.10 is unavailable, so the protected package matrix remains the source of truth for that interpreter. The repo-local `python/.venv` also defeats two pre-existing missing-dependency fixture simulations because the example runners intentionally prefer that venv; the complete suite passed with the repo venv hidden, matching CI selection behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened Biscuit verification to reject holder-authored child blocks that attempt to widen authority across tool rules, resource scopes, side-effects, budgets/time, delegation, lineage/parent linkage, and working directory.
  * Added time-aware validation at verification time, strict monotonic parent→child narrowing (no silent clamping), and more consistent error reporting while preserving valid transitive attenuation.

* **Documentation**
  * Updated ADR-017 to Accepted, clarifying narrowing/replace-vs-inherit semantics and pointing to the expanded regression coverage.

* **Tests**
  * Expanded handcrafted and chain regression tests to cover widening rejection, expiry enforcement, delegation constraints, input-shape robustness, and A→B→C cumulative narrowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->