### PR TITLE
docs: reconcile stale claims across repo docs and Hugo site (v0.2.0 dev state)

### DIFF
--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -37,7 +37,7 @@ rather than trivially agreeing.
 
 ## Reproducing the results
 
-**Prerequisites**: Go ≥ 1.23, `make`.
+**Prerequisites**: Go ≥ 1.26.5, `make`.
 
 ```sh
 # 1. Clone (or pull) the repository

--- a/deploy/helm/ardur/README.md
+++ b/deploy/helm/ardur/README.md
@@ -99,7 +99,7 @@ production-ready" future effort. That lane would:
 2. Produce a real `values.production.yaml` example
 3. Run on a kind cluster end-to-end (MissionDeclaration CR →
    Reconcile verdict)
-4. Add an ADR (next available number after ADR-021, e.g. `docs/decisions/ADR-022-ardur-helm-chart.md`)
+4. Add an ADR (next available number after ADR-024, e.g. `docs/decisions/ADR-025-ardur-helm-chart.md`)
    documenting chart design decisions — ADR-016 is already taken
    (delegation lineage hash index)
 5. Publish to a Helm repo (possibly GitHub Pages under

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,14 +81,14 @@ while Linux benchmark stress is manual.
 
 [`/.github/workflows/secret-scan.yml`](../.github/workflows/secret-scan.yml)
 
-- **gitleaks** scans the full git history (`fetch-depth: 0`) for secrets — API keys, tokens, private key material. Pinned to commit SHA `ff98106e...`.
+- **gitleaks** scans the full git history (`fetch-depth: 0`) for secrets — API keys, tokens, private key material. It downloads the `gitleaks` v8.18.0 release tarball over HTTPS and verifies it against the published SHA-256 checksum before scanning.
 - **forbidden-terms** is a custom `grep -RInE` job. The configured pattern is defined inline in [`/.github/workflows/secret-scan.yml`](../.github/workflows/secret-scan.yml) — read the workflow file for the authoritative regex (this page deliberately doesn't reproduce the pattern, because doing so would self-trip the gate). The pattern targets a small set of historical-internal references the repo cannot leak. Excludes `.github/`, `.git/`, `artifacts/`. Includes Markdown, YAML, JSON, asciinema casts, TOML, Python, Go, shell, `.gitignore`, `.env*`, `Dockerfile*`, `Makefile*`.
 
 ### `link-check` — lychee on Markdown links
 
 [`/.github/workflows/link-check.yml`](../.github/workflows/link-check.yml)
 
-- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.8.0` (commit-pinned).
+- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
 - Currently excludes five URL patterns/domains. One (`security/advisories/new`) requires being signed in to GitHub, so an unauthenticated checker gets a 404. Four bot-blocking domains (`developers.redhat.com`, `medium.com`, `answers.uillinois.edu`, `theregister.com`) return 403 to automated requests; these are legitimate research citations excluded rather than removed. The earlier Discussions-tab exclude was removed once Discussions was enabled on the repo.
 
 ### `validate-formats` — JSON and YAML parsers
@@ -104,7 +104,7 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
 [`/.github/workflows/codeql.yml`](../.github/workflows/codeql.yml)
 
 - A pre-flight job (`detect-languages`) checks whether `python/` or `go/` carries source files. With the current dev tree, the matrix detects Python and Go and runs analysis per language.
-- The CodeQL actions (`init`, `autobuild`, and `analyze`) are pinned to full commit SHAs in the workflow file, with the human-readable `v3` series noted in comments. Treat `.github/workflows/codeql.yml` as the authority for the exact pins so this testing guide does not drift when the pin is updated.
+- The CodeQL actions (`init`, `autobuild`, and `analyze`) are pinned to full commit SHAs in the workflow file, with the human-readable `v4` series noted in comments. Treat `.github/workflows/codeql.yml` as the authority for the exact pins so this testing guide does not drift when the pin is updated.
 - Pairs with the `code_quality` ruleset rule on `main`: that rule reads from GitHub's code-scanning alerts table, so it passes vacuously while the matrix is empty and substantively once code lands. The CI job name (`codeql`) is intentionally **not** in the required-status-checks list — the ruleset already gates merges via the alerts mechanism.
 
 ### `tests` — Python and Go runtime tests
@@ -165,7 +165,7 @@ make reproduce
 
 ## Go AAT Test Suite
 
-The `go/pkg/aat` package has 74 named tests covering the draft-00 DG v0.1
+The `go/pkg/aat` package has 76 named tests covering the draft-00 DG v0.1
 contract and the version-dispatched draft-01 DG v0.2 profile. The fixture
 command has an additional byte-for-byte artifact regression:
 

--- a/docs/articles/06-public-import-discipline.md
+++ b/docs/articles/06-public-import-discipline.md
@@ -142,7 +142,7 @@ The graduation gates we run before promoting a `dev` commit to
    (the runtime's embedded copy). A CI gate fails the build on
    drift between them.
 4. **Tests.** Python on 3.10 and 3.13; Go at the version pinned
-   in `go.mod` (currently 1.25.9).
+   in `go.mod` (currently 1.26.5).
 5. **CodeQL** for both Python and Go.
 6. **A 24-hour cool-off re-read** of the diff by the maintainer
    before the merge. The graduation gate isn't just CI — it's

--- a/docs/mvp-evaluator-guide.md
+++ b/docs/mvp-evaluator-guide.md
@@ -234,8 +234,10 @@ This removes the Compose containers, network, and named volumes for the project.
   so the walkthrough uses curl's loopback-only `--insecure` mode. Do not carry
   that TLS policy to a remote deployment.
 - **Single-user demo:** the local stack is not a multi-tenant isolation model.
-- **Python Token Status List:** Token Status List revocation checking is
-  implemented in the Go credential verifier but not yet in Python.
+- **Token Status List scope:** Credential-level Token Status List revocation
+  checking lives in the Go credential verifier (`go/pkg/credential`). The Python
+  path checks mission-level status lists (`vibap.mission.mission_is_revoked`)
+  but does not yet implement the credential-level check.
 
 ## Where to look next
 

--- a/docs/public-import-plan.md
+++ b/docs/public-import-plan.md
@@ -100,7 +100,7 @@ ardur/
 5. **Go runtime and protocol schemas — done.**
    `go/` is a coherent module covering credential, governance, policy, SPIFFE,
    AAT (draft-00/draft-01 profile dispatch, constraint engine, derivation, PoP,
-   chain verification, and deterministic fixture regression — 74 package tests),
+   chain verification, and deterministic fixture regression — 76 package tests),
    provenance, issuer, trust, transparency, and CLI surfaces.
 
 6. **Deployment material — partly done.**

--- a/docs/reference/ardur-md-profile.md
+++ b/docs/reference/ardur-md-profile.md
@@ -109,6 +109,9 @@ Passport:
   new users.
 - `safe-coding` — allow Read, Search, Edit, Write inside the protected
   folder; block shell commands.
+- `personal-firewall` — allow Read, Search, Edit, Write; block shell commands
+  and external network access; adds a forbid rule that blocks secret-like
+  arguments (API keys, tokens, private key material).
 
 Template source is in
 [`python/vibap/ardur_profile.py`](../../python/vibap/ardur_profile.py)

--- a/go/README.md
+++ b/go/README.md
@@ -107,8 +107,9 @@ governance HTTP API.
 - **Governance HTTP proxy** — lives in `python/vibap/proxy.py`.
 - **CLI** — lives in `python/vibap/cli.py`.
 - **Personal Hub** — lives in `python/vibap/personal_hub.py`.
-- **Benchmark harness binaries** — the `cmd/benchmark*` and `cmd/benchcheck`
-  binaries were removed; benchmark scenario types live in `benchmark/`.
+- **Benchmark harness binaries** — the `cmd/benchmark*` binaries were removed;
+  benchmark scenario types live in `benchmark/`. The `cmd/benchcheck` AuditBench
+  evaluation harness remains present.
 - **Vendor-specific telemetry connectors** — stay private.
 - **Live benchmark fixtures** — AgentDojo, InjecAgent, R-Judge, STAC remain
   in the internal research tree.

--- a/reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md
+++ b/reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md
@@ -40,7 +40,7 @@ This is an experimental development boundary, not release or production readines
 - `go/pkg/kernelcapture/daemon_accept_loop_plan.go` validates a dry-run accept-loop plan with custody validation, explicit UID/GID allowlists, bounded request bytes, read timeout, bounded concurrency, and non-executed preflight/bind/accept/peer-observation/decode/authorization/dispatch steps.
 - `go/pkg/kernelcapture/launch_wrapper_session.go` defines the launch-wrapper no-execution contract seam and deterministic evidence envelope.
 - `go/pkg/kernelcapture/launch_wrapper_session_test.go` verifies launch-wrapper digest integrity and boundary behavior.
-- `reports/PHASE2_EBPF_MVP_VERIFICATION_2026-05-10.md` records the Linux eBPF MVP verification context and environment limits.
+- `reports/PHASE2_EBPF_MVP_VERIFICATION_2026-05-10.md` recorded the Linux eBPF MVP verification context and environment limits (that companion report was removed during the open-source-release cleanup and is no longer present in this tree).
 
 ## Not claimed
 

--- a/site/content/get-started.md
+++ b/site/content/get-started.md
@@ -86,7 +86,7 @@ ollama pull <your-model>
 ollama serve
 
 # Run the governance proxy
-PYTHONPATH=python python -m vibap.cli hub start
+PYTHONPATH=python python -m vibap.cli hub
 ```
 
 ### With Ollama (cloud models)
@@ -97,7 +97,7 @@ For larger models via Ollama's cloud API:
 export OLLAMA_API_KEY="your-api-key"
 
 # Run the full governance test
-PYTHONPATH=python python tests/run_cloud_model_test.py "$MODEL_NAME"
+PYTHONPATH=python python python/tests/run_cloud_model_test.py "$MODEL_NAME"
 ```
 
 This optional harness routes its configured tool requests through Ardur's

--- a/site/content/proof.md
+++ b/site/content/proof.md
@@ -25,11 +25,11 @@ a live provider.
 
 ## Current Verification Snapshot
 
-At the reviewed `dev` tree on 2026-07-09:
+At the reviewed `dev` tree on 2026-07-11:
 
 | Gate | Result |
 |---|---|
-| Python local run with CI coverage flags | 1,363 passed, 32 skipped, 85% coverage |
+| Python local run with CI coverage flags | 1,665 passed, 33 skipped; CI separately enforces its coverage threshold |
 | Python CI | Python 3.10 and 3.13, lint, and wheel smoke passed |
 | Go CI | Tests, vet, lint, and vulnerability scan passed |
 | Static/security | Python and Go CodeQL, secret scans, and format checks passed |

--- a/site/content/source/REPRODUCE.md
+++ b/site/content/source/REPRODUCE.md
@@ -2,7 +2,7 @@
 title: "Reproducing AuditBench Harness Fixtures"
 description: "This document describes how to reproduce the deterministic AuditBench harness"
 source_path: "REPRODUCE.md"
-source_sha256: "fc3bf5268c6766b23e1c30c348d378267a8f17932ec7cacb4304b93186c32054"
+source_sha256: "dc0e4bbc322e20664bc83fa6d6460719d81ee9bc6f5c9d729f73802d22e4e3dc"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -54,7 +54,7 @@ rather than trivially agreeing.
 
 ## Reproducing the results
 
-**Prerequisites**: Go ≥ 1.23, `make`.
+**Prerequisites**: Go ≥ 1.26.5, `make`.
 
 ```sh
 # 1. Clone (or pull) the repository

--- a/site/content/source/deploy/helm/ardur/README.md
+++ b/site/content/source/deploy/helm/ardur/README.md
@@ -2,7 +2,7 @@
 title: "Ardur Helm chart — skeleton"
 description: "Status: **SKELETON**. `Chart.yaml` + `values.yaml` + `_helpers.tpl`"
 source_path: "deploy/helm/ardur/README.md"
-source_sha256: "53aef24980af634f660a23c50edd05791602e3583ccca549e70c4bbcfb8418f2"
+source_sha256: "b238f5e29a628be585973059c91667c7e2f7d6609e3997936dd92f3621322784"
 weight: 100
 maturity: ["in-progress"]
 claim_types: ["deployment"]
@@ -116,7 +116,7 @@ production-ready" future effort. That lane would:
 2. Produce a real `values.production.yaml` example
 3. Run on a kind cluster end-to-end (MissionDeclaration CR →
    Reconcile verdict)
-4. Add an ADR (next available number after ADR-021, e.g. `docs/decisions/ADR-022-ardur-helm-chart.md`)
+4. Add an ADR (next available number after ADR-024, e.g. `docs/decisions/ADR-025-ardur-helm-chart.md`)
    documenting chart design decisions — ADR-016 is already taken
    (delegation lineage hash index)
 5. Publish to a Helm repo (possibly GitHub Pages under

--- a/site/content/source/docs/TESTING.md
+++ b/site/content/source/docs/TESTING.md
@@ -2,7 +2,7 @@
 title: "Testing"
 description: "The public tree includes curated Python and Go runtime code under `python/`"
 source_path: "docs/TESTING.md"
-source_sha256: "d909610cc24d34c84a59fbd5bbc4492f89fa860d3483e7f73efef1df8eb1cbc0"
+source_sha256: "33a43e63be579a3252216ab9832292ed92c9c84ba61ad0bab6fec205994c5eed"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -98,14 +98,14 @@ while Linux benchmark stress is manual.
 
 [`/.github/workflows/secret-scan.yml`](/__ardur_internal__/repo/.github/workflows/secret-scan.yml)
 
-- **gitleaks** scans the full git history (`fetch-depth: 0`) for secrets — API keys, tokens, private key material. Pinned to commit SHA `ff98106e...`.
+- **gitleaks** scans the full git history (`fetch-depth: 0`) for secrets — API keys, tokens, private key material. It downloads the `gitleaks` v8.18.0 release tarball over HTTPS and verifies it against the published SHA-256 checksum before scanning.
 - **forbidden-terms** is a custom `grep -RInE` job. The configured pattern is defined inline in [`/.github/workflows/secret-scan.yml`](/__ardur_internal__/repo/.github/workflows/secret-scan.yml) — read the workflow file for the authoritative regex (this page deliberately doesn't reproduce the pattern, because doing so would self-trip the gate). The pattern targets a small set of historical-internal references the repo cannot leak. Excludes `.github/`, `.git/`, `artifacts/`. Includes Markdown, YAML, JSON, asciinema casts, TOML, Python, Go, shell, `.gitignore`, `.env*`, `Dockerfile*`, `Makefile*`.
 
 ### `link-check` — lychee on Markdown links
 
 [`/.github/workflows/link-check.yml`](/__ardur_internal__/repo/.github/workflows/link-check.yml)
 
-- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.8.0` (commit-pinned).
+- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
 - Currently excludes five URL patterns/domains. One (`security/advisories/new`) requires being signed in to GitHub, so an unauthenticated checker gets a 404. Four bot-blocking domains (`developers.redhat.com`, `medium.com`, `answers.uillinois.edu`, `theregister.com`) return 403 to automated requests; these are legitimate research citations excluded rather than removed. The earlier Discussions-tab exclude was removed once Discussions was enabled on the repo.
 
 ### `validate-formats` — JSON and YAML parsers
@@ -121,7 +121,7 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
 [`/.github/workflows/codeql.yml`](/__ardur_internal__/repo/.github/workflows/codeql.yml)
 
 - A pre-flight job (`detect-languages`) checks whether `python/` or `go/` carries source files. With the current dev tree, the matrix detects Python and Go and runs analysis per language.
-- The CodeQL actions (`init`, `autobuild`, and `analyze`) are pinned to full commit SHAs in the workflow file, with the human-readable `v3` series noted in comments. Treat `.github/workflows/codeql.yml` as the authority for the exact pins so this testing guide does not drift when the pin is updated.
+- The CodeQL actions (`init`, `autobuild`, and `analyze`) are pinned to full commit SHAs in the workflow file, with the human-readable `v4` series noted in comments. Treat `.github/workflows/codeql.yml` as the authority for the exact pins so this testing guide does not drift when the pin is updated.
 - Pairs with the `code_quality` ruleset rule on `main`: that rule reads from GitHub's code-scanning alerts table, so it passes vacuously while the matrix is empty and substantively once code lands. The CI job name (`codeql`) is intentionally **not** in the required-status-checks list — the ruleset already gates merges via the alerts mechanism.
 
 ### `tests` — Python and Go runtime tests
@@ -182,7 +182,7 @@ make reproduce
 
 ## Go AAT Test Suite
 
-The `go/pkg/aat` package has 74 named tests covering the draft-00 DG v0.1
+The `go/pkg/aat` package has 76 named tests covering the draft-00 DG v0.1
 contract and the version-dispatched draft-01 DG v0.2 profile. The fixture
 command has an additional byte-for-byte artifact regression:
 

--- a/site/content/source/docs/articles/06-public-import-discipline.md
+++ b/site/content/source/docs/articles/06-public-import-discipline.md
@@ -2,7 +2,7 @@
 title: "Public Import Discipline"
 description: "We had a private research repo with three years of history, a paper,"
 source_path: "docs/articles/06-public-import-discipline.md"
-source_sha256: "42edc3ae5860d01bdc6063bb54615f45b7d704004ed76edccf9eefed83f4ba68"
+source_sha256: "7086b650d92cb623df02117f0ec1762db8e13f275ec6f9c1a11c63a5d41871c8"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["article"]
@@ -159,7 +159,7 @@ The graduation gates we run before promoting a `dev` commit to
    (the runtime's embedded copy). A CI gate fails the build on
    drift between them.
 4. **Tests.** Python on 3.10 and 3.13; Go at the version pinned
-   in `go.mod` (currently 1.25.9).
+   in `go.mod` (currently 1.26.5).
 5. **CodeQL** for both Python and Go.
 6. **A 24-hour cool-off re-read** of the diff by the maintainer
    before the merge. The graduation gate isn't just CI — it's

--- a/site/content/source/docs/mvp-evaluator-guide.md
+++ b/site/content/source/docs/mvp-evaluator-guide.md
@@ -2,7 +2,7 @@
 title: "Ardur MVP Evaluator Guide"
 description: "Use this source-checkout guide to evaluate Ardur's authenticated Docker demo:"
 source_path: "docs/mvp-evaluator-guide.md"
-source_sha256: "6f96a6f592cb74634e596913957e6b13b1864fd06ccf4e62b41b82f829faaf75"
+source_sha256: "d61273611c9d0c7ff38a2352d4053853727a4275236dc21137e9f39745095573"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -251,8 +251,10 @@ This removes the Compose containers, network, and named volumes for the project.
   so the walkthrough uses curl's loopback-only `--insecure` mode. Do not carry
   that TLS policy to a remote deployment.
 - **Single-user demo:** the local stack is not a multi-tenant isolation model.
-- **Python Token Status List:** Token Status List revocation checking is
-  implemented in the Go credential verifier but not yet in Python.
+- **Token Status List scope:** Credential-level Token Status List revocation
+  checking lives in the Go credential verifier (`go/pkg/credential`). The Python
+  path checks mission-level status lists (`vibap.mission.mission_is_revoked`)
+  but does not yet implement the credential-level check.
 
 ## Where to look next
 

--- a/site/content/source/docs/public-import-plan.md
+++ b/site/content/source/docs/public-import-plan.md
@@ -2,7 +2,7 @@
 title: "Public Import Plan"
 description: "This plan converted the private source tree into the public Ardur repo without"
 source_path: "docs/public-import-plan.md"
-source_sha256: "669f9b325e65afaea908f009d46a6c00b32356cd0c568f5a13b51edfe3f3028f"
+source_sha256: "f0a42f67de9f7e06c29d55ccfc9fc962a1dbb1246073cbdcad6f63153e4e797c"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -117,7 +117,7 @@ ardur/
 5. **Go runtime and protocol schemas — done.**
    `go/` is a coherent module covering credential, governance, policy, SPIFFE,
    AAT (draft-00/draft-01 profile dispatch, constraint engine, derivation, PoP,
-   chain verification, and deterministic fixture regression — 74 package tests),
+   chain verification, and deterministic fixture regression — 76 package tests),
    provenance, issuer, trust, transparency, and CLI surfaces.
 
 6. **Deployment material — partly done.**

--- a/site/content/source/docs/reference/ardur-md-profile.md
+++ b/site/content/source/docs/reference/ardur-md-profile.md
@@ -2,7 +2,7 @@
 title: "ARDUR.md` Profile Format"
 description: "The `ARDUR.md` profile is a plain-Markdown guardrail file that compiles into"
 source_path: "docs/reference/ardur-md-profile.md"
-source_sha256: "926aba720ee884d74863521a0678ee03745ce5ae1bbd29be5a01d2a8f77279c8"
+source_sha256: "82d0a7fedfb1f63ef729b05e554a3e21a0308da0b65f7af171854223a43de8ca"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -126,6 +126,9 @@ Passport:
   new users.
 - `safe-coding` — allow Read, Search, Edit, Write inside the protected
   folder; block shell commands.
+- `personal-firewall` — allow Read, Search, Edit, Write; block shell commands
+  and external network access; adds a forbid rule that blocks secret-like
+  arguments (API keys, tokens, private key material).
 
 Template source is in
 [`python/vibap/ardur_profile.py`](https://github.com/ArdurAI/ardur/blob/__ARDUR_SOURCE_REF__/python/vibap/ardur_profile.py)

--- a/site/content/source/go/README.md
+++ b/site/content/source/go/README.md
@@ -2,7 +2,7 @@
 title: "Ardur — Go Runtime"
 description: "Go handles the parts of Ardur where Python falls short: Linux eBPF kernel"
 source_path: "go/README.md"
-source_sha256: "e3bc7418f4418c9fa1a31f6f7e6c598cfb63970d58524736e9f27e273e0fd025"
+source_sha256: "95c8a6265e7485facdd3b2b8917d19c92ab78ee61e5fd071341d568792fb1cf2"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["runtime-boundary"]
@@ -124,8 +124,9 @@ governance HTTP API.
 - **Governance HTTP proxy** — lives in `python/vibap/proxy.py`.
 - **CLI** — lives in `python/vibap/cli.py`.
 - **Personal Hub** — lives in `python/vibap/personal_hub.py`.
-- **Benchmark harness binaries** — the `cmd/benchmark*` and `cmd/benchcheck`
-  binaries were removed; benchmark scenario types live in `benchmark/`.
+- **Benchmark harness binaries** — the `cmd/benchmark*` binaries were removed;
+  benchmark scenario types live in `benchmark/`. The `cmd/benchcheck` AuditBench
+  evaluation harness remains present.
 - **Vendor-specific telemetry connectors** — stay private.
 - **Live benchmark fixtures** — AgentDojo, InjecAgent, R-Judge, STAC remain
   in the internal research tree.

--- a/site/content/source/reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md
+++ b/site/content/source/reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md
@@ -2,7 +2,7 @@
 title: "Phase 2 Daemon/Kernel Boundary Claim Ledger"
 description: "Date: 2026-07-01"
 source_path: "reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md"
-source_sha256: "dd4cb70f45d329e166f96424e7c6c47ccb0f4703d8feed7051e9d0c76d5b1610"
+source_sha256: "6b7465dbf359e1614be977c27c71402868d9a37d710fe1cb9ad18346817f9ecc"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -57,7 +57,7 @@ This is an experimental development boundary, not release or production readines
 - `go/pkg/kernelcapture/daemon_accept_loop_plan.go` validates a dry-run accept-loop plan with custody validation, explicit UID/GID allowlists, bounded request bytes, read timeout, bounded concurrency, and non-executed preflight/bind/accept/peer-observation/decode/authorization/dispatch steps.
 - `go/pkg/kernelcapture/launch_wrapper_session.go` defines the launch-wrapper no-execution contract seam and deterministic evidence envelope.
 - `go/pkg/kernelcapture/launch_wrapper_session_test.go` verifies launch-wrapper digest integrity and boundary behavior.
-- `reports/PHASE2_EBPF_MVP_VERIFICATION_2026-05-10.md` records the Linux eBPF MVP verification context and environment limits.
+- `reports/PHASE2_EBPF_MVP_VERIFICATION_2026-05-10.md` recorded the Linux eBPF MVP verification context and environment limits (that companion report was removed during the open-source-release cleanup and is no longer present in this tree).
 
 ## Not claimed
 


### PR DESCRIPTION
## What this is

A **verification-first** refresh of the public documentation against the current `dev` tree (package semver `0.2.0`). Every claim was checked against the actual code, workflows, or CHANGELOG **before** editing. No capability claims were added and no honest caveats were removed. The corpus was already meticulously maintained (README verification snapshot dated 2026-07-11), so this is surgical reconciliation, not a rewrite — **16 findings surfaced by a read-only audit of all 160 editable docs; 15 applied, 1 held for reviewer judgement (below).**

## How it was verified

A read-only audit fanned across all 160 editable markdown files (15 clusters), each cross-checked against the real code, with an adversarial verify pass that rejects any edit that would introduce an overclaim (0 rejected of 16 confirmed). Every low-confidence/flagged finding was then independently re-verified by hand before applying. Site validators (`sync_source_docs.py --check`, `validate_claims.py`, `validate_rendered_docs_links.py`) and `hugo --gc --minify` all pass; the source-provenance check passes with the CI `HUGO_PARAMS_SOURCEREF` env.

## Files changed — one line each

| File | Change | Verified against |
|---|---|---|
| `REPRODUCE.md` | Go prerequisite `1.23` → `1.26.5` | `go/go.mod` (`go 1.26.5`) |
| `docs/articles/06-public-import-discipline.md` | go.mod pin `1.25.9` → `1.26.5` | `go/go.mod`; enforce-e2e Dockerfile |
| `docs/TESTING.md` | gitleaks now downloads+checksums the v8.18.0 release (was "pinned action SHA `ff98106e`"); lychee-action `v2.8.0` → `v2.9.0`; CodeQL `v3` → `v4`; go/pkg/aat test count `74` → `76` | `secret-scan.yml`, `link-check.yml`, `codeql.yml`, `go test ./pkg/aat` |
| `docs/public-import-plan.md` | aat package test count `74` → `76` | `grep '^func Test' go/pkg/aat` = 76 |
| `docs/mvp-evaluator-guide.md` | Clarify Token Status List scope: credential-level TSL is Go-only (`go/pkg/credential`); Python does mission-level TSL (`vibap.mission.mission_is_revoked`). Prior "not yet in Python" was inverted. | `mission.py`, `go/pkg/credential/status.go`, `docs/known-limitations.md` |
| `docs/reference/ardur-md-profile.md` | Document the third built-in template `personal-firewall` | `PROFILE_TEMPLATES` in `ardur_profile.py` |
| `go/README.md` | `cmd/benchcheck` still exists (AuditBench harness); only `cmd/benchmark*` were removed | `go/cmd/benchcheck/main.go` present |
| `deploy/helm/ardur/README.md` | Next-available ADR after `ADR-024` (was `ADR-021`) | `docs/decisions/` max = ADR-024 |
| `reports/PHASE2_DAEMON_KERNEL_BOUNDARY_CLAIM_LEDGER_2026-05-11.md` | Note the referenced companion report was removed in the OSS-release cleanup (dangling ref) | `git log` commit `aa04c26` |
| `site/content/get-started.md` | `hub` takes no `start` positional; cloud-model test path is `python/tests/`, not `tests/` | `cli.py` hub subparser; filesystem |
| `site/content/proof.md` | Sync verification snapshot to the 2026-07-11 numbers already in `README.md` | `README.md:79-83` |
| `site/content/source/**` (9 files) | Regenerated mirrors of the above via `sync_source_docs.py` | CI `--check` passes |

## ⚠️ Flagged for reviewer — not auto-changed

1. **Package semver 0.2.0 vs no `[0.2.0]` release.** `python/pyproject.toml`, `vibap/__init__.py`, `vibap/proxy.py` and the Go sensor are all versioned `0.2.0`, **but** `CHANGELOG.md` still has everything under `[Unreleased]` and the only git tag is `v0.1.0`. I deliberately did **not** cut a `[0.2.0]` heading or tag — that's a release decision. Please decide whether to cut the release heading/tag as a follow-up.
2. **CVE-2021-33505 CVSS score** in `docs/research/epic-b-performance-fp-budget.md` — the doc says **7.3**; NVD scores it **7.8** (verified first-hand). The doc cites the Falco GHSA advisory as its source, and that link appears to resolve to a *different* CVE (CVE-2022-26316). Left unchanged pending your reconciliation of the citation + source attribution.
3. **`v0.1` labels are mostly correct, not stale.** The MCEP spec series (`v0.1`) and "capture boundary today (v0.1)" are intentional spec-series / capability labels; the roadmap `v0.2/v0.5/v1.0` are *capture-capability milestones* distinct from package semver. No blanket `v0.1 → v0.2` sweep was done, by design.
4. **Identity note.** "radiantic" appears only in `docs/articles/06` as the deliberate historical naming-migration record ("Was: Radiantic → (erased)"). Left intact — deleting it would erase the documentation of the erasure.
5. **One archival dated ledger touched** (`reports/PHASE2...2026-05-11.md`) to fix a dangling reference. Flagging since these are point-in-time records.

Do **not** merge — for GR review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reproduction and testing prerequisites to Go 1.26.5.
  * Refreshed CI guidance, action versions, checksum verification details, and test-count references.
  * Clarified Token Status List revocation behavior across credential and mission checks.
  * Expanded the `personal-firewall` template description, including secret-like argument blocking.
  * Corrected setup commands, benchmark documentation, ADR examples, verification records, and release metadata.
  * Updated verification results to reflect the latest test coverage snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->