### PR TITLE
fix(kernel): prevent seccomp listener fd reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Keep seccomp listener ownership in one goroutine and wake cancellation through
+  a dedicated eventfd, preventing listener teardown from closing a reused
+  control-connection descriptor
 - Prevent torn `PolicyMaps` reads and use-after-close during BPF-LSM guard
   startup, degradation, and shutdown; reject late guards after seccomp fallback
 - Reject attacker-signed JWT-SVIDs even when their SPIFFE ID matches the

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -275,24 +276,27 @@ func sendSeccompHandoffResponse(conn *net.UnixConn, ok bool, errMsg string) erro
 // superviseSeccompListener services connect(2) notifications on fd until ctx
 // is cancelled or the listener errors out — most commonly because the
 // governed process tree exited, closing the last reference to the seccomp
-// filter the notifications were flowing from.
+// filter the notifications were flowing from. The caller is the listener's
+// sole owner and closer; cancellation wakes the poll below through a separate
+// eventfd rather than closing fd from another goroutine.
 func superviseSeccompListener(ctx context.Context, fd int, sessionID string, registrationGeneration, cgroupID uint64, d *daemon, log *slog.Logger) {
-	// Unblock a pending RecvSeccompNotif on shutdown — SECCOMP_IOCTL_NOTIF_RECV
-	// has no context awareness of its own, the same limitation
-	// ringbuf.Reader.Read() has (see daemon_guard_linux.go's runGuardConsumer,
-	// which uses the identical ctx.Done()-closes-the-fd pattern).
-	stop := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			unix.Close(fd)
-		case <-stop:
-		}
-	}()
-	defer close(stop)
+	cancelFD, stopCancellationWatcher, err := newSeccompListenerCancellation(ctx)
+	if err != nil {
+		log.Error("create seccomp listener cancellation event", "session_id", sessionID, "error", err)
+		return
+	}
+	defer stopCancellationWatcher()
 
 	for {
 		if ctx.Err() != nil {
+			return
+		}
+		ready, err := waitForSeccompListenerEvent(fd, cancelFD)
+		if err != nil {
+			log.Info("seccomp listener poll stopped supervisor", "session_id", sessionID, "error", err)
+			return
+		}
+		if !ready || ctx.Err() != nil {
 			return
 		}
 		notif, err := kernelcapture.RecvSeccompNotif(fd)
@@ -314,6 +318,76 @@ func superviseSeccompListener(ctx context.Context, fd int, sessionID string, reg
 		}
 		d.handleSeccompConnectNotif(fd, notif, sessionID, cgroupID, log)
 		d.seccompSessionMu.RUnlock()
+	}
+}
+
+// newSeccompListenerCancellation returns an eventfd that becomes readable
+// when ctx is cancelled. cleanup first stops and joins the watcher, then
+// closes the eventfd, so the watcher can never write to a reused descriptor.
+// It intentionally never closes the seccomp listener itself.
+func newSeccompListenerCancellation(ctx context.Context) (cancelFD int, cleanup func(), err error) {
+	cancelFD, err = unix.Eventfd(0, unix.EFD_CLOEXEC)
+	if err != nil {
+		return -1, nil, fmt.Errorf("create eventfd: %w", err)
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case <-ctx.Done():
+			var signal [8]byte
+			binary.NativeEndian.PutUint64(signal[:], 1)
+			for {
+				if _, writeErr := unix.Write(cancelFD, signal[:]); !errors.Is(writeErr, unix.EINTR) {
+					return
+				}
+			}
+		case <-stop:
+		}
+	}()
+
+	cleanup = func() {
+		close(stop)
+		<-done
+		_ = unix.Close(cancelFD)
+	}
+	return cancelFD, cleanup, nil
+}
+
+// waitForSeccompListenerEvent blocks without consuming either event. A true
+// result means the kernel reported that the following notification receive
+// ioctl will not block. A false result means cancellation won the race.
+func waitForSeccompListenerEvent(listenerFD, cancelFD int) (bool, error) {
+	pollFDs := []unix.PollFd{
+		{Fd: int32(listenerFD), Events: unix.POLLIN},
+		{Fd: int32(cancelFD), Events: unix.POLLIN},
+	}
+	for {
+		_, err := unix.Poll(pollFDs, -1)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("poll listener and cancellation event: %w", err)
+		}
+
+		cancelEvents := pollFDs[1].Revents
+		if cancelEvents&unix.POLLIN != 0 {
+			return false, nil
+		}
+		if cancelEvents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
+			return false, fmt.Errorf("cancellation eventfd reported poll events %#x", cancelEvents)
+		}
+
+		listenerEvents := pollFDs[0].Revents
+		if listenerEvents&unix.POLLIN != 0 {
+			return true, nil
+		}
+		if listenerEvents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
+			return false, fmt.Errorf("seccomp listener reported poll events %#x", listenerEvents)
+		}
 	}
 }
 

--- a/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux_test.go
+++ b/go/cmd/ardur-kernelcaptured/daemon_seccomp_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -331,6 +332,151 @@ func TestSeccompNotificationLifecycleBarrierBlocksEndUntilEvidenceCompletes(t *t
 	}
 	if err := root.cmd.Wait(); err != nil {
 		t.Fatalf("notification child failed: %v\n%s", err, root.output.String())
+	}
+}
+
+func TestSeccompListenerCancellationWakesWithoutClosingListener(t *testing.T) {
+	listenerRead, listenerWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create listener stand-in pipe: %v", err)
+	}
+	defer listenerRead.Close()
+	defer listenerWrite.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelFD, cleanup, err := newSeccompListenerCancellation(ctx)
+	if err != nil {
+		t.Fatalf("create cancellation event: %v", err)
+	}
+	defer cleanup()
+	cancel()
+	cancelPoll := []unix.PollFd{{Fd: int32(cancelFD), Events: unix.POLLIN}}
+	count, err := unix.Poll(cancelPoll, 1000)
+	if err != nil {
+		t.Fatalf("wait for cancellation descriptor readiness: %v", err)
+	}
+	if count != 1 || cancelPoll[0].Revents&unix.POLLIN == 0 {
+		t.Fatalf("cancellation descriptor did not become readable: count=%d events=%#x", count, cancelPoll[0].Revents)
+	}
+
+	ready, err := waitForSeccompListenerEvent(int(listenerRead.Fd()), cancelFD)
+	if err != nil {
+		t.Fatalf("wait for cancellation event: %v", err)
+	}
+	if ready {
+		t.Fatal("listener reported ready when cancellation should win")
+	}
+
+	// The cancellation watcher must not close the listener descriptor. Prove
+	// that the original owner can still use it after the wait has returned.
+	if _, err := listenerWrite.Write([]byte{0x7a}); err != nil {
+		t.Fatalf("write listener stand-in after cancellation: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := listenerRead.Read(buf); err != nil {
+		t.Fatalf("read listener stand-in after cancellation: %v", err)
+	}
+	if buf[0] != 0x7a {
+		t.Fatalf("listener stand-in byte = %#x, want 0x7a", buf[0])
+	}
+}
+
+func TestSeccompListenerPollReportsReadyListener(t *testing.T) {
+	listenerRead, listenerWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create listener stand-in pipe: %v", err)
+	}
+	defer listenerRead.Close()
+	defer listenerWrite.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelFD, cleanup, err := newSeccompListenerCancellation(ctx)
+	if err != nil {
+		t.Fatalf("create cancellation event: %v", err)
+	}
+	defer cleanup()
+	if _, err := listenerWrite.Write([]byte{0x01}); err != nil {
+		t.Fatalf("make listener stand-in readable: %v", err)
+	}
+
+	ready, err := waitForSeccompListenerEvent(int(listenerRead.Fd()), cancelFD)
+	if err != nil {
+		t.Fatalf("wait for listener event: %v", err)
+	}
+	if !ready {
+		t.Fatal("cancellation reported before context was cancelled")
+	}
+}
+
+func TestSeccompListenerCancellationWinsWhenBothDescriptorsAreReady(t *testing.T) {
+	listenerRead, listenerWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create listener stand-in pipe: %v", err)
+	}
+	defer listenerRead.Close()
+	defer listenerWrite.Close()
+	if _, err := listenerWrite.Write([]byte{0x01}); err != nil {
+		t.Fatalf("make listener stand-in readable: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelFD, cleanup, err := newSeccompListenerCancellation(ctx)
+	if err != nil {
+		t.Fatalf("create cancellation event: %v", err)
+	}
+	defer cleanup()
+	cancel()
+	cancelPoll := []unix.PollFd{{Fd: int32(cancelFD), Events: unix.POLLIN}}
+	count, err := unix.Poll(cancelPoll, 1000)
+	if err != nil {
+		t.Fatalf("wait for cancellation descriptor readiness: %v", err)
+	}
+	if count != 1 || cancelPoll[0].Revents&unix.POLLIN == 0 {
+		t.Fatalf("cancellation descriptor did not become readable: count=%d events=%#x", count, cancelPoll[0].Revents)
+	}
+
+	ready, err := waitForSeccompListenerEvent(int(listenerRead.Fd()), cancelFD)
+	if err != nil {
+		t.Fatalf("wait for simultaneous events: %v", err)
+	}
+	if ready {
+		t.Fatal("listener readiness won over cancellation")
+	}
+}
+
+func TestSeccompListenerPollRejectsInvalidListenerDescriptor(t *testing.T) {
+	listenerRead, listenerWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create listener stand-in pipe: %v", err)
+	}
+	defer listenerWrite.Close()
+	listenerFD := int(listenerRead.Fd())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelFD, cleanup, err := newSeccompListenerCancellation(ctx)
+	if err != nil {
+		t.Fatalf("create cancellation event: %v", err)
+	}
+	defer cleanup()
+	// Allocate the cancellation descriptor before closing listenerFD. If the
+	// order is reversed, eventfd can immediately reuse listenerFD and the test
+	// stops exercising POLLNVAL—the exact numeric-fd reuse this regression is
+	// intended to guard against.
+	if err := listenerRead.Close(); err != nil {
+		t.Fatalf("close listener stand-in: %v", err)
+	}
+
+	ready, err := waitForSeccompListenerEvent(listenerFD, cancelFD)
+	if err == nil {
+		t.Fatal("invalid listener descriptor returned no error")
+	}
+	if ready {
+		t.Fatal("invalid listener descriptor reported ready")
+	}
+	if !strings.Contains(err.Error(), "seccomp listener reported poll events") {
+		t.Fatalf("invalid listener error = %q", err)
 	}
 }
 

--- a/go/cmd/ardur-seccomp-smoke/main.go
+++ b/go/cmd/ardur-seccomp-smoke/main.go
@@ -43,6 +43,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -50,6 +51,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -63,12 +65,18 @@ const (
 
 func main() {
 	probeConnect := flag.String("probe-connect", "", "internal: re-exec self as a connect(2) probe against this host:port")
+	probeWait := flag.Bool("probe-wait", false, "internal: re-exec self as a long-lived listener holder")
 	daemonBin := flag.String("daemon-bin", "", "path to a prebuilt ardur-kernelcaptured binary (required)")
 	shimBin := flag.String("shim-bin", "", "path to a prebuilt ardur-exec-shim binary (required)")
+	lifecycleStressIterations := flag.Int("lifecycle-stress-iterations", 100, "live listener teardown iterations under concurrent control traffic")
 	flag.Parse()
 
 	if *probeConnect != "" {
 		runProbe(*probeConnect)
+		return
+	}
+	if *probeWait {
+		runWaitProbe()
 		return
 	}
 
@@ -76,11 +84,15 @@ func main() {
 		fmt.Fprintln(os.Stderr, "usage: ardur-seccomp-smoke --daemon-bin PATH --shim-bin PATH")
 		os.Exit(2)
 	}
-	if err := run(*daemonBin, *shimBin); err != nil {
+	if *lifecycleStressIterations < 1 {
+		fmt.Fprintln(os.Stderr, "lifecycle-stress-iterations must be at least 1")
+		os.Exit(2)
+	}
+	if err := run(*daemonBin, *shimBin, *lifecycleStressIterations); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("PASS: seccomp tier denied a policy-blocked connect() with EPERM and allowed a policy-permitted one through to the kernel")
+	fmt.Println("PASS: seccomp tier enforced connect policy and listener cancellation did not corrupt concurrent control connections")
 }
 
 // runProbe is this binary's own re-exec mode: attempt one TCP connect and
@@ -102,7 +114,13 @@ func runProbe(addr string) {
 	fmt.Printf("OTHER_ERROR:%v\n", err)
 }
 
-func run(daemonBin, shimBin string) (runErr error) {
+func runWaitProbe() {
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func run(daemonBin, shimBin string, lifecycleStressIterations int) (runErr error) {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve own executable path (needed to re-exec as the connect probe): %w", err)
@@ -204,7 +222,233 @@ func run(daemonBin, shimBin string) (runErr error) {
 	}
 	fmt.Println("allowed target correctly reached the kernel with ECONNREFUSED:", allowedOut)
 
+	if err := runListenerCloseStress(sockPath, seccompSockPath, shimBin, self, lifecycleStressIterations); err != nil {
+		return err
+	}
+	fmt.Printf("listener cancellation survived %d live teardowns under concurrent control traffic\n", lifecycleStressIterations)
+
 	return nil
+}
+
+func runListenerCloseStress(daemonSockPath, seccompSockPath, shimBin, self string, iterations int) error {
+	const controlSessionID = "seccomp-close-race-control"
+	if err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    controlSessionID,
+			RootPID:      uint32(os.Getpid()),
+			CgroupID:     uint64(os.Getpid()),
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   300,
+		},
+	}); err != nil {
+		return fmt.Errorf("register control-churn session: %w", err)
+	}
+	defer func() {
+		_ = daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodEndSession,
+			EndSession:      &kernelcapture.DaemonEndSessionRequest{SessionID: controlSessionID},
+		})
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	controlErr := make(chan error, 1)
+	reportControlErr := func(err error) {
+		select {
+		case controlErr <- err:
+		default:
+		}
+	}
+	var controlWG sync.WaitGroup
+
+	// Keep one mutation stream sequential so every generation arrives in the
+	// strictly increasing order the daemon protocol requires. The health
+	// workers provide the other concurrently accepted control connections that
+	// make numeric-fd reuse likely without depending on out-of-order policy
+	// updates being accepted.
+	controlWG.Add(1)
+	go func() {
+		defer controlWG.Done()
+		var generation kernelcapture.BpfPolicyGeneration
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			if generation == kernelcapture.MaxDaemonPolicyGeneration {
+				reportControlErr(errors.New("apply_policy generation exhausted during listener teardown stress"))
+				return
+			}
+			generation++
+			err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+				ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+				Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+				ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+					SessionID:   controlSessionID,
+					Generation:  generation,
+					EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+					OpPolicies: []kernelcapture.DaemonOpPolicy{{
+						Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionAllowlist, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+					}},
+					NetAllow: []string{"127.0.0.2/32"},
+				},
+			})
+			if err != nil {
+				reportControlErr(fmt.Errorf("apply_policy generation %d: %w", generation, err))
+				return
+			}
+		}
+	}()
+
+	for worker := 0; worker < 3; worker++ {
+		controlWG.Add(1)
+		go func(worker int) {
+			defer controlWG.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+					ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+					Method:          kernelcapture.DaemonProtocolMethodHealth,
+					Health:          &kernelcapture.DaemonHealthRequest{},
+				})
+				if err != nil {
+					reportControlErr(fmt.Errorf("health worker %d: %w", worker, err))
+					return
+				}
+			}
+		}(worker)
+	}
+
+	for i := 0; i < iterations; i++ {
+		select {
+		case err := <-controlErr:
+			cancel()
+			controlWG.Wait()
+			return fmt.Errorf("control connection failed during listener teardown: %w", err)
+		default:
+		}
+		sessionID := fmt.Sprintf("seccomp-close-race-%04d", i)
+		waiter, output, err := startShimWaiter(daemonSockPath, shimBin, seccompSockPath, sessionID, self)
+		if err != nil {
+			cancel()
+			controlWG.Wait()
+			return err
+		}
+		endErr := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodEndSession,
+			EndSession:      &kernelcapture.DaemonEndSessionRequest{SessionID: sessionID},
+		})
+		_ = waiter.Process.Kill()
+		waitErr := waiter.Wait()
+		if endErr != nil {
+			cancel()
+			controlWG.Wait()
+			return fmt.Errorf("end live listener session %q: %w (waiter output: %s)", sessionID, endErr, output.String())
+		}
+		if waitErr == nil {
+			cancel()
+			controlWG.Wait()
+			return fmt.Errorf("listener waiter %q exited before cleanup", sessionID)
+		}
+	}
+
+	cancel()
+	controlWG.Wait()
+	select {
+	case err := <-controlErr:
+		return fmt.Errorf("control connection failed during listener teardown: %w", err)
+	default:
+		return nil
+	}
+}
+
+func startShimWaiter(daemonSockPath, shimBin, seccompSockPath, sessionID, self string) (*exec.Cmd, *bytes.Buffer, error) {
+	readyFile := filepath.Join(filepath.Dir(seccompSockPath), sessionID+".ready")
+	cmd := exec.Command(shimBin,
+		"--session-id", sessionID,
+		"--seccomp-socket", seccompSockPath,
+		"--ready-file", readyFile,
+		"--",
+		self, "--probe-wait",
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start listener waiter %q: %w", sessionID, err)
+	}
+	fail := func(err error) (*exec.Cmd, *bytes.Buffer, error) {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(readyFile)
+		return nil, nil, err
+	}
+	if err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodRegisterSession,
+		RegisterSession: &kernelcapture.DaemonRegisterSessionRequest{
+			SessionID:    sessionID,
+			RootPID:      uint32(cmd.Process.Pid),
+			CgroupID:     uint64(cmd.Process.Pid),
+			EventClasses: []string{kernelcapture.DaemonProtocolEventProcessLifecycle},
+			TTLSeconds:   300,
+		},
+	}); err != nil {
+		return fail(fmt.Errorf("register listener waiter %q: %w", sessionID, err))
+	}
+	if err := daemonCall(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+		ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+		Method:          kernelcapture.DaemonProtocolMethodApplyPolicy,
+		ApplyPolicy: &kernelcapture.DaemonApplyPolicyRequest{
+			SessionID:   sessionID,
+			Generation:  1,
+			EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			OpPolicies: []kernelcapture.DaemonOpPolicy{{
+				Op: kernelcapture.BpfOpNetConnect, Action: kernelcapture.BpfActionDeny, EnforceMode: kernelcapture.BpfEnforceModeEnforce,
+			}},
+		},
+	}); err != nil {
+		return fail(fmt.Errorf("apply listener waiter policy %q: %w", sessionID, err))
+	}
+	if err := os.WriteFile(readyFile, []byte("ready\n"), 0o600); err != nil {
+		return fail(fmt.Errorf("release listener waiter %q: %w", sessionID, err))
+	}
+	defer os.Remove(readyFile)
+	if err := waitForListenerAttached(daemonSockPath, sessionID); err != nil {
+		return fail(err)
+	}
+	return cmd, &output, nil
+}
+
+func waitForListenerAttached(daemonSockPath, sessionID string) error {
+	deadline := time.Now().Add(pollTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := daemonRequest(daemonSockPath, kernelcapture.DaemonProtocolRequest{
+			ProtocolVersion: kernelcapture.DaemonProtocolVersion,
+			Method:          kernelcapture.DaemonProtocolMethodSessionStatus,
+			SessionStatus:   &kernelcapture.DaemonSessionStatusRequest{SessionID: sessionID},
+		})
+		if err == nil && resp.OK && resp.SeccompListenerAttached {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else if !resp.OK {
+			lastErr = errors.New(resp.Error)
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("seccomp listener for %q did not attach within %s (last error: %v)", sessionID, pollTimeout, lastErr)
 }
 
 func waitForSocket(path string) error {

--- a/go/cmd/ardur-seccomp-smoke/main.go
+++ b/go/cmd/ardur-seccomp-smoke/main.go
@@ -441,10 +441,13 @@ func waitForListenerAttached(daemonSockPath, sessionID string) error {
 		if err == nil && resp.OK && resp.SeccompListenerAttached {
 			return nil
 		}
-		if err != nil {
+		switch {
+		case err != nil:
 			lastErr = err
-		} else if !resp.OK {
+		case !resp.OK:
 			lastErr = errors.New(resp.Error)
+		default:
+			lastErr = fmt.Errorf("session %q reported ok=true but seccomp_listener_attached=false", sessionID)
 		}
 		time.Sleep(pollInterval)
 	}

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "8c69468dc7656a79739a37fcc05bff056ed40b811eb661fdd3fa1c2b7131db86"
+source_sha256: "119fca0a30ba11f8a99a689a0db3c4d1ff68983c05c13212cff1b8f84f0f9674"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -78,6 +78,9 @@ All notable changes to Ardur will be documented in this file.
 - Removed stale adversarial test-results directory from tracking
 
 ### Fixed
+- Keep seccomp listener ownership in one goroutine and wake cancellation through
+  a dedicated eventfd, preventing listener teardown from closing a reused
+  control-connection descriptor
 - Prevent torn `PolicyMaps` reads and use-after-close during BPF-LSM guard
   startup, degradation, and shutdown; reject late guards after seccomp fallback
 - Reject attacker-signed JWT-SVIDs even when their SPIFFE ID matches the


### PR DESCRIPTION
## Relevant issues

Addresses #278.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new capability or surface
- [ ] `docs` — article, README, or doc change
- [ ] `refactor` — internal change, no behaviour change
- [ ] `test` — test-only change
- [ ] `ci` — CI / workflow / tooling
- [ ] `chore` — housekeeping
- [ ] `dev → main graduation` — promoting reviewed work to release branch

## Changes

- Keep each received seccomp listener fd owned and closed by its supervisor goroutine.
- Wake cancellation through a dedicated `eventfd` in the same `poll(2)` set instead of closing the listener from a watcher goroutine.
- Join the cancellation watcher before closing its eventfd so that descriptor cannot be reused under an in-flight write.
- Add focused cancellation/readiness/POLLNVAL regressions.
- Extend the real Linux seccomp smoke with 100 bounded live listener teardowns under one monotonic policy mutator and three concurrent health streams.
- Record the fix in the Unreleased changelog and regenerate the Hugo source mirror.

## Adversarial proof

- In an ephemeral Linux copy, restored only the legacy production supervisor while retaining the new stress arm.
- The protocol-compliant legacy run failed with `health worker 2: read response: connection reset by peer`, reproducing unrelated control-fd corruption.
- The fixed tree completed three independent 100-iteration privileged runs without reset, `EBADF`, or partial response.

## Testing

- Focused Linux unit tests for cancellation without listener close, listener readiness, cancellation precedence, and invalid-listener `POLLNVAL`.
- Linux Go 1.26.5: `go build ./...`, `go vet ./...`, and `go test -race -count=1 ./...` — green.
- Real privileged seccomp lifecycle stress: 3 x 100 live teardowns — green.
- Seccomp demo enforce/permissive: `EPERM` deny, allowed-path `ECONNREFUSED`, zero permissive denied verdicts, intact chains and matching attestation digests.
- Clean locked Python suite: 1,810 passed, 34 skipped.
- `govulncheck` v1.1.4: zero reachable vulnerabilities.
- gitleaks v8.18.0: 520 commits scanned, no leaks.
- `gofmt`, `git diff --check`, and generated Hugo mirror check — clean.

## Documentation

README reviewed: no change required because this repairs internal descriptor lifetime without expanding the documented seccomp support boundary.

## Review boundary

Target is `dev`. Promotion from `dev` to `main` remains a separate human-reviewed graduation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Linux seccomp-notification listener cancellation and teardown.
  * Cancellation no longer closes/reuses the listener/control connection in a conflicting way.
  * Updated waiting behavior so cancellation deterministically wins under concurrent readiness.

* **Tests**
  * Added new seccomp listener cancellation/polling test cases (including invalid descriptor handling).
  * Extended the seccomp-smoke runner with a lifecycle stress phase to verify cancellation survivability.

* **Documentation**
  * Updated changelog entries under **Fixed** to reflect the listener cancellation and cleanup behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->