### PR TITLE
[D][Security] Fail closed when proxy TLS configuration is unavailable

### DIFF
--- a/docs/reference/proxy-oci-image.md
+++ b/docs/reference/proxy-oci-image.md
@@ -43,9 +43,12 @@ should use encrypted storage with access controls appropriate for signing-key
 material. Do not put API tokens, private keys, or development certificates in
 the image, build arguments, labels, or Kubernetes manifests.
 
-`ARDUR_NO_TLS=1` is supported only when a trusted local reverse proxy, sidecar,
-or service mesh terminates TLS before traffic reaches the container. Bearer
-tokens must not cross an unencrypted or untrusted network.
+Plain HTTP is supported only when a trusted local reverse proxy, sidecar, or
+service mesh terminates TLS before traffic reaches the container. Append the
+explicit `--no-tls` argument to the image command and set `ARDUR_NO_TLS=1` so
+the container healthcheck probes HTTP. The environment variable selects only
+the healthcheck scheme; by itself it cannot disable proxy TLS. Bearer tokens
+must not cross an unencrypted or untrusted network.
 
 An equivalent hardened Docker invocation is:
 

--- a/python/tests/test_proxy_tls_startup.py
+++ b/python/tests/test_proxy_tls_startup.py
@@ -138,7 +138,8 @@ def test_tls_expected_never_starts_plain_http(
                 ) as response:
                     plaintext_status = int(response.status)
             except (OSError, urllib.error.URLError):
-                pass
+                # Refusal or protocol failure is the expected fail-closed outcome.
+                plaintext_status = None
             pytest.fail(
                 "TLS-expected proxy stayed alive instead of failing closed; "
                 f"plaintext_health_status={plaintext_status}"

--- a/python/tests/test_proxy_tls_startup.py
+++ b/python/tests/test_proxy_tls_startup.py
@@ -1,0 +1,322 @@
+"""Organic startup tests for the governance proxy TLS boundary."""
+
+from __future__ import annotations
+
+import os
+import json
+import socket
+import ssl
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from vibap.tls import generate_self_signed_cert
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _proxy_command(tmp_path: Path, port: int, *extra: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "vibap.proxy",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--keys-dir",
+        str(tmp_path / "keys"),
+        "--state-dir",
+        str(tmp_path / "state"),
+        "--log-path",
+        str(tmp_path / "audit.jsonl"),
+        "--no-require-auth",
+        *extra,
+    ]
+
+
+def _proxy_environment(tmp_path: Path, *, disable_tls: bool = False) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["VIBAP_HOME"] = str(tmp_path / "home")
+    if disable_tls:
+        environment["ARDUR_NO_TLS"] = "1"
+    else:
+        environment.pop("ARDUR_NO_TLS", None)
+    return environment
+
+
+def _stop_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+    stdout, stderr = process.communicate(timeout=5)
+    return stdout, stderr
+
+
+def _wait_for_health(
+    process: subprocess.Popen[str],
+    url: str,
+    *,
+    context: ssl.SSLContext | None = None,
+) -> int:
+    deadline = time.monotonic() + 8
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stdout, stderr = process.communicate(timeout=5)
+            raise AssertionError(
+                f"proxy exited before health check: rc={process.returncode}; "
+                f"stdout={stdout!r}; stderr={stderr!r}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=0.5, context=context) as response:
+                return int(response.status)
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.05)
+    raise AssertionError(f"proxy health check did not become ready: {last_error}")
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "disable_tls"),
+    [
+        ((), True),
+        (("--tls-cert", "missing-cert.pem"), False),
+        (("--tls-key", "missing-key.pem"), False),
+        (
+            (
+                "--tls-cert",
+                "missing-cert.pem",
+                "--tls-key",
+                "missing-key.pem",
+            ),
+            False,
+        ),
+    ],
+    ids=(
+        "environment-disable",
+        "certificate-only",
+        "key-only",
+        "missing-pair",
+    ),
+)
+def test_tls_expected_never_starts_plain_http(
+    tmp_path: Path,
+    extra_args: tuple[str, ...],
+    disable_tls: bool,
+) -> None:
+    port = _free_port()
+    process = subprocess.Popen(
+        _proxy_command(tmp_path, port, *extra_args),
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path, disable_tls=disable_tls),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        try:
+            return_code = process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            plaintext_status: int | None = None
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/health", timeout=1
+                ) as response:
+                    plaintext_status = int(response.status)
+            except (OSError, urllib.error.URLError):
+                pass
+            pytest.fail(
+                "TLS-expected proxy stayed alive instead of failing closed; "
+                f"plaintext_health_status={plaintext_status}"
+            )
+        stdout, stderr = process.communicate(timeout=5)
+    finally:
+        if process.poll() is None:
+            _stop_process(process)
+
+    assert return_code == 1
+    assert stdout == ""
+    assert "TLS configuration is unavailable" in stderr
+    assert "--no-tls" in stderr
+    assert "Traceback" not in stderr
+    assert str(tmp_path) not in stderr
+    assert "missing-cert.pem" not in stderr
+    assert "missing-key.pem" not in stderr
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as replacement:
+        replacement.bind(("127.0.0.1", port))
+
+
+def test_default_startup_serves_real_https(tmp_path: Path) -> None:
+    port = _free_port()
+    process = subprocess.Popen(
+        _proxy_command(tmp_path, port),
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        assert (
+            _wait_for_health(
+                process,
+                f"https://127.0.0.1:{port}/health",
+                context=context,
+            )
+            == 200
+        )
+    finally:
+        _stdout, stderr = _stop_process(process)
+
+    assert "auto-generated self-signed cert" in stderr
+    assert "TLS disabled" not in stderr
+
+
+def test_explicit_valid_tls_pair_serves_real_https(tmp_path: Path) -> None:
+    key_path, cert_path, _fingerprint = generate_self_signed_cert(
+        tmp_path / "explicit-tls"
+    )
+    port = _free_port()
+    process = subprocess.Popen(
+        _proxy_command(
+            tmp_path,
+            port,
+            "--tls-cert",
+            str(cert_path),
+            "--tls-key",
+            str(key_path),
+        ),
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        assert (
+            _wait_for_health(
+                process,
+                f"https://127.0.0.1:{port}/health",
+                context=context,
+            )
+            == 200
+        )
+    finally:
+        _stdout, stderr = _stop_process(process)
+
+    assert "cert fingerprint" in stderr
+    assert "TLS disabled" not in stderr
+
+
+def test_existing_but_invalid_tls_pair_fails_without_binding_or_traceback(
+    tmp_path: Path,
+) -> None:
+    cert_path = tmp_path / "invalid-cert.pem"
+    key_path = tmp_path / "invalid-key.pem"
+    cert_path.write_text("not a certificate", encoding="utf-8")
+    key_path.write_text("not a private key", encoding="utf-8")
+    port = _free_port()
+    result = subprocess.run(
+        _proxy_command(
+            tmp_path,
+            port,
+            "--tls-cert",
+            str(cert_path),
+            "--tls-key",
+            str(key_path),
+        ),
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path),
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "TLS configuration is unavailable" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert str(tmp_path) not in result.stderr
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as replacement:
+        replacement.bind(("127.0.0.1", port))
+
+
+def test_explicit_no_tls_remains_the_plain_http_control(tmp_path: Path) -> None:
+    port = _free_port()
+    process = subprocess.Popen(
+        _proxy_command(tmp_path, port, "--no-tls"),
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path, disable_tls=True),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert _wait_for_health(process, f"http://127.0.0.1:{port}/health") == 200
+    finally:
+        _stdout, stderr = _stop_process(process)
+
+    assert "WARNING: TLS disabled" in stderr
+
+
+def test_ardur_start_rejects_environment_only_tls_disable_before_side_effects(
+    tmp_path: Path,
+) -> None:
+    keys_dir = tmp_path / "cli-keys"
+    state_dir = tmp_path / "cli-state"
+    audit_log = tmp_path / "cli-audit.jsonl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vibap.cli",
+            "start",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--keys-dir",
+            str(keys_dir),
+            "--state-dir",
+            str(state_dir),
+            "--log-path",
+            str(audit_log),
+        ],
+        cwd=tmp_path,
+        env=_proxy_environment(tmp_path, disable_tls=True),
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert result.stderr == ""
+    assert payload["condition"] == "start_tls_material_invalid"
+    assert "--no-tls" in json.dumps(payload)
+    assert str(tmp_path) not in result.stdout
+    assert not keys_dir.exists()
+    assert not state_dir.exists()
+    assert not audit_log.exists()

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -91,9 +91,25 @@ from .codex_app_server_fixture import (
     _fixture_path_failure_response as codex_fixture_path_failure_response,
     handle_host_event as handle_codex_host_event,
 )
-from .posture_index import build_posture_index, format_posture_report, posture_receipts_failure_response, PostureReceiptsError, posture_input_failure_response, PostureInputError
-from .claude_code_daemon import install_native_pre_tool_use_command, resolve_native_pre_tool_use_command_path
-from .proxy import DEFAULT_STATE_DIR, GovernanceProxy, GovernanceSession, serve_proxy
+from .posture_index import (
+    build_posture_index,
+    format_posture_report,
+    posture_receipts_failure_response,
+    PostureReceiptsError,
+    posture_input_failure_response,
+    PostureInputError,
+)
+from .claude_code_daemon import (
+    install_native_pre_tool_use_command,
+    resolve_native_pre_tool_use_command_path,
+)
+from .proxy import (
+    DEFAULT_STATE_DIR,
+    GovernanceProxy,
+    GovernanceSession,
+    TLSConfigurationError,
+    serve_proxy,
+)
 from .run_bridge import VALID_VIA_MODES, run_governed_cli
 from .shareable_redaction import path_aliases, redact_local_path_text
 from .tool_preflight import (
@@ -104,6 +120,7 @@ from .tool_preflight import (
     render_tool_preflight_markdown,
     scan_tool_server_config,
 )
+from .tls import tls_disabled_by_environment
 
 
 _ATTEST_SESSION_ID_RE = re.compile(
@@ -243,7 +260,9 @@ def _keys_dir_failure_next_steps(condition: str) -> list[dict[str, str]]:
 
 def _keys_dir_failure_response(exc: KeyDirectoryError) -> dict:
     condition = _keys_dir_failure_condition(exc)
-    detail = getattr(exc, "detail", "The selected Mission Passport key path is not a directory.")
+    detail = getattr(
+        exc, "detail", "The selected Mission Passport key path is not a directory."
+    )
     return {
         "ok": False,
         "error": condition,
@@ -810,7 +829,8 @@ def _start_tls_material_failure_response() -> dict:
         "condition": condition,
         "message": "Ardur start TLS material is invalid.",
         "detail": (
-            "Explicit --tls-cert and --tls-key values must both point to existing files "
+            "TLS stays enabled unless --no-tls is explicitly supplied. When explicit "
+            "--tls-cert and --tls-key values are used, both must point to existing files "
             "before Ardur starts the local governance proxy."
         ),
         "next_steps": _start_tls_material_failure_next_steps(condition),
@@ -820,12 +840,17 @@ def _start_tls_material_failure_response() -> dict:
 def _start_tls_material_invalid(args: argparse.Namespace) -> bool:
     if args.no_tls:
         return False
+    if tls_disabled_by_environment():
+        return True
     if args.tls_cert is None and args.tls_key is None:
         return False
     if args.tls_cert is None or args.tls_key is None:
         return True
     try:
-        return not Path(args.tls_cert).expanduser().is_file() or not Path(args.tls_key).expanduser().is_file()
+        return (
+            not Path(args.tls_cert).expanduser().is_file()
+            or not Path(args.tls_key).expanduser().is_file()
+        )
     except OSError:
         return True
 
@@ -966,7 +991,9 @@ def _start_api_token_invalid_response() -> dict[str, object]:
     }
 
 
-def _start_api_token_invalid_failure(args: argparse.Namespace) -> dict[str, object] | None:
+def _start_api_token_invalid_failure(
+    args: argparse.Namespace,
+) -> dict[str, object] | None:
     """Return the api-token-invalid response when --api-token is whitespace-only.
 
     ``None`` means the argument is acceptable: either unset (None), an empty
@@ -1135,18 +1162,22 @@ def cmd_start(args: argparse.Namespace) -> int:
             }
         )
 
-    serve_proxy(
-        proxy=proxy,
-        private_key=private_key,
-        host=args.host,
-        port=args.port,
-        initial_session_id=initial_session_id,
-        require_auth=args.require_auth,
-        api_token=args.api_token,
-        tls_cert=args.tls_cert,
-        tls_key=args.tls_key,
-        no_tls=args.no_tls,
-    )
+    try:
+        serve_proxy(
+            proxy=proxy,
+            private_key=private_key,
+            host=args.host,
+            port=args.port,
+            initial_session_id=initial_session_id,
+            require_auth=args.require_auth,
+            api_token=args.api_token,
+            tls_cert=args.tls_cert,
+            tls_key=args.tls_key,
+            no_tls=args.no_tls,
+        )
+    except TLSConfigurationError:
+        _print_json(_start_tls_material_failure_response())
+        return 1
     return 0
 
 
@@ -1179,7 +1210,9 @@ def _issue_budget_failure_response(condition: str, detail: str) -> dict:
     }
 
 
-def _issue_budget_int(value: str | int, condition: str, detail: str) -> tuple[int | None, tuple[dict, int] | None]:
+def _issue_budget_int(
+    value: str | int, condition: str, detail: str
+) -> tuple[int | None, tuple[dict, int] | None]:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -1316,10 +1349,9 @@ def cmd_issue(args: argparse.Namespace) -> int:
         _print_json(response)
         return exit_code
     requested_scope = list(args.resource_scope or [])
-    if (
-        UNRESTRICTED_RESOURCE_SCOPE_PATTERN in requested_scope
-        and requested_scope != [UNRESTRICTED_RESOURCE_SCOPE_PATTERN]
-    ):
+    if UNRESTRICTED_RESOURCE_SCOPE_PATTERN in requested_scope and requested_scope != [
+        UNRESTRICTED_RESOURCE_SCOPE_PATTERN
+    ]:
         _print_json(
             {
                 "ok": False,
@@ -1500,7 +1532,9 @@ def _verify_malformed_token_failure_exit_code(token: str) -> int | None:
         )
     except jwt.PyJWTError:
         _print_json(
-            _verify_failure_response(jwt.DecodeError("Mission Passport token is malformed."))
+            _verify_failure_response(
+                jwt.DecodeError("Mission Passport token is malformed.")
+            )
         )
         return 1
     return None
@@ -1594,7 +1628,9 @@ def _load_transparency_public_key(path: Path):  # type: ignore[no-untyped-def]
     with path.open("rb") as handle:
         data = handle.read(64 * 1024 + 1)
     if not data or len(data) > 64 * 1024:
-        raise ValueError("transparency log public key is empty or exceeds the size limit")
+        raise ValueError(
+            "transparency log public key is empty or exceeds the size limit"
+        )
     key = serialization.load_pem_public_key(data)
     if not isinstance(key, (ec.EllipticCurvePublicKey, ed25519.Ed25519PublicKey)):
         raise ValueError("transparency log public key must be ECDSA or Ed25519")
@@ -2005,9 +2041,7 @@ def cmd_telemetry_export(args: argparse.Namespace) -> int:
 
     try:
         receipt_public_key = (
-            _load_p256_public_key(
-                args.receipt_public_key, label="receipt public key"
-            )
+            _load_p256_public_key(args.receipt_public_key, label="receipt public key")
             if args.receipt_public_key is not None
             else load_existing_public_key(keys_dir=args.keys_dir)
         )
@@ -2072,7 +2106,9 @@ def _load_local_log_private_key(path: Path):  # type: ignore[no-untyped-def]
     if not path.is_file():
         raise FileNotFoundError(f"local transparency-log private key not found: {path}")
     if os.name == "posix" and path.stat().st_mode & 0o077:
-        raise PermissionError("local transparency-log private key must use mode 0600 or stricter")
+        raise PermissionError(
+            "local transparency-log private key must use mode 0600 or stricter"
+        )
     key = serialization.load_pem_private_key(path.read_bytes(), password=None)
     if not isinstance(key, ed25519.Ed25519PrivateKey):
         raise ValueError("local transparency-log private key must be Ed25519")
@@ -2097,7 +2133,11 @@ def cmd_anchor(args: argparse.Namespace) -> int:
     try:
         receipt_private_key = None
         if args.backend == BACKEND_LOCAL_SIGNED:
-            if args.local_log is None or args.log_private_key is None or not args.origin:
+            if (
+                args.local_log is None
+                or args.log_private_key is None
+                or not args.origin
+            ):
                 raise TransparencyError(
                     "local anchoring requires --local-log, --log-private-key, and --origin"
                 )
@@ -2245,9 +2285,15 @@ def _validate_attest_session_file_before_artifacts(session_path: Path) -> int | 
     return None
 
 
-def _attest_session_failure_exit_code(session_id: str, state_dir: Path | None) -> int | None:
+def _attest_session_failure_exit_code(
+    session_id: str, state_dir: Path | None
+) -> int | None:
     if not _ATTEST_SESSION_ID_RE.match(session_id):
-        _print_json(_attest_failure_response(ValueError("invalid session ID format: must be UUID")))
+        _print_json(
+            _attest_failure_response(
+                ValueError("invalid session ID format: must be UUID")
+            )
+        )
         return 1
     session_path = _attest_session_file_path(session_id, state_dir)
     try:
@@ -2317,8 +2363,20 @@ def cmd_claude_code_report(args: argparse.Namespace) -> int:
         command_title="Claude Code report",
         specs=(
             ("home", "--home", "home", "claude_code_report_home_empty", False),
-            ("chain_dir", "--chain-dir", "chain dir", "claude_code_report_chain_dir_empty", False),
-            ("keys_dir", "--keys-dir", "keys dir", "claude_code_report_keys_dir_empty", False),
+            (
+                "chain_dir",
+                "--chain-dir",
+                "chain dir",
+                "claude_code_report_chain_dir_empty",
+                False,
+            ),
+            (
+                "keys_dir",
+                "--keys-dir",
+                "keys dir",
+                "claude_code_report_keys_dir_empty",
+                False,
+            ),
         ),
     )
     if path_failure is not None:
@@ -2338,7 +2396,9 @@ def cmd_claude_code_report(args: argparse.Namespace) -> int:
         _print_json(report)
         return 0
 
-    print(f"Ardur Claude Code receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains")
+    print(
+        f"Ardur Claude Code receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains"
+    )
     print(f"Home: {report['home']}")
     print(f"Chains: {report['chain_dir']}")
     print(f"Tools: {report['totals']['tools']}")
@@ -2356,13 +2416,17 @@ def cmd_claude_code_report(args: argparse.Namespace) -> int:
     )
     print(f"Per-child attribution: {report['coverage']['per_child_attribution']}")
     print(f"Attribution: {report['coverage']['attribution']}")
-    actions = [action for chain in report["chains"] for action in chain.get("actions", [])]
+    actions = [
+        action for chain in report["chains"] for action in chain.get("actions", [])
+    ]
     if actions:
         print("Actions:")
         for action in actions[-20:]:
             request = action["request"]
             remaining = action.get("budget_remaining", {}).get("tool_calls")
-            budget_text = f"; {remaining} governed calls remain" if remaining is not None else ""
+            budget_text = (
+                f"; {remaining} governed calls remain" if remaining is not None else ""
+            )
             print(
                 f"- {action['verdict'].upper()} {request['tool']} "
                 f"({request['action_class']}/{request['side_effect_class']}): "
@@ -2415,8 +2479,12 @@ def _receiver_attestation_fixture_output_invalid_response(condition: str) -> dic
         "ok": False,
         "error": condition,
         "condition": condition,
-        "message": messages.get(condition, "Receiver attestation fixture output path is invalid."),
-        "detail": details.get(condition, "Provide a directory path for the --output argument."),
+        "message": messages.get(
+            condition, "Receiver attestation fixture output path is invalid."
+        ),
+        "detail": details.get(
+            condition, "Provide a directory path for the --output argument."
+        ),
         "next_steps": [
             {
                 "condition": condition,
@@ -2466,8 +2534,12 @@ def _drp_profile_fixture_output_invalid_response(condition: str) -> dict:
         "ok": False,
         "error": condition,
         "condition": condition,
-        "message": messages.get(condition, "DRP profile fixture output path is invalid."),
-        "detail": details.get(condition, "Provide a directory path for the --output argument."),
+        "message": messages.get(
+            condition, "DRP profile fixture output path is invalid."
+        ),
+        "detail": details.get(
+            condition, "Provide a directory path for the --output argument."
+        ),
         "next_steps": [
             {
                 "condition": condition,
@@ -2517,8 +2589,12 @@ def _offline_verification_fixture_output_invalid_response(condition: str) -> dic
         "ok": False,
         "error": condition,
         "condition": condition,
-        "message": messages.get(condition, "Offline verification fixture output path is invalid."),
-        "detail": details.get(condition, "Provide a directory path for the --output argument."),
+        "message": messages.get(
+            condition, "Offline verification fixture output path is invalid."
+        ),
+        "detail": details.get(
+            condition, "Provide a directory path for the --output argument."
+        ),
         "next_steps": [
             {
                 "condition": condition,
@@ -2562,9 +2638,7 @@ def cmd_drp_profile_fixture(args: argparse.Namespace) -> int:
     try:
         report = run_drp_profile_fixture(args.output)
     except DrpFixtureOutputError as exc:
-        _print_json(
-            _drp_profile_fixture_output_invalid_response(exc.condition)
-        )
+        _print_json(_drp_profile_fixture_output_invalid_response(exc.condition))
         return 1
     except (OSError, TypeError, ValueError) as exc:
         _print_json(
@@ -2625,18 +2699,26 @@ def cmd_gemini_cli_fixture(args: argparse.Namespace) -> int:
         _print_json(gemini_fixture_project_dir_failure_response(exc.condition))
         return 1
     except GeminiFixturePathError as exc:
-        _print_json(gemini_fixture_path_failure_response(
-            condition=exc.condition,
-            label=exc.detail.split(" is ")[0] if " is " in exc.detail else "path",
-            arg_name="--" + exc.condition.replace("gemini_cli_fixture_", "").replace("_not_directory", "").replace("_empty", "").replace("_", "-"),
-        ))
+        _print_json(
+            gemini_fixture_path_failure_response(
+                condition=exc.condition,
+                label=exc.detail.split(" is ")[0] if " is " in exc.detail else "path",
+                arg_name="--"
+                + exc.condition.replace("gemini_cli_fixture_", "")
+                .replace("_not_directory", "")
+                .replace("_empty", "")
+                .replace("_", "-"),
+            )
+        )
         return 1
     except KeyDirectoryError:
-        _print_json(gemini_fixture_path_failure_response(
-            condition="gemini_cli_fixture_keys_dir_not_directory",
-            label="keys dir",
-            arg_name="--keys-dir",
-        ))
+        _print_json(
+            gemini_fixture_path_failure_response(
+                condition="gemini_cli_fixture_keys_dir_not_directory",
+                label="keys dir",
+                arg_name="--keys-dir",
+            )
+        )
         return 1
     _print_json(build_gemini_shareable_context(fixture))
     return 0
@@ -2722,8 +2804,20 @@ def cmd_gemini_cli_report(args: argparse.Namespace) -> int:
         command_title="Gemini CLI report",
         specs=(
             ("home", "--home", "home", "gemini_cli_report_home_empty", False),
-            ("chain_dir", "--chain-dir", "chain dir", "gemini_cli_report_chain_dir_empty", False),
-            ("keys_dir", "--keys-dir", "keys dir", "gemini_cli_report_keys_dir_empty", False),
+            (
+                "chain_dir",
+                "--chain-dir",
+                "chain dir",
+                "gemini_cli_report_chain_dir_empty",
+                False,
+            ),
+            (
+                "keys_dir",
+                "--keys-dir",
+                "keys dir",
+                "gemini_cli_report_keys_dir_empty",
+                False,
+            ),
         ),
     )
     if path_failure is not None:
@@ -2742,7 +2836,9 @@ def cmd_gemini_cli_report(args: argparse.Namespace) -> int:
     if args.json:
         _print_json(report)
         return 0
-    print(f"Ardur Gemini CLI receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains")
+    print(
+        f"Ardur Gemini CLI receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains"
+    )
     print(f"Chains: {report['chain_dir']}")
     print(f"Verdicts: {report['policy_verdict_counts']}")
     print(f"Coverage gaps: {report['coverage_gaps']}")
@@ -2831,18 +2927,26 @@ def cmd_codex_app_server_fixture(args: argparse.Namespace) -> int:
         _print_json(codex_fixture_project_dir_failure_response(exc.condition))
         return 1
     except CodexFixturePathError as exc:
-        _print_json(codex_fixture_path_failure_response(
-            condition=exc.condition,
-            label=exc.detail.split(" is ")[0] if " is " in exc.detail else "path",
-            arg_name="--" + exc.condition.replace("codex_app_server_fixture_", "").replace("_not_directory", "").replace("_empty", "").replace("_", "-"),
-        ))
+        _print_json(
+            codex_fixture_path_failure_response(
+                condition=exc.condition,
+                label=exc.detail.split(" is ")[0] if " is " in exc.detail else "path",
+                arg_name="--"
+                + exc.condition.replace("codex_app_server_fixture_", "")
+                .replace("_not_directory", "")
+                .replace("_empty", "")
+                .replace("_", "-"),
+            )
+        )
         return 1
     except KeyDirectoryError:
-        _print_json(codex_fixture_path_failure_response(
-            condition="codex_app_server_fixture_keys_dir_not_directory",
-            label="keys dir",
-            arg_name="--keys-dir",
-        ))
+        _print_json(
+            codex_fixture_path_failure_response(
+                condition="codex_app_server_fixture_keys_dir_not_directory",
+                label="keys dir",
+                arg_name="--keys-dir",
+            )
+        )
         return 1
     _print_json(build_codex_shareable_context(fixture))
     return 0
@@ -2855,8 +2959,20 @@ def cmd_codex_app_server_report(args: argparse.Namespace) -> int:
         command_title="Codex app-server report",
         specs=(
             ("home", "--home", "home", "codex_app_server_report_home_empty", False),
-            ("chain_dir", "--chain-dir", "chain dir", "codex_app_server_report_chain_dir_empty", False),
-            ("keys_dir", "--keys-dir", "keys dir", "codex_app_server_report_keys_dir_empty", False),
+            (
+                "chain_dir",
+                "--chain-dir",
+                "chain dir",
+                "codex_app_server_report_chain_dir_empty",
+                False,
+            ),
+            (
+                "keys_dir",
+                "--keys-dir",
+                "keys dir",
+                "codex_app_server_report_keys_dir_empty",
+                False,
+            ),
         ),
     )
     if path_failure is not None:
@@ -2875,7 +2991,9 @@ def cmd_codex_app_server_report(args: argparse.Namespace) -> int:
     if args.json:
         _print_json(report)
         return 0
-    print(f"Ardur Codex app-server receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains")
+    print(
+        f"Ardur Codex app-server receipt report: {report['receipt_count']} receipts across {report['chain_count']} chains"
+    )
     print(f"Chains: {report['chain_dir']}")
     print(f"Verdicts: {report['policy_verdict_counts']}")
     print(f"Coverage gaps: {report['coverage_gaps']}")
@@ -2990,7 +3108,9 @@ def _posture_report_input_failure_response(exc: Exception) -> dict:
     else:
         condition = "posture_report_input_unreadable"
         message = "Posture report input file could not be read."
-        detail = f"Reading the supplied --input file failed with {exc.__class__.__name__}."
+        detail = (
+            f"Reading the supplied --input file failed with {exc.__class__.__name__}."
+        )
     return {
         "ok": False,
         "error": condition,
@@ -3017,7 +3137,15 @@ def cmd_posture_report(args: argparse.Namespace) -> int:
         posture = json.loads(args.input.read_text(encoding="utf-8"))
         if not isinstance(posture, dict):
             raise ValueError("posture report input must be a JSON object")
-    except (FileNotFoundError, PermissionError, IsADirectoryError, OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+    except (
+        FileNotFoundError,
+        PermissionError,
+        IsADirectoryError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as exc:
         response = _posture_report_input_failure_response(exc)
         if args.format == "json":
             _print_json(response)
@@ -3124,7 +3252,12 @@ def _kill_switch_next_steps_for_failure(
     )
     endpoint_problem = status_text in {"404", "405"} or "not found" in normalized_error
 
-    if not proxy_unavailable and not tls_problem and not token_problem and not endpoint_problem:
+    if (
+        not proxy_unavailable
+        and not tls_problem
+        and not token_problem
+        and not endpoint_problem
+    ):
         return []
 
     steps: list[dict[str, str]] = []
@@ -3279,7 +3412,9 @@ def cmd_kill_switch(args: argparse.Namespace) -> int:
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_token}",
     }
-    req = urlreq.Request(f"{proxy_base_url}/admin/kill-switch", data=payload, headers=headers)
+    req = urlreq.Request(
+        f"{proxy_base_url}/admin/kill-switch", data=payload, headers=headers
+    )
     ctx = _kill_switch_ssl_context(proxy_base_url)
     try:
         with urlreq.urlopen(req, timeout=5, context=ctx) as resp:
@@ -3383,7 +3518,9 @@ def cmd_desktop_observe(args: argparse.Namespace) -> int:
     return 0 if response.get("ok") else 1
 
 
-def _personal_native_host_once_json_input_next_steps(condition: str) -> list[dict[str, str]]:
+def _personal_native_host_once_json_input_next_steps(
+    condition: str,
+) -> list[dict[str, str]]:
     return [
         {
             "condition": condition,
@@ -3421,7 +3558,9 @@ def _personal_native_host_once_json_failure_response(exc: Exception) -> dict:
     elif isinstance(exc, FileNotFoundError):
         condition = "personal_native_host_once_json_missing"
         message = "Native Messaging --once-json input file could not be read."
-        detail = "No native-message JSON file was found at the supplied --once-json path."
+        detail = (
+            "No native-message JSON file was found at the supplied --once-json path."
+        )
     else:
         condition = "personal_native_host_once_json_unreadable"
         message = "Native Messaging --once-json input file could not be read."
@@ -3458,10 +3597,18 @@ def cmd_personal_native_host(args: argparse.Namespace) -> int:
         ) as exc:
             _print_json(_personal_native_host_once_json_failure_response(exc))
             return 1
-        response = handle_native_host_message(message, hub_url=args.hub_url, hub_token=args.hub_token, home=args.home)
+        response = handle_native_host_message(
+            message, hub_url=args.hub_url, hub_token=args.hub_token, home=args.home
+        )
         _print_json(response)
         return 0 if response.get("ok") else 1
-    run_native_host(sys.stdin.buffer, sys.stdout.buffer, hub_url=args.hub_url, hub_token=args.hub_token, home=args.home)
+    run_native_host(
+        sys.stdin.buffer,
+        sys.stdout.buffer,
+        hub_url=args.hub_url,
+        hub_token=args.hub_token,
+        home=args.home,
+    )
     return 0
 
 
@@ -3483,7 +3630,9 @@ def cmd_personal_firewall_demo(args: argparse.Namespace) -> int:
     try:
         result = run_personal_firewall_demo(
             timeout_s=args.timeout_s,
-            temp_parent=args.temp_parent.expanduser().resolve() if args.temp_parent else None,
+            temp_parent=args.temp_parent.expanduser().resolve()
+            if args.temp_parent
+            else None,
             emit=not args.json,
         )
     except PersonalFirewallDemoError as exc:
@@ -3548,7 +3697,9 @@ def _claude_code_doctor_file_uri_placeholder(_value: str) -> str:
     return "<local-file-uri>"
 
 
-def _claude_code_plugin_validation_detail(raw_detail: str, *, plugin: Path, home: Path) -> str:
+def _claude_code_plugin_validation_detail(
+    raw_detail: str, *, plugin: Path, home: Path
+) -> str:
     detail = raw_detail.strip()
     if not detail:
         return "Claude Code plugin validation failed; inspect the validation output."
@@ -3614,7 +3765,9 @@ def _claude_code_plugin_checks(plugin_dir: Path) -> list[dict[str, object]]:
 
 
 def _validate_claude_code_plugin_dir(plugin_dir: Path) -> None:
-    failed = [check for check in _claude_code_plugin_checks(plugin_dir) if not check["ok"]]
+    failed = [
+        check for check in _claude_code_plugin_checks(plugin_dir) if not check["ok"]
+    ]
     if failed:
         details = ", ".join(str(item["detail"]) for item in failed)
         raise FileNotFoundError(f"Claude Code plugin is incomplete: {details}")
@@ -3655,7 +3808,9 @@ _CLAUDE_CODE_REQUIRED_HOOK_EVENTS = (
 )
 
 
-def _claude_code_plugin_json_object_check(path: Path, check_name: str, label: str) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+def _claude_code_plugin_json_object_check(
+    path: Path, check_name: str, label: str
+) -> tuple[dict[str, object] | None, dict[str, object] | None]:
     try:
         raw = path.read_text("utf-8")
     except (OSError, UnicodeDecodeError) as exc:
@@ -3723,10 +3878,14 @@ def _claude_code_plugin_content_checks(plugin_dir: Path) -> list[dict[str, objec
             if not isinstance(field_value, str) or not field_value.strip():
                 missing_manifest_fields.append(field_name)
         if missing_manifest_fields:
-            failures.append({
-                "name": "plugin_manifest",
-                "detail": "Claude Code plugin manifest is missing non-empty fields: " + ", ".join(missing_manifest_fields) + ".",
-            })
+            failures.append(
+                {
+                    "name": "plugin_manifest",
+                    "detail": "Claude Code plugin manifest is missing non-empty fields: "
+                    + ", ".join(missing_manifest_fields)
+                    + ".",
+                }
+            )
 
     hooks_manifest, hooks_failure = _claude_code_plugin_json_object_check(
         plugin_dir / "hooks" / "hooks.json",
@@ -3735,15 +3894,19 @@ def _claude_code_plugin_content_checks(plugin_dir: Path) -> list[dict[str, objec
     )
     if hooks_failure:
         failures.append(hooks_failure)
-    elif hooks_manifest is not None and not _claude_code_hooks_manifest_valid(hooks_manifest):
-        failures.append({
-            "name": "plugin_hooks",
-            "detail": (
-                "Claude Code hooks manifest must define command hooks for "
-                + ", ".join(_CLAUDE_CODE_REQUIRED_HOOK_EVENTS)
-                + "."
-            ),
-        })
+    elif hooks_manifest is not None and not _claude_code_hooks_manifest_valid(
+        hooks_manifest
+    ):
+        failures.append(
+            {
+                "name": "plugin_hooks",
+                "detail": (
+                    "Claude Code hooks manifest must define command hooks for "
+                    + ", ".join(_CLAUDE_CODE_REQUIRED_HOOK_EVENTS)
+                    + "."
+                ),
+            }
+        )
     return failures
 
 
@@ -3751,7 +3914,11 @@ def _protect_claude_code_plugin_invalid_response(
     failed_checks: list[dict[str, object]],
 ) -> dict[str, object]:
     invalid_checks = [str(check["name"]) for check in failed_checks]
-    details = [str(check.get("detail", "")).strip() for check in failed_checks if str(check.get("detail", "")).strip()]
+    details = [
+        str(check.get("detail", "")).strip()
+        for check in failed_checks
+        if str(check.get("detail", "")).strip()
+    ]
     detail = "Invalid Claude Code plugin checks: " + ", ".join(invalid_checks)
     if details:
         detail += ". " + " ".join(details)
@@ -3794,51 +3961,65 @@ def _protect_policy_input_placeholder(option: str) -> str:
     }.get(option, "<policy-input-file>")
 
 
-def _protect_policy_input_next_steps(option: str, condition: str) -> list[dict[str, str]]:
+def _protect_policy_input_next_steps(
+    option: str, condition: str
+) -> list[dict[str, str]]:
     placeholder = _protect_policy_input_placeholder(option)
     steps: list[dict[str, str]] = []
     is_empty = condition.endswith("_empty")
     if is_empty:
-        steps.append({
-            "condition": condition,
-            "action": "provide_policy_path",
-            "command": f"ardur protect claude-code {option} {placeholder}",
-            "detail": f"Replace {placeholder} with an explicit, non-empty path to a local policy input file.",
-        })
+        steps.append(
+            {
+                "condition": condition,
+                "action": "provide_policy_path",
+                "command": f"ardur protect claude-code {option} {placeholder}",
+                "detail": f"Replace {placeholder} with an explicit, non-empty path to a local policy input file.",
+            }
+        )
     elif option in {"--forbid-rules", "--cedar-entities"}:
-        steps.append({
-            "condition": condition,
-            "action": "validate_policy_json",
-            "command": f"python -m json.tool {placeholder}",
-            "detail": "Validate the local policy JSON file before rerunning Claude Code protection.",
-        })
+        steps.append(
+            {
+                "condition": condition,
+                "action": "validate_policy_json",
+                "command": f"python -m json.tool {placeholder}",
+                "detail": "Validate the local policy JSON file before rerunning Claude Code protection.",
+            }
+        )
     else:
-        steps.append({
-            "condition": condition,
-            "action": "check_policy_file",
-            "command": f"test -r {placeholder}",
-            "detail": "Confirm the local policy file exists and is readable before rerunning protection.",
-        })
+        steps.append(
+            {
+                "condition": condition,
+                "action": "check_policy_file",
+                "command": f"test -r {placeholder}",
+                "detail": "Confirm the local policy file exists and is readable before rerunning protection.",
+            }
+        )
 
     if option == "--forbid-rules":
         rerun_suffix = "--forbid-rules <forbid-rules.json>"
     elif option == "--cedar-entities":
-        rerun_suffix = "--cedar-policy <policy.cedar> --cedar-entities <cedar-entities.json>"
+        rerun_suffix = (
+            "--cedar-policy <policy.cedar> --cedar-entities <cedar-entities.json>"
+        )
     else:
         rerun_suffix = "--cedar-policy <policy.cedar>"
-    steps.append({
-        "condition": condition,
-        "action": "rerun_protect",
-        "command": (
-            "ardur protect claude-code --scope <your-project> --home <ardur-home> "
-            f"--plugin-dir <claude-code-plugin> {rerun_suffix}"
-        ),
-        "detail": "Rerun protection after the local policy input file is present, readable, and valid.",
-    })
+    steps.append(
+        {
+            "condition": condition,
+            "action": "rerun_protect",
+            "command": (
+                "ardur protect claude-code --scope <your-project> --home <ardur-home> "
+                f"--plugin-dir <claude-code-plugin> {rerun_suffix}"
+            ),
+            "detail": "Rerun protection after the local policy input file is present, readable, and valid.",
+        }
+    )
     return steps
 
 
-def _protect_policy_input_failure_response(exc: _ProtectPolicyInputError) -> dict[str, object]:
+def _protect_policy_input_failure_response(
+    exc: _ProtectPolicyInputError,
+) -> dict[str, object]:
     return {
         "ok": False,
         "agent": "claude-code",
@@ -3868,7 +4049,9 @@ def _read_protect_policy_text(path: Path, option: str) -> str:
         ) from exc
 
 
-def _validate_protect_cedar_policy_syntax(policy_src: str, option: str = "--cedar-policy") -> None:
+def _validate_protect_cedar_policy_syntax(
+    policy_src: str, option: str = "--cedar-policy"
+) -> None:
     try:
         import cedarpy  # type: ignore[import-not-found]
     except ModuleNotFoundError as exc:  # pragma: no cover - dependency-gated install
@@ -3892,7 +4075,9 @@ def _validate_protect_cedar_policy_syntax(policy_src: str, option: str = "--ceda
         ) from exc
 
 
-def _validate_protect_cedar_entities(entities: object, option: str = "--cedar-entities") -> None:
+def _validate_protect_cedar_entities(
+    entities: object, option: str = "--cedar-entities"
+) -> None:
     try:
         import cedarpy  # type: ignore[import-not-found]
     except ModuleNotFoundError as exc:  # pragma: no cover - dependency-gated install
@@ -3919,7 +4104,10 @@ def _validate_protect_cedar_entities(entities: object, option: str = "--cedar-en
         # `is_authorized` is the cedarpy surface that parses entity payloads.
         # Keep this setup-time parser probe quiet so malformed local files
         # cannot corrupt `--json` output with validator diagnostics.
-        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
             result = cedarpy.is_authorized(
                 request=request,
                 policies="permit(principal, action, resource);\n",
@@ -3966,7 +4154,9 @@ def _write_private_text(path: Path, text: str) -> None:
             os.close(fd)
 
 
-def _claude_code_doctor_next_steps(checks: list[dict[str, object]]) -> list[dict[str, str]]:
+def _claude_code_doctor_next_steps(
+    checks: list[dict[str, object]],
+) -> list[dict[str, str]]:
     by_name = {str(check["name"]): check for check in checks}
     steps: list[dict[str, str]] = []
     plugin_check_names = [
@@ -3990,7 +4180,8 @@ def _claude_code_doctor_next_steps(checks: list[dict[str, object]]) -> list[dict
                     "ardur doctor-claude-code --plugin-dir "
                     f"{_CLAUDE_CODE_PLUGIN_PLACEHOLDER} --home {_ARDUR_HOME_PLACEHOLDER}"
                 ),
-                "detail": "Missing Claude Code plugin checks: " + ", ".join(missing_plugin_checks),
+                "detail": "Missing Claude Code plugin checks: "
+                + ", ".join(missing_plugin_checks),
             }
         )
 
@@ -4040,42 +4231,56 @@ def _claude_code_doctor_next_steps(checks: list[dict[str, object]]) -> list[dict
     return steps
 
 
-def claude_code_doctor(plugin_dir: Path | None = None, home: Path | None = None) -> dict[str, object]:
+def claude_code_doctor(
+    plugin_dir: Path | None = None, home: Path | None = None
+) -> dict[str, object]:
     plugin = (plugin_dir or _default_claude_plugin_dir()).expanduser().resolve()
     checks = _claude_code_plugin_checks(plugin)
     claude_binary = shutil.which("claude")
-    checks.append({
-        "name": "claude_binary",
-        "ok": bool(claude_binary),
-        "detail": "claude found on PATH" if claude_binary else "claude not found on PATH",
-    })
-    active_passport = (home.expanduser() if home else DEFAULT_HOME) / "active_mission.jwt"
-    checks.append({
-        "name": "active_passport",
-        "ok": active_passport.is_file(),
-        "detail": f"expected file at {_ARDUR_HOME_PLACEHOLDER}/active_mission.jwt",
-    })
+    checks.append(
+        {
+            "name": "claude_binary",
+            "ok": bool(claude_binary),
+            "detail": "claude found on PATH"
+            if claude_binary
+            else "claude not found on PATH",
+        }
+    )
+    active_passport = (
+        home.expanduser() if home else DEFAULT_HOME
+    ) / "active_mission.jwt"
+    checks.append(
+        {
+            "name": "active_passport",
+            "ok": active_passport.is_file(),
+            "detail": f"expected file at {_ARDUR_HOME_PLACEHOLDER}/active_mission.jwt",
+        }
+    )
     if claude_binary and all(check["ok"] for check in checks[:5]):
         result = subprocess.run(
             [claude_binary, "plugin", "validate", str(plugin)],
             capture_output=True,
             text=True,
         )
-        checks.append({
-            "name": "plugin_validate",
-            "ok": result.returncode == 0,
-            "detail": _claude_code_plugin_validation_detail(
-                result.stdout.strip() or result.stderr.strip(),
-                plugin=plugin,
-                home=active_passport.parent,
-            ),
-        })
+        checks.append(
+            {
+                "name": "plugin_validate",
+                "ok": result.returncode == 0,
+                "detail": _claude_code_plugin_validation_detail(
+                    result.stdout.strip() or result.stderr.strip(),
+                    plugin=plugin,
+                    home=active_passport.parent,
+                ),
+            }
+        )
     else:
-        checks.append({
-            "name": "plugin_validate",
-            "ok": False,
-            "detail": "skipped; missing claude binary or plugin files",
-        })
+        checks.append(
+            {
+                "name": "plugin_validate",
+                "ok": False,
+                "detail": "skipped; missing claude binary or plugin files",
+            }
+        )
     ok = all(bool(check["ok"]) for check in checks)
     return {
         "ok": ok,
@@ -4130,52 +4335,64 @@ def _resolve_protect_policies(
         rules = _read_protect_policy_json(Path(forbid_rules_raw), "--forbid-rules")
         if not isinstance(rules, list):
             rules = [rules]
-        policies.append({
-            "backend": "forbid_rules",
-            "label": "cli-forbid-rules",
-            "policy_inline": "",
-            "policy_sha256": forbid_rules_sha256(rules),
-            "data_inline": rules,
-        })
+        policies.append(
+            {
+                "backend": "forbid_rules",
+                "label": "cli-forbid-rules",
+                "policy_inline": "",
+                "policy_sha256": forbid_rules_sha256(rules),
+                "data_inline": rules,
+            }
+        )
     if cedar_policy_raw is not None:
         policy_src = _read_protect_policy_text(Path(cedar_policy_raw), "--cedar-policy")
         _validate_protect_cedar_policy_syntax(policy_src)
         entities: object = []
         if cedar_entities_raw is not None:
-            entities = _read_protect_policy_json(Path(cedar_entities_raw), "--cedar-entities")
+            entities = _read_protect_policy_json(
+                Path(cedar_entities_raw), "--cedar-entities"
+            )
             _validate_protect_cedar_entities(entities)
-        policies.append({
-            "backend": "cedar",
-            "label": "cli-cedar-policy",
-            "policy_inline": policy_src,
-            "policy_sha256": hashlib.sha256(policy_src.encode()).hexdigest(),
-            "data_inline": entities,
-        })
+        policies.append(
+            {
+                "backend": "cedar",
+                "label": "cli-cedar-policy",
+                "policy_inline": policy_src,
+                "policy_sha256": hashlib.sha256(policy_src.encode()).hexdigest(),
+                "data_inline": entities,
+            }
+        )
 
     # Profile policies
     if profile and profile.forbid_rules:
-        policies.append({
-            "backend": "forbid_rules",
-            "label": "profile-forbid-rules",
-            "policy_inline": "",
-            "policy_sha256": forbid_rules_sha256(profile.forbid_rules),
-            "data_inline": profile.forbid_rules,
-        })
+        policies.append(
+            {
+                "backend": "forbid_rules",
+                "label": "profile-forbid-rules",
+                "policy_inline": "",
+                "policy_sha256": forbid_rules_sha256(profile.forbid_rules),
+                "data_inline": profile.forbid_rules,
+            }
+        )
     if profile and profile.cedar_policy:
-        policies.append({
-            "backend": "cedar",
-            "label": "profile-cedar-policy",
-            "policy_inline": profile.cedar_policy,
-            "policy_sha256": hashlib.sha256(
-                profile.cedar_policy.encode()
-            ).hexdigest(),
-            "data_inline": [],
-        })
+        policies.append(
+            {
+                "backend": "cedar",
+                "label": "profile-cedar-policy",
+                "policy_inline": profile.cedar_policy,
+                "policy_sha256": hashlib.sha256(
+                    profile.cedar_policy.encode()
+                ).hexdigest(),
+                "data_inline": [],
+            }
+        )
 
     return policies
 
 
-def _protect_claude_code_missing_scope_response(profile_present: bool) -> dict[str, object]:
+def _protect_claude_code_missing_scope_response(
+    profile_present: bool,
+) -> dict[str, object]:
     profile_detail = (
         "The selected profile does not define `Protect folder:`."
         if profile_present
@@ -4583,7 +4800,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         profile = load_ardur_profile(args.profile) if args.profile else None
     except (FileNotFoundError, IsADirectoryError):
         return _protect_claude_code_missing_profile_response()
-    mode_name = _normalize_protect_mode(args.mode or (profile.mode if profile and profile.mode else "safe-coding"))
+    mode_name = _normalize_protect_mode(
+        args.mode or (profile.mode if profile and profile.mode else "safe-coding")
+    )
     if mode_name not in CLAUDE_CODE_PROTECT_MODES:
         raise ValueError(f"unsupported Claude Code protection mode: {mode_name}")
     mode = CLAUDE_CODE_PROTECT_MODES[mode_name]
@@ -4595,7 +4814,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         else:
             raw_scope = Path(args.profile).expanduser().parent / profile_scope
     if raw_scope is None:
-        return _protect_claude_code_missing_scope_response(profile_present=bool(args.profile))
+        return _protect_claude_code_missing_scope_response(
+            profile_present=bool(args.profile)
+        )
     # Reject empty/whitespace-only --scope before any key generation or directory
     # creation. ``args.scope`` is ``type=str`` so an empty or whitespace-only
     # value survives here as-is (previously ``type=Path`` normalized ``""`` to
@@ -4619,7 +4840,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
     # whitespace-only string so that ``--mission ""`` cannot silently create
     # an active mission with keys.
     if isinstance(args.agent_id, str) and not args.agent_id.strip():
-        return _protect_claude_code_identity_invalid_response("protect_agent_id_invalid")
+        return _protect_claude_code_identity_invalid_response(
+            "protect_agent_id_invalid"
+        )
     if isinstance(args.mission, str) and not args.mission.strip():
         return _protect_claude_code_identity_invalid_response("protect_mission_invalid")
     # Reject empty/whitespace-only --home before any directory creation or key
@@ -4686,7 +4909,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
     else:
         _ensure_default_home_dir()
     plugin_dir = Path(args.plugin_dir).expanduser().resolve()
-    failed_plugin_checks = [check for check in _claude_code_plugin_checks(plugin_dir) if not check["ok"]]
+    failed_plugin_checks = [
+        check for check in _claude_code_plugin_checks(plugin_dir) if not check["ok"]
+    ]
     if failed_plugin_checks:
         return _protect_claude_code_plugin_incomplete_response(failed_plugin_checks)
     invalid_plugin_checks = _claude_code_plugin_content_checks(plugin_dir)
@@ -4698,7 +4923,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         additional_policies = _resolve_protect_policies(args, profile, home)
     except _ProtectPolicyInputError as exc:
         return _protect_policy_input_failure_response(exc)
-    keys_dir_resolved = Path(args.keys_dir).expanduser().resolve() if args.keys_dir else (home / "keys")
+    keys_dir_resolved = (
+        Path(args.keys_dir).expanduser().resolve() if args.keys_dir else (home / "keys")
+    )
     private_key, public_key = generate_keypair(keys_dir=keys_dir_resolved)
     if profile and profile.allowed_tools:
         # A profile with an explicit allowlist is authoritative: if the author
@@ -4709,12 +4936,25 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         forbidden_tools = list(profile.forbidden_tools)
     else:
         allowed_tools = list(mode["allowed_tools"])
-        forbidden_tools = list(profile.forbidden_tools if profile and profile.forbidden_tools else mode["forbidden_tools"])
-    max_tool_calls = profile.max_tool_calls if profile and profile.max_tool_calls is not None else args.max_tool_calls
-    max_duration_s = profile.max_duration_s if profile and profile.max_duration_s is not None else args.max_duration_s
+        forbidden_tools = list(
+            profile.forbidden_tools
+            if profile and profile.forbidden_tools
+            else mode["forbidden_tools"]
+        )
+    max_tool_calls = (
+        profile.max_tool_calls
+        if profile and profile.max_tool_calls is not None
+        else args.max_tool_calls
+    )
+    max_duration_s = (
+        profile.max_duration_s
+        if profile and profile.max_duration_s is not None
+        else args.max_duration_s
+    )
     mission = MissionPassport(
         agent_id=args.agent_id,
-        mission=args.mission or (profile.mission if profile and profile.mission else mode["mission"]),
+        mission=args.mission
+        or (profile.mission if profile and profile.mission else mode["mission"]),
         allowed_tools=allowed_tools,
         forbidden_tools=forbidden_tools,
         resource_scope=[str(scope), f"{scope}/*"],
@@ -4730,6 +4970,7 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
     # resolved from CLI flags first, then from the profile.
     if additional_policies:
         from vibap.backed_policy_store import FileBackedPolicyStore
+
         store = FileBackedPolicyStore(home)
         store.put_policies(
             mission_id=str(
@@ -4759,7 +5000,9 @@ def protect_claude_code(args: argparse.Namespace) -> dict[str, object]:
         # ``active_passport`` key for existing callers.
         "active_mission_path": str(active_passport),
         "hook_python": str(hook_python),
-        "native_pre_hook_command": str(native_pre_hook_command) if native_pre_hook_command else None,
+        "native_pre_hook_command": str(native_pre_hook_command)
+        if native_pre_hook_command
+        else None,
         "native_pre_hook_command_expected": str(native_pre_hook_command_expected),
         "plugin_dir": str(plugin_dir),
         "run_command": run_command,
@@ -4815,7 +5058,9 @@ def _profile_init_existing_profile_response() -> dict[str, object]:
     }
 
 
-def _profile_init_path_invalid_response(exc: InvalidProfilePathError) -> dict[str, object]:
+def _profile_init_path_invalid_response(
+    exc: InvalidProfilePathError,
+) -> dict[str, object]:
     condition = "profile_path_invalid"
     return {
         "ok": False,
@@ -4871,7 +5116,9 @@ def _profile_init_path_failure_response(exc: OSError) -> dict[str, object]:
 
 def cmd_profile_init(args: argparse.Namespace) -> int:
     try:
-        path = write_profile_template(args.path, template=args.template, force=args.force)
+        path = write_profile_template(
+            args.path, template=args.template, force=args.force
+        )
     except InvalidProfilePathError as exc:
         result = _profile_init_path_invalid_response(exc)
         if args.json:
@@ -4927,21 +5174,34 @@ def build_parser() -> argparse.ArgumentParser:
         prog="ardur",
         description="Ardur governance proxy and mission-passport tooling",
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     start = subparsers.add_parser("start", help="start the VIBAP proxy HTTP service")
     start.add_argument("--host", default="127.0.0.1", help="bind address")
     start.add_argument("--port", type=int, default=8080, help="listen port")
-    start.add_argument("--mission", type=str, help="optional mission JSON to issue and start immediately")
-    start.add_argument("--keys-dir", type=str, help="directory containing VIBAP signing keys")
+    start.add_argument(
+        "--mission",
+        type=str,
+        help="optional mission JSON to issue and start immediately",
+    )
+    start.add_argument(
+        "--keys-dir", type=str, help="directory containing VIBAP signing keys"
+    )
     start.add_argument("--state-dir", type=str, help="directory for persisted sessions")
     start.add_argument("--log-path", type=str, help="JSONL audit log path")
-    start.add_argument("--api-token", help="Bearer token for clients; VIBAP_API_TOKEN still takes precedence")
+    start.add_argument(
+        "--api-token",
+        help="Bearer token for clients; VIBAP_API_TOKEN still takes precedence",
+    )
     start.add_argument("--tls-cert", type=str, help="TLS certificate PEM file")
     start.add_argument("--tls-key", type=str, help="TLS private key PEM file")
-    start.add_argument("--no-tls", action="store_true", help="disable TLS (plain HTTP only)")
+    start.add_argument(
+        "--no-tls", action="store_true", help="disable TLS (plain HTTP only)"
+    )
     auth_group = start.add_mutually_exclusive_group()
     auth_group.add_argument(
         "--require-auth",
@@ -4960,8 +5220,12 @@ def build_parser() -> argparse.ArgumentParser:
     issue = subparsers.add_parser("issue", help="issue a mission passport JWT")
     issue.add_argument("--agent-id", required=True, help="agent subject identifier")
     issue.add_argument("--mission", required=True, help="declared mission string")
-    issue.add_argument("--allowed-tools", nargs="*", default=[], help="allowed tool names")
-    issue.add_argument("--forbidden-tools", nargs="*", default=[], help="forbidden tool names")
+    issue.add_argument(
+        "--allowed-tools", nargs="*", default=[], help="allowed tool names"
+    )
+    issue.add_argument(
+        "--forbidden-tools", nargs="*", default=[], help="forbidden tool names"
+    )
     issue.add_argument(
         "--resource-scope",
         nargs="*",
@@ -4969,11 +5233,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="resource patterns; empty grants none, sole '**' explicitly grants all",
     )
     issue.add_argument("--max-tool-calls", default=50, help="max permitted tool calls")
-    issue.add_argument("--max-duration-s", default=600, help="max mission duration in seconds")
-    issue.add_argument("--delegation-allowed", action="store_true", help="allow one-step delegation")
-    issue.add_argument("--max-delegation-depth", default=0, help="delegation depth budget")
+    issue.add_argument(
+        "--max-duration-s", default=600, help="max mission duration in seconds"
+    )
+    issue.add_argument(
+        "--delegation-allowed", action="store_true", help="allow one-step delegation"
+    )
+    issue.add_argument(
+        "--max-delegation-depth", default=0, help="delegation depth budget"
+    )
     issue.add_argument("--ttl-s", help="override token TTL in seconds")
-    issue.add_argument("--keys-dir", type=str, help="directory containing VIBAP signing keys")
+    issue.add_argument(
+        "--keys-dir", type=str, help="directory containing VIBAP signing keys"
+    )
     issue.set_defaults(func=cmd_issue)
 
     verify = subparsers.add_parser(
@@ -4998,7 +5270,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="portable receiver-attestation receipt envelope",
     )
-    verify.add_argument("--keys-dir", type=str, help="directory containing VIBAP signing keys")
+    verify.add_argument(
+        "--keys-dir", type=str, help="directory containing VIBAP signing keys"
+    )
     verify.add_argument(
         "--receipt-public-key",
         type=Path,
@@ -5062,7 +5336,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="also enforce short receipt expiry windows during archival verification",
     )
-    verify.add_argument("--json", action="store_true", help="print a machine-readable explorer report")
+    verify.add_argument(
+        "--json", action="store_true", help="print a machine-readable explorer report"
+    )
     verify.add_argument(
         "--html-report",
         type=Path,
@@ -5103,9 +5379,7 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="explicit adapter for the JSONL event source",
     )
-    evidence_key_source = evidence_correlate.add_mutually_exclusive_group(
-        required=True
-    )
+    evidence_key_source = evidence_correlate.add_mutually_exclusive_group(required=True)
     evidence_key_source.add_argument(
         "--keys-dir",
         type=str,
@@ -5158,9 +5432,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="signed receipt JSONL journal to verify before export",
     )
-    telemetry_key_source = telemetry_export.add_mutually_exclusive_group(
-        required=True
-    )
+    telemetry_key_source = telemetry_export.add_mutually_exclusive_group(required=True)
     telemetry_key_source.add_argument(
         "--keys-dir",
         type=str,
@@ -5217,10 +5489,18 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="transparency backend used for pending anchors",
     )
-    anchor.add_argument("--keys-dir", type=str, help="receipt signing keys (required by Rekor v1)")
-    anchor.add_argument("--local-log", type=Path, help="self-hosted append-only log JSONL path")
-    anchor.add_argument("--log-private-key", type=Path, help="self-hosted log Ed25519 private key PEM")
-    anchor.add_argument("--origin", help="C2SP checkpoint origin for the self-hosted log")
+    anchor.add_argument(
+        "--keys-dir", type=str, help="receipt signing keys (required by Rekor v1)"
+    )
+    anchor.add_argument(
+        "--local-log", type=Path, help="self-hosted append-only log JSONL path"
+    )
+    anchor.add_argument(
+        "--log-private-key", type=Path, help="self-hosted log Ed25519 private key PEM"
+    )
+    anchor.add_argument(
+        "--origin", help="C2SP checkpoint origin for the self-hosted log"
+    )
     anchor.add_argument(
         "--rekor-url",
         default="https://rekor.sigstore.dev",
@@ -5269,10 +5549,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     offline_fixture.set_defaults(func=cmd_offline_verification_fixture)
 
-    attest = subparsers.add_parser("attest", help="issue a behavioral attestation for a saved session")
-    attest.add_argument("--session", required=True, help="session identifier / passport jti")
-    attest.add_argument("--keys-dir", type=str, help="directory containing VIBAP signing keys")
-    attest.add_argument("--state-dir", type=str, help="directory containing persisted sessions")
+    attest = subparsers.add_parser(
+        "attest", help="issue a behavioral attestation for a saved session"
+    )
+    attest.add_argument(
+        "--session", required=True, help="session identifier / passport jti"
+    )
+    attest.add_argument(
+        "--keys-dir", type=str, help="directory containing VIBAP signing keys"
+    )
+    attest.add_argument(
+        "--state-dir", type=str, help="directory containing persisted sessions"
+    )
     attest.add_argument("--log-path", type=str, help="JSONL audit log path")
     attest.set_defaults(func=cmd_attest)
 
@@ -5296,22 +5584,30 @@ def build_parser() -> argparse.ArgumentParser:
         "claude-code-report",
         help="verify Claude Code hook receipt chains and summarize observability",
     )
-    cc_report.add_argument("--home", type=str, help="Ardur home containing claude-code-hook receipts")
-    cc_report.add_argument("--chain-dir", type=str, help="explicit Claude Code receipt chain directory")
+    cc_report.add_argument(
+        "--home", type=str, help="Ardur home containing claude-code-hook receipts"
+    )
+    cc_report.add_argument(
+        "--chain-dir", type=str, help="explicit Claude Code receipt chain directory"
+    )
     cc_report.add_argument("--keys-dir", type=str, help="signing public-key directory")
     cc_report.add_argument(
         "--verify-expiry",
         action="store_true",
         help="also enforce short receipt expiry windows while verifying",
     )
-    cc_report.add_argument("--json", action="store_true", help="print machine-readable report")
+    cc_report.add_argument(
+        "--json", action="store_true", help="print machine-readable report"
+    )
     cc_report.set_defaults(func=cmd_claude_code_report)
 
     gemini_hook = subparsers.add_parser(
         "gemini-cli-hook",
         help="run the local-only Gemini CLI hook adapter",
     )
-    gemini_hook.add_argument("phase_pos", nargs="?", choices=["pre"], help="hook lifecycle phase")
+    gemini_hook.add_argument(
+        "phase_pos", nargs="?", choices=["pre"], help="hook lifecycle phase"
+    )
     gemini_hook.add_argument("--phase", choices=["pre"], help="hook lifecycle phase")
     gemini_hook.add_argument("--keys-dir", type=Path, help="signing keys directory")
     gemini_hook.set_defaults(func=cmd_gemini_cli_hook)
@@ -5325,8 +5621,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         help="explicit Gemini home/settings directory to populate; defaults to isolated Ardur local fixture state",
     )
-    gemini_fixture.add_argument("--project-dir", type=str, help="project directory that receives GEMINI.md")
-    gemini_fixture.add_argument("--chain-dir", type=str, help="Ardur Gemini receipt chain directory")
+    gemini_fixture.add_argument(
+        "--project-dir", type=str, help="project directory that receives GEMINI.md"
+    )
+    gemini_fixture.add_argument(
+        "--chain-dir", type=str, help="Ardur Gemini receipt chain directory"
+    )
     gemini_fixture.add_argument("--keys-dir", type=str, help="signing keys directory")
     gemini_fixture.set_defaults(func=cmd_gemini_cli_fixture)
 
@@ -5334,15 +5634,23 @@ def build_parser() -> argparse.ArgumentParser:
         "gemini-cli-report",
         help="verify Gemini CLI hook receipt chains and summarize local-only observability",
     )
-    gemini_report.add_argument("--home", type=str, help="Gemini/Ardur home used for redaction context")
-    gemini_report.add_argument("--chain-dir", type=str, help="explicit Gemini CLI receipt chain directory")
-    gemini_report.add_argument("--keys-dir", type=str, help="signing public-key directory")
+    gemini_report.add_argument(
+        "--home", type=str, help="Gemini/Ardur home used for redaction context"
+    )
+    gemini_report.add_argument(
+        "--chain-dir", type=str, help="explicit Gemini CLI receipt chain directory"
+    )
+    gemini_report.add_argument(
+        "--keys-dir", type=str, help="signing public-key directory"
+    )
     gemini_report.add_argument(
         "--verify-expiry",
         action="store_true",
         help="also enforce short receipt expiry windows while verifying",
     )
-    gemini_report.add_argument("--json", action="store_true", help="print machine-readable report")
+    gemini_report.add_argument(
+        "--json", action="store_true", help="print machine-readable report"
+    )
     gemini_report.set_defaults(func=cmd_gemini_cli_report)
 
     codex_event = subparsers.add_parser(
@@ -5361,8 +5669,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         help="explicit Codex home/config directory to populate; defaults to isolated Ardur local fixture state",
     )
-    codex_fixture.add_argument("--project-dir", type=str, help="project directory that receives CODEX.md")
-    codex_fixture.add_argument("--chain-dir", type=str, help="Ardur Codex receipt chain directory")
+    codex_fixture.add_argument(
+        "--project-dir", type=str, help="project directory that receives CODEX.md"
+    )
+    codex_fixture.add_argument(
+        "--chain-dir", type=str, help="Ardur Codex receipt chain directory"
+    )
     codex_fixture.add_argument("--keys-dir", type=str, help="signing keys directory")
     codex_fixture.set_defaults(func=cmd_codex_app_server_fixture)
 
@@ -5370,15 +5682,25 @@ def build_parser() -> argparse.ArgumentParser:
         "codex-app-server-report",
         help="verify Codex app-server receipt chains and summarize local-only observability",
     )
-    codex_report.add_argument("--home", type=str, help="Codex/Ardur home used for redaction context")
-    codex_report.add_argument("--chain-dir", type=str, help="explicit Codex app-server receipt chain directory")
-    codex_report.add_argument("--keys-dir", type=str, help="signing public-key directory")
+    codex_report.add_argument(
+        "--home", type=str, help="Codex/Ardur home used for redaction context"
+    )
+    codex_report.add_argument(
+        "--chain-dir",
+        type=str,
+        help="explicit Codex app-server receipt chain directory",
+    )
+    codex_report.add_argument(
+        "--keys-dir", type=str, help="signing public-key directory"
+    )
     codex_report.add_argument(
         "--verify-expiry",
         action="store_true",
         help="also enforce short receipt expiry windows while verifying",
     )
-    codex_report.add_argument("--json", action="store_true", help="print machine-readable report")
+    codex_report.add_argument(
+        "--json", action="store_true", help="print machine-readable report"
+    )
     codex_report.set_defaults(func=cmd_codex_app_server_report)
 
     posture = subparsers.add_parser(
@@ -5390,10 +5712,25 @@ def build_parser() -> argparse.ArgumentParser:
         "scan",
         help="scan receipt/profile/evidence artifacts into a posture JSON document",
     )
-    posture_scan.add_argument("--receipts", type=str, required=True, help="receipt chain directory or receipts.jsonl file")
-    posture_scan.add_argument("--keys-dir", type=str, help="directory containing passport_public.pem for read-only verification")
-    posture_scan.add_argument("--profile", type=str, help="optional ARDUR.md profile to digest")
-    posture_scan.add_argument("--evidence-bundle", type=str, help="optional redacted no-key evidence bundle to summarize")
+    posture_scan.add_argument(
+        "--receipts",
+        type=str,
+        required=True,
+        help="receipt chain directory or receipts.jsonl file",
+    )
+    posture_scan.add_argument(
+        "--keys-dir",
+        type=str,
+        help="directory containing passport_public.pem for read-only verification",
+    )
+    posture_scan.add_argument(
+        "--profile", type=str, help="optional ARDUR.md profile to digest"
+    )
+    posture_scan.add_argument(
+        "--evidence-bundle",
+        type=str,
+        help="optional redacted no-key evidence bundle to summarize",
+    )
     posture_scan.add_argument(
         "--verify-expiry",
         action="store_true",
@@ -5411,7 +5748,12 @@ def build_parser() -> argparse.ArgumentParser:
         "report",
         help="render a posture JSON document as a concise report",
     )
-    posture_report.add_argument("--input", type=str, required=True, help="posture JSON produced by ardur posture scan")
+    posture_report.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="posture JSON produced by ardur posture scan",
+    )
     posture_report.add_argument(
         "--format",
         choices=["markdown", "json"],
@@ -5462,7 +5804,9 @@ def build_parser() -> argparse.ArgumentParser:
     hub.add_argument("--home", type=str, help="Ardur Personal home directory")
     hub.add_argument("--tls-cert", type=Path, help="TLS certificate PEM file")
     hub.add_argument("--tls-key", type=Path, help="TLS private key PEM file")
-    hub.add_argument("--no-tls", action="store_true", help="disable TLS (plain HTTP only)")
+    hub.add_argument(
+        "--no-tls", action="store_true", help="disable TLS (plain HTTP only)"
+    )
     hub.set_defaults(func=cmd_hub)
 
     setup = subparsers.add_parser("setup", help="configure Ardur Personal on this Mac")
@@ -5484,28 +5828,55 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = subparsers.add_parser("status", help="show Ardur Personal Hub status")
     status.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL")
-    status.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
+    status.add_argument(
+        "--hub-token", default=None, help="Hub bearer token (defaults to config/env)"
+    )
     status.add_argument("--home", type=str, help="Ardur Personal home directory")
     status.set_defaults(func=cmd_status)
 
     doctor = subparsers.add_parser("doctor", help="check local Ardur Personal setup")
     doctor.add_argument("--home", type=str, help="Ardur Personal home directory")
     doctor.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL")
-    doctor.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
+    doctor.add_argument(
+        "--hub-token", default=None, help="Hub bearer token (defaults to config/env)"
+    )
     doctor.set_defaults(func=cmd_doctor)
 
-    doctor_cc = subparsers.add_parser("doctor-claude-code", help="check Claude Code plugin and active passport setup")
-    doctor_cc.add_argument("--home", type=Path, help="Ardur home containing active_mission.jwt")
-    doctor_cc.add_argument("--plugin-dir", type=Path, default=_default_claude_plugin_dir(), help="Claude Code plugin directory")
+    doctor_cc = subparsers.add_parser(
+        "doctor-claude-code", help="check Claude Code plugin and active passport setup"
+    )
+    doctor_cc.add_argument(
+        "--home", type=Path, help="Ardur home containing active_mission.jwt"
+    )
+    doctor_cc.add_argument(
+        "--plugin-dir",
+        type=Path,
+        default=_default_claude_plugin_dir(),
+        help="Claude Code plugin directory",
+    )
     doctor_cc.set_defaults(func=cmd_doctor_claude_code)
 
-    kill_switch = subparsers.add_parser("kill-switch", help="activate/deactivate the emergency kill switch")
-    kill_switch.add_argument("--deactivate", action="store_true", help="deactivate the kill switch")
-    kill_switch.add_argument("--proxy-url", default=None, help="proxy base URL (defaults to ARDUR_PROXY_URL env or https://127.0.0.1:8443)")
-    kill_switch.add_argument("--api-token", default=None, help="proxy bearer token (defaults to ARDUR_API_TOKEN env)")
+    kill_switch = subparsers.add_parser(
+        "kill-switch", help="activate/deactivate the emergency kill switch"
+    )
+    kill_switch.add_argument(
+        "--deactivate", action="store_true", help="deactivate the kill switch"
+    )
+    kill_switch.add_argument(
+        "--proxy-url",
+        default=None,
+        help="proxy base URL (defaults to ARDUR_PROXY_URL env or https://127.0.0.1:8443)",
+    )
+    kill_switch.add_argument(
+        "--api-token",
+        default=None,
+        help="proxy bearer token (defaults to ARDUR_API_TOKEN env)",
+    )
     kill_switch.set_defaults(func=cmd_kill_switch)
 
-    uninstall = subparsers.add_parser("uninstall", help="remove Ardur Personal launch files")
+    uninstall = subparsers.add_parser(
+        "uninstall", help="remove Ardur Personal launch files"
+    )
     uninstall.add_argument("--home", type=str, help="Ardur Personal home directory")
     uninstall.add_argument(
         "--remove-data",
@@ -5524,13 +5895,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="run a command through Ardur — governed launcher (with --mission/--allowed-tools) "
         "or Ardur Personal Hub streaming (legacy)",
     )
-    run.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL (legacy hub path)")
-    run.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
+    run.add_argument(
+        "--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL (legacy hub path)"
+    )
+    run.add_argument(
+        "--hub-token", default=None, help="Hub bearer token (defaults to config/env)"
+    )
     # ``--home`` uses ``type=str`` (not ``type=Path``) so empty/whitespace-only
     # values survive to the handler instead of being normalized to
     # ``Path('.')`` (the CWD) by argparse.  The handler rejects empty/whitespace
     # values before any ``Path()`` conversion or governance execution.
-    run.add_argument("--home", type=str, help="Ardur home directory (ephemeral by default for governance)")
+    run.add_argument(
+        "--home",
+        type=str,
+        help="Ardur home directory (ephemeral by default for governance)",
+    )
     # Governance-bridge flags. Supplying any of these switches `ardur run` from
     # the legacy hub-streaming path to the zero-setup governance launcher.
     run.add_argument("--mission", help="mission text for the governed agent run")
@@ -5591,7 +5970,9 @@ def build_parser() -> argparse.ArgumentParser:
         "a mission that also carries a file-scope dimension can never be fully "
         "enforceable on that tier",
     )
-    run.add_argument("command", nargs=argparse.REMAINDER, help="command to run after --")
+    run.add_argument(
+        "command", nargs=argparse.REMAINDER, help="command to run after --"
+    )
     run.set_defaults(func=cmd_run)
 
     desktop = subparsers.add_parser(
@@ -5599,11 +5980,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="record a Mac desktop app observation through Ardur Personal Hub",
     )
     desktop.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL")
-    desktop.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
+    desktop.add_argument(
+        "--hub-token", default=None, help="Hub bearer token (defaults to config/env)"
+    )
     desktop.add_argument("--home", type=str, help="Ardur Personal home directory")
     desktop.add_argument("--session-id", help="stable desktop session id")
-    desktop.add_argument("--app", help="application name; autodetected on macOS when omitted")
-    desktop.add_argument("--title", help="window title; autodetected on macOS when omitted")
+    desktop.add_argument(
+        "--app", help="application name; autodetected on macOS when omitted"
+    )
+    desktop.add_argument(
+        "--title", help="window title; autodetected on macOS when omitted"
+    )
     desktop.add_argument(
         "--text",
         help="explicit-consent visible text excerpt to include in the session review",
@@ -5614,9 +6001,15 @@ def build_parser() -> argparse.ArgumentParser:
         "personal-native-host",
         help="run the Ardur Personal native messaging bridge",
     )
-    personal_native_host.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL")
-    personal_native_host.add_argument("--hub-token", default=None, help="Hub bearer token (defaults to config/env)")
-    personal_native_host.add_argument("--home", type=str, help="Ardur Personal home directory")
+    personal_native_host.add_argument(
+        "--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL"
+    )
+    personal_native_host.add_argument(
+        "--hub-token", default=None, help="Hub bearer token (defaults to config/env)"
+    )
+    personal_native_host.add_argument(
+        "--home", type=str, help="Ardur Personal home directory"
+    )
     personal_native_host.add_argument(
         "--once-json",
         type=Path,
@@ -5678,9 +6071,15 @@ def build_parser() -> argparse.ArgumentParser:
         default="read-only",
         help="starter profile to write",
     )
-    profile_init.add_argument("--path", type=Path, default=Path("ARDUR.md"), help="profile file to create")
-    profile_init.add_argument("--force", action="store_true", help="replace an existing profile")
-    profile_init.add_argument("--json", action="store_true", help="print machine-readable setup details")
+    profile_init.add_argument(
+        "--path", type=Path, default=Path("ARDUR.md"), help="profile file to create"
+    )
+    profile_init.add_argument(
+        "--force", action="store_true", help="replace an existing profile"
+    )
+    profile_init.add_argument(
+        "--json", action="store_true", help="print machine-readable setup details"
+    )
     profile_init.set_defaults(func=cmd_profile_init)
 
     protect = subparsers.add_parser(
@@ -5692,41 +6091,66 @@ def build_parser() -> argparse.ArgumentParser:
         "claude-code",
         help="issue an active Mission Passport and print the Claude Code plugin command",
     )
-    protect_cc.add_argument("--scope", type=str, help="folder Claude Code is allowed to work in")
+    protect_cc.add_argument(
+        "--scope", type=str, help="folder Claude Code is allowed to work in"
+    )
     # ``--profile`` uses ``type=str`` (not ``type=Path``) so empty/whitespace-only
     # values survive to the handler instead of being normalized to
     # ``PosixPath('.')`` (the CWD) at parse time. The handler validates the
     # stripped string before any key generation or profile loading.
-    protect_cc.add_argument("--profile", type=str, help="Markdown Ardur profile, such as ARDUR.md")
+    protect_cc.add_argument(
+        "--profile", type=str, help="Markdown Ardur profile, such as ARDUR.md"
+    )
     protect_cc.add_argument(
         "--mode",
         choices=sorted(CLAUDE_CODE_PROTECT_MODES),
         default=None,
         help="plain-English policy template",
     )
-    protect_cc.add_argument("--json", action="store_true", help="print machine-readable setup details")
+    protect_cc.add_argument(
+        "--json", action="store_true", help="print machine-readable setup details"
+    )
     # ``--home`` uses ``type=str`` (not ``type=Path``) so empty/whitespace-only
     # values survive to the handler instead of being normalized to
     # ``PosixPath('.')`` (the CWD) at parse time. The handler validates the
     # stripped string before any directory creation or key generation.
-    protect_cc.add_argument("--home", type=str, help="Ardur home that receives active_mission.jwt")
-    protect_cc.add_argument("--plugin-dir", type=Path, default=_default_claude_plugin_dir(), help="Claude Code plugin directory")
+    protect_cc.add_argument(
+        "--home", type=str, help="Ardur home that receives active_mission.jwt"
+    )
+    protect_cc.add_argument(
+        "--plugin-dir",
+        type=Path,
+        default=_default_claude_plugin_dir(),
+        help="Claude Code plugin directory",
+    )
     # ``--keys-dir`` uses ``type=str`` (not ``type=Path``) so empty/whitespace-
     # only values survive to the handler instead of being normalized to
     # ``PosixPath('.')`` (the CWD) at parse time. The handler validates the
     # stripped string before any directory creation or key generation.
     protect_cc.add_argument("--keys-dir", type=str, help="signing keys directory")
-    protect_cc.add_argument("--agent-id", default="local-user:claude-code", help="Mission Passport subject")
-    protect_cc.add_argument("--mission", help="override the default mission text for the selected mode")
-    protect_cc.add_argument("--max-tool-calls", type=int, default=250, help="maximum governed tool calls")
-    protect_cc.add_argument("--max-duration-s", type=int, default=86400, help="mission duration budget in seconds")
+    protect_cc.add_argument(
+        "--agent-id", default="local-user:claude-code", help="Mission Passport subject"
+    )
+    protect_cc.add_argument(
+        "--mission", help="override the default mission text for the selected mode"
+    )
+    protect_cc.add_argument(
+        "--max-tool-calls", type=int, default=250, help="maximum governed tool calls"
+    )
+    protect_cc.add_argument(
+        "--max-duration-s",
+        type=int,
+        default=86400,
+        help="mission duration budget in seconds",
+    )
     protect_cc.add_argument("--ttl-s", type=int, help="override token TTL in seconds")
     protect_cc.add_argument(
         # ``type=str`` (not ``Path``) so an empty or whitespace-only value
         # survives parsing and can be rejected explicitly below. ``type=Path``
         # normalises ``""`` to ``PosixPath(".")`` which silently resolves to the
         # CWD and masks the empty-argument defect.
-        "--forbid-rules", type=str,
+        "--forbid-rules",
+        type=str,
         help="JSON file containing forbid_rules policy specifications",
     )
     protect_cc.add_argument(
@@ -5734,7 +6158,8 @@ def build_parser() -> argparse.ArgumentParser:
         # survives parsing and can be rejected explicitly below. ``type=Path``
         # normalises ``""`` to ``PosixPath(".")`` which silently resolves to the
         # CWD and masks the empty-argument defect.
-        "--cedar-policy", type=str,
+        "--cedar-policy",
+        type=str,
         help="Cedar policy file (.cedar)",
     )
     protect_cc.add_argument(
@@ -5742,7 +6167,8 @@ def build_parser() -> argparse.ArgumentParser:
         # survives parsing and can be rejected explicitly below. ``type=Path``
         # normalises ``""`` to ``PosixPath(".")`` which silently resolves to the
         # CWD and masks the empty-argument defect.
-        "--cedar-entities", type=str,
+        "--cedar-entities",
+        type=str,
         help="Cedar entities JSON file (used with --cedar-policy)",
     )
     protect_cc.set_defaults(func=cmd_protect_claude_code)

--- a/python/vibap/proxy.py
+++ b/python/vibap/proxy.py
@@ -35,34 +35,7 @@ import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from .metrics import metrics as ardur_metrics
-from .rate_limiter import RateLimiter
-from .tls import create_ssl_context, resolve_tls_paths
-
-# Session IDs are UUIDs — reject anything else to prevent path traversal
-_SESSION_ID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
-_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
-MAX_REQUEST_BODY = 1024 * 1024  # 1 MiB
-_API_TOKEN_COMPARE_MAX_BYTES = 4096
-
-# Per-session in-process coordination for shared state_dir access. ``flock``
-# closes the cross-process hole, but same-process proxies can still share a
-# PID, so we need a process-local lock keyed by the absolute lockfile path.
-class _SessionCoordinationLock:
-    """Weakref-able wrapper for a per-session reentrant process lock."""
-
-    __slots__ = ("lock", "__weakref__")
-
-    def __init__(self) -> None:
-        self.lock = threading.RLock()
-
-
-_SESSION_COORDINATION_LOCKS: weakref.WeakValueDictionary[str, _SessionCoordinationLock] = (
-    weakref.WeakValueDictionary()
-)
-_SESSION_COORDINATION_LOCKS_GUARD = threading.Lock()
-
-from .aat_adapter import (  # noqa: E402
+from .aat_adapter import (
     AAT_CREDENTIAL_FORMAT,
     decode_aat_claims,
     material_from_aat_grant,
@@ -75,6 +48,13 @@ from .lineage_budget import (
     LineageBudgetConflictError,
     LineageBudgetLedger,
 )
+from .memory import (
+    MEMORY_STORE_READ_TOOL,
+    MEMORY_STORE_WRITE_TOOL,
+    GovernedMemoryStore,
+    MemoryIntegrityError,
+)
+from .metrics import metrics as ardur_metrics
 from .mission import (
     MissionBindingError,
     MissionCache,
@@ -82,12 +62,6 @@ from .mission import (
     fetch_mission_declaration,
     mission_is_revoked,
     parse_mission_ref,
-)
-from .memory import (
-    MEMORY_STORE_READ_TOOL,
-    MEMORY_STORE_WRITE_TOOL,
-    GovernedMemoryStore,
-    MemoryIntegrityError,
 )
 from .passport import (
     DEFAULT_HOME,
@@ -103,6 +77,41 @@ from .passport import (
     resolve_keys_dir,
     verify_passport,
 )
+from .policy_backend import (
+    PolicyDecision,
+    compose_decisions,
+    get_backend,
+    timed_evaluate,
+)
+from .rate_limiter import RateLimiter
+from .tls import create_ssl_context, resolve_tls_paths
+
+# Session IDs are UUIDs — reject anything else to prevent path traversal
+_SESSION_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+MAX_REQUEST_BODY = 1024 * 1024  # 1 MiB
+_API_TOKEN_COMPARE_MAX_BYTES = 4096
+
+
+# Per-session in-process coordination for shared state_dir access. ``flock``
+# closes the cross-process hole, but same-process proxies can still share a
+# PID, so we need a process-local lock keyed by the absolute lockfile path.
+class _SessionCoordinationLock:
+    """Weakref-able wrapper for a per-session reentrant process lock."""
+
+    __slots__ = ("lock", "__weakref__")
+
+    def __init__(self) -> None:
+        self.lock = threading.RLock()
+
+
+_SESSION_COORDINATION_LOCKS: weakref.WeakValueDictionary[
+    str, _SessionCoordinationLock
+] = weakref.WeakValueDictionary()
+_SESSION_COORDINATION_LOCKS_GUARD = threading.Lock()
+
 # NOTE: ``from .receipt import build_receipt, sign_receipt`` was a top-level
 # import here, but proxy ↔ receipt forms a cycle (receipt.py uses ``PolicyEvent``
 # from this module under ``TYPE_CHECKING``). Although the cycle is safe at
@@ -113,9 +122,10 @@ from .passport import (
 # called in exactly one method (``_build_receipt_log_entry``), so a deferred
 # local import there breaks the topological cycle without changing semantics.
 # See ``_build_receipt_log_entry`` for the deferred import.
-from .policy_backend import PolicyDecision, compose_decisions, get_backend, timed_evaluate
 
-DEFAULT_STATE_DIR = Path(os.environ.get("VIBAP_STATE_DIR", DEFAULT_HOME / "state")).expanduser()
+DEFAULT_STATE_DIR = Path(
+    os.environ.get("VIBAP_STATE_DIR", DEFAULT_HOME / "state")
+).expanduser()
 DEFAULT_LOG_PATH = DEFAULT_HOME / "governance_log.jsonl"
 DEFAULT_RECEIPTS_LOG_PATH = DEFAULT_HOME / "receipts_log.jsonl"
 
@@ -139,6 +149,7 @@ def _warn_explicit_unrestricted_resource_scope(claims: Mapping[str, Any]) -> Non
         claims.get("jti", "unknown"),
         claims.get("sub", "unknown"),
     )
+
 
 # B.2 fail-closed precondition (PLAN E.8). Declared telemetry fields MUST be
 # present and non-empty in the tool-call arguments dict or the verifier returns
@@ -257,7 +268,7 @@ _WINDOWS_UNC_RE = re.compile(r"^\\\\[^\\]+\\")
 # We intentionally exclude U+2571 BOX DRAWINGS LIGHT DIAGONAL (decorative
 # line-drawing, very rare in real paths) and backslash variants — ASCII
 # ``\`` has its own dedicated handling (Windows shape + bare-backslash).
-_SLASH_LIKE_CODEPOINTS = frozenset({"/", "\uFF0F", "\u2044", "\u29F8", "\u2215"})
+_SLASH_LIKE_CODEPOINTS = frozenset({"/", "\uff0f", "\u2044", "\u29f8", "\u2215"})
 
 # Dot-confusable codepoints: NFKC maps all three to ASCII ``.`` (U+002E).
 # NFC does NOT fold them, so the step-2 NFC pass alone is insufficient. A
@@ -272,7 +283,7 @@ _SLASH_LIKE_CODEPOINTS = frozenset({"/", "\uFF0F", "\u2044", "\u29F8", "\u2215"}
 #
 # We fold explicitly (same pattern as ``_SLASH_LIKE_CODEPOINTS``) so the
 # step-3 pre-normalisation ``..`` check fires before a PERMIT is issued.
-_DOT_LIKE_CODEPOINTS = frozenset({"\u2024", "\uFE52", "\uFF0E"})
+_DOT_LIKE_CODEPOINTS = frozenset({"\u2024", "\ufe52", "\uff0e"})
 
 
 def _contains_slash_like(s: str) -> bool:
@@ -333,29 +344,68 @@ _RESOURCE_SCAN_MAX_DEPTH = 16
 #
 # Hints are resolved per-check (not cached at import time) so tests and
 # operators can flip env vars without reimporting the module.
-_DEFAULT_PATH_HINTS = frozenset({
-    "path", "file", "filepath", "filename", "url", "uri",
-    "src", "source", "dst", "dest", "destination",
-    "location", "object_key", "cwd", "directory", "dir",
-    "target", "resource",
-    "command", "script", "cmd", "file_path",
-    # Phase-3.1b M-1 (external-review-G F1): `pattern` was previously a PATH hint,
-    # but grep / ripgrep / find / SQL LIKE wrappers all use `pattern`
-    # for a REGEX / GLOB / LIKE expression, not a filesystem path.
-    # Treating it as a path produced false-DENYs on in-memory-only
-    # operations (e.g. `{"pattern": "foo/bar", "path": "ok.txt"}`
-    # denied on `pattern`). Dropped from PATH_HINTS. A caller who
-    # really does want `pattern` scoped can re-add it via the
-    # `VIBAP_SCOPE_PATH_HINTS` env var — the defaults now optimize
-    # for the common case.
-})
-_DEFAULT_PROSE_HINTS = frozenset({
-    "content", "body", "text", "message", "note", "summary",
-    "description", "old_string", "new_string", "prompt",
-    "markdown", "response", "stdout", "stderr", "log",
-    "comment", "memo", "answer", "output", "instruction",
-    "query", "sql", "html",
-})
+_DEFAULT_PATH_HINTS = frozenset(
+    {
+        "path",
+        "file",
+        "filepath",
+        "filename",
+        "url",
+        "uri",
+        "src",
+        "source",
+        "dst",
+        "dest",
+        "destination",
+        "location",
+        "object_key",
+        "cwd",
+        "directory",
+        "dir",
+        "target",
+        "resource",
+        "command",
+        "script",
+        "cmd",
+        "file_path",
+        # Phase-3.1b M-1 (external-review-G F1): `pattern` was previously a PATH hint,
+        # but grep / ripgrep / find / SQL LIKE wrappers all use `pattern`
+        # for a REGEX / GLOB / LIKE expression, not a filesystem path.
+        # Treating it as a path produced false-DENYs on in-memory-only
+        # operations (e.g. `{"pattern": "foo/bar", "path": "ok.txt"}`
+        # denied on `pattern`). Dropped from PATH_HINTS. A caller who
+        # really does want `pattern` scoped can re-add it via the
+        # `VIBAP_SCOPE_PATH_HINTS` env var — the defaults now optimize
+        # for the common case.
+    }
+)
+_DEFAULT_PROSE_HINTS = frozenset(
+    {
+        "content",
+        "body",
+        "text",
+        "message",
+        "note",
+        "summary",
+        "description",
+        "old_string",
+        "new_string",
+        "prompt",
+        "markdown",
+        "response",
+        "stdout",
+        "stderr",
+        "log",
+        "comment",
+        "memo",
+        "answer",
+        "output",
+        "instruction",
+        "query",
+        "sql",
+        "html",
+    }
+)
 
 # Cap on raw token input. An attacker who can stuff an MB-sized blob into
 # one arg shouldn't be able to make us do MB-sized splits per call. Values
@@ -371,17 +421,19 @@ _RESOURCE_PERCENT_DECODE_MAX_ITERATIONS = 8
 # be reclassified as resource references by the embedded-path rule below.
 # ``_is_path_shaped_token`` remains the primary grammar guard; this set only
 # fences the extra pure-alpha path recovery added for round-3 C1.
-_GRAMMATICAL_PROSE_SLASH_TOKENS = frozenset({
-    "and/or",
-    "either/or",
-    "he/she",
-    "her/him",
-    "her/his",
-    "him/her",
-    "his/her",
-    "s/he",
-    "she/he",
-})
+_GRAMMATICAL_PROSE_SLASH_TOKENS = frozenset(
+    {
+        "and/or",
+        "either/or",
+        "he/she",
+        "her/him",
+        "her/his",
+        "him/her",
+        "his/her",
+        "s/he",
+        "she/he",
+    }
+)
 
 
 def _sanitize_value(value: str) -> tuple[str, str | None]:
@@ -424,6 +476,7 @@ def _sanitize_value(value: str) -> tuple[str, str | None]:
     #    nested encodings (%252E → %2E → .). The loop is bounded and fails
     #    closed if a value keeps changing after the cap.
     import urllib.parse
+
     raw_input = value
     for _ in range(_RESOURCE_PERCENT_DECODE_MAX_ITERATIONS):
         decoded = urllib.parse.unquote(value)
@@ -536,6 +589,7 @@ def _resolve_hint_sets() -> tuple[frozenset[str], frozenset[str]]:
     Resolved on every call (not cached) so tests can flip env vars without
     reimporting the module. The cost is a tiny set union per check.
     """
+
     def _parse(raw: str | None) -> set[str]:
         if not raw:
             return set()
@@ -684,7 +738,9 @@ def _is_short_pure_alpha_slash_compound(s: str) -> bool:
     segments = _SLASH_LIKE_SPLIT_RE.split(s)
     if len(segments) != 2:
         return False
-    return all(segment and segment.isalpha() and len(segment) <= 4 for segment in segments)
+    return all(
+        segment and segment.isalpha() and len(segment) <= 4 for segment in segments
+    )
 
 
 def _extract_path_tokens(
@@ -910,7 +966,11 @@ def _iter_resource_values(
                     exhausted["v"] = True
                 return
             yield from _iter_resource_values(
-                val, key=str(k), depth=depth + 1, budget=budget, exhausted=exhausted,
+                val,
+                key=str(k),
+                depth=depth + 1,
+                budget=budget,
+                exhausted=exhausted,
             )
         return
     if isinstance(arguments, (list, tuple)):
@@ -925,7 +985,11 @@ def _iter_resource_values(
             # ``{"directory": ["hr"]}`` evade ``resource_scope`` because
             # they do not have path syntax on their own.
             yield from _iter_resource_values(
-                item, key=key, depth=depth + 1, budget=budget, exhausted=exhausted,
+                item,
+                key=key,
+                depth=depth + 1,
+                budget=budget,
+                exhausted=exhausted,
             )
         return
     # Non-string scalars (int/float/bool/None) are never resources.
@@ -1003,8 +1067,7 @@ def _check_resource_scope(
             "fix the passport's resource_scope field"
         )
     if UNRESTRICTED_RESOURCE_SCOPE_PATTERN in patterns and (
-        patterns != [UNRESTRICTED_RESOURCE_SCOPE_PATTERN]
-        or len(resource_scope) != 1
+        patterns != [UNRESTRICTED_RESOURCE_SCOPE_PATTERN] or len(resource_scope) != 1
     ):
         return False, "unrestricted '**' must be the only resource_scope pattern"
 
@@ -1150,9 +1213,7 @@ def _check_resource_scope(
                 )
             normalized, error_reason = _sanitize_value(token)
             if error_reason is not None:
-                return False, (
-                    f"resource '{_preview(token)}' rejected: {error_reason}"
-                )
+                return False, (f"resource '{_preview(token)}' rejected: {error_reason}")
 
             token_is_absolute = (
                 normalized.startswith("/")
@@ -1181,7 +1242,9 @@ def _check_resource_scope(
                     # posixpath.normpath on a join that contains '..' would
                     # already be flagged by the sanitizer, but we defend in
                     # depth against any future helper change.
-                    if joined == cwd_anchor or joined.startswith(cwd_anchor.rstrip("/") + "/"):
+                    if joined == cwd_anchor or joined.startswith(
+                        cwd_anchor.rstrip("/") + "/"
+                    ):
                         if _matches_any(joined):
                             matched_candidate = joined
 
@@ -1334,7 +1397,9 @@ def _receipt_step_id(
         sort_keys=True,
         separators=(",", ":"),
     )
-    digest = hmac.new(b"vibap-receipt-step", material.encode("utf-8"), "sha256").hexdigest()[:32]
+    digest = hmac.new(
+        b"vibap-receipt-step", material.encode("utf-8"), "sha256"
+    ).hexdigest()[:32]
     return f"step:{digest}"
 
 
@@ -1369,19 +1434,29 @@ def _policy_action_class(tool_name: str) -> str:
     lowered = tool_name.lower()
     if "delegat" in lowered:
         return "delegate"
-    if any(token in lowered for token in ("send", "email", "mail", "post", "notify", "message", "share")):
+    if any(
+        token in lowered
+        for token in ("send", "email", "mail", "post", "notify", "message", "share")
+    ):
         return "send"
     if any(token in lowered for token in ("search", "find", "lookup", "grep")):
         return "search"
     if any(token in lowered for token in ("query", "sql", "select", "calc", "compute")):
         return "query"
-    if any(token in lowered for token in ("write", "create", "append", "save", "upload")):
+    if any(
+        token in lowered for token in ("write", "create", "append", "save", "upload")
+    ):
         return "write"
     if any(token in lowered for token in ("summar", "analy", "report")):
         return "summarize"
-    if any(token in lowered for token in ("read", "get", "fetch", "view", "list", "download", "open")):
+    if any(
+        token in lowered
+        for token in ("read", "get", "fetch", "view", "list", "download", "open")
+    ):
         return "read"
-    if any(token in lowered for token in ("update", "edit", "modify", "delete", "remove")):
+    if any(
+        token in lowered for token in ("update", "edit", "modify", "delete", "remove")
+    ):
         return "write"
     return "observe"
 
@@ -1394,9 +1469,14 @@ def _policy_resource_family(
 ) -> str:
     lowered_tool = tool_name.lower()
     lowered_target = target.lower()
-    if _is_memory_store_tool(tool_name) or any(key in arguments for key in ("store_id", "record_id")):
+    if _is_memory_store_tool(tool_name) or any(
+        key in arguments for key in ("store_id", "record_id")
+    ):
         return "memory_store"
-    if any(key in arguments for key in ("path", "file_path", "filename", "directory", "cwd")):
+    if any(
+        key in arguments
+        for key in ("path", "file_path", "filename", "directory", "cwd")
+    ):
         return "filesystem"
     if any(key in arguments for key in ("url", "uri")):
         return "network_resource"
@@ -1408,7 +1488,10 @@ def _policy_resource_family(
         return "computation"
     if any(token in lowered_tool for token in ("memory", "store")):
         return "memory_store"
-    if any(token in lowered_target for token in ("/", ".txt", ".md", ".json", ".csv", ".pdf")):
+    if any(
+        token in lowered_target
+        for token in ("/", ".txt", ".md", ".json", ".csv", ".pdf")
+    ):
         return "filesystem"
     return "general"
 
@@ -1489,13 +1572,17 @@ class PolicyEvent:
             "side_effect_class": self.side_effect_class,
             "decision": self.decision.value,
             "reason": self.reason,
-            "denial_reason": self.denial_reason.value if self.denial_reason is not None else None,
+            "denial_reason": self.denial_reason.value
+            if self.denial_reason is not None
+            else None,
             "passport_jti": self.passport_jti,
             "trace_id": self.trace_id,
             "run_nonce": self.run_nonce,
             "response": self.response,
             "duration_ms": self.duration_ms,
-            "budget_delta": dict(self.budget_delta) if self.budget_delta is not None else None,
+            "budget_delta": dict(self.budget_delta)
+            if self.budget_delta is not None
+            else None,
             "evidence_proof_ref": copy.deepcopy(self.evidence_proof_ref),
             "policy_decisions": list(self.policy_decisions),
         }
@@ -1541,7 +1628,9 @@ class PolicyEvent:
             run_nonce=data.get("run_nonce"),
             response=data.get("response"),
             duration_ms=float(data.get("duration_ms", 0.0)),
-            budget_delta=dict(data["budget_delta"]) if isinstance(data.get("budget_delta"), dict) else None,
+            budget_delta=dict(data["budget_delta"])
+            if isinstance(data.get("budget_delta"), dict)
+            else None,
             evidence_proof_ref=copy.deepcopy(data.get("evidence_proof_ref")),
             policy_decisions=list(data.get("policy_decisions", []) or []),
         )
@@ -1556,7 +1645,9 @@ class PassportStateUnavailableError(RuntimeError):
 
 
 class _MissionPolicyResolutionError(RuntimeError):
-    def __init__(self, decision: Decision, reason: str, denial_reason: DenialReason) -> None:
+    def __init__(
+        self, decision: Decision, reason: str, denial_reason: DenialReason
+    ) -> None:
         super().__init__(reason)
         self.decision = decision
         self.reason = reason
@@ -1582,7 +1673,9 @@ class GovernanceSession:
     last_receipt_id: str | None = None
     last_receipt_full_hash: str | None = None
     run_nonce: str = field(default_factory=lambda: secrets.token_urlsafe(24))
-    _lock: threading.RLock = field(default_factory=threading.RLock, repr=False, compare=False)
+    _lock: threading.RLock = field(
+        default_factory=threading.RLock, repr=False, compare=False
+    )
 
     @property
     def elapsed_s(self) -> float:
@@ -1603,11 +1696,15 @@ class GovernanceSession:
     ) -> tuple[Decision, str, PolicyEvent]:
         """Atomically check a tool call and record the event under the session lock."""
         with self._lock:
-            active_policy = policy_claims if policy_claims is not None else self.passport_claims
+            active_policy = (
+                policy_claims if policy_claims is not None else self.passport_claims
+            )
             actor = str(self.passport_claims.get("sub", "unknown"))
             target = _policy_event_target(tool_name, arguments)
             action_class = _policy_action_class(tool_name)
-            resource_family = _policy_resource_family(tool_name, arguments, target, action_class)
+            resource_family = _policy_resource_family(
+                tool_name, arguments, target, action_class
+            )
             sec = _policy_side_effect_class(tool_name, action_class, resource_family)
             shared_context = {
                 "passport": dict(active_policy),
@@ -1616,7 +1713,9 @@ class GovernanceSession:
                     "tool_call_count_by_class": dict(self.tool_call_count_by_class),
                     "side_effect_counts": dict(self.tool_call_count_by_class),
                     "delegated_budget_reserved": self.delegated_budget_reserved,
-                    "delegation_depth": len(active_policy.get("delegation_chain", []) or []),
+                    "delegation_depth": len(
+                        active_policy.get("delegation_chain", []) or []
+                    ),
                     "elapsed_s": self.elapsed_s,
                     "cwd": active_policy.get("cwd"),
                 },
@@ -1652,7 +1751,9 @@ class GovernanceSession:
                 )
             decisions.append(native_decision)
             if additional:
-                policy_decisions_dicts.append(GovernanceProxy._event_policy_decision_dict(native_decision))
+                policy_decisions_dicts.append(
+                    GovernanceProxy._event_policy_decision_dict(native_decision)
+                )
 
             # Always evaluate every registered backend — no short-circuit on
             # Deny. §1 claims "all three evaluate on every call" and the audit
@@ -1693,7 +1794,9 @@ class GovernanceSession:
                             eval_ms=policy_decision.eval_ms,
                         )
                 decisions.append(policy_decision)
-                policy_decisions_dicts.append(GovernanceProxy._event_policy_decision_dict(policy_decision))
+                policy_decisions_dicts.append(
+                    GovernanceProxy._event_policy_decision_dict(policy_decision)
+                )
 
             final_decision, first_denier = compose_decisions(decisions)
             denial_reason: DenialReason | None = None
@@ -1706,11 +1809,14 @@ class GovernanceSession:
                 denial_reason = DenialReason.POLICY_DENIED
             elif first_denier.backend == "native":
                 decision = Decision.DENY
-                reason = "; ".join(first_denier.reasons) if first_denier.reasons else "native policy denied"
+                reason = (
+                    "; ".join(first_denier.reasons)
+                    if first_denier.reasons
+                    else "native policy denied"
+                )
                 denial_reason = _legacy_denial_reason(decision, reason)
-            elif (
-                first_denier.reasons
-                and first_denier.reasons[0].startswith("unknown policy backend:")
+            elif first_denier.reasons and first_denier.reasons[0].startswith(
+                "unknown policy backend:"
             ):
                 decision = Decision.DENY
                 reason = first_denier.reasons[0]
@@ -1771,13 +1877,17 @@ class GovernanceSession:
                 "side_effect_class": event.side_effect_class,
                 "decision": event.decision.value,
                 "reason": event.reason,
-                "denial_reason": event.denial_reason.value if event.denial_reason is not None else None,
+                "denial_reason": event.denial_reason.value
+                if event.denial_reason is not None
+                else None,
                 "passport_jti": event.passport_jti,
                 "trace_id": event.trace_id,
                 "run_nonce": event.run_nonce,
                 "response_preview": (event.response or "")[:200],
                 "duration_ms": event.duration_ms,
-                "budget_delta": dict(event.budget_delta) if event.budget_delta is not None else None,
+                "budget_delta": dict(event.budget_delta)
+                if event.budget_delta is not None
+                else None,
             }
             for event in self.events
         ]
@@ -1800,7 +1910,9 @@ class GovernanceSession:
         if self.attestation_token is not None:
             payload["attestation_token"] = self.attestation_token
         if self.memory_compromised_stores:
-            payload["memory_compromised_stores"] = sorted(self.memory_compromised_stores)
+            payload["memory_compromised_stores"] = sorted(
+                self.memory_compromised_stores
+            )
         if self.last_receipt_id is not None:
             payload["last_receipt_id"] = self.last_receipt_id
         if self.last_receipt_full_hash is not None:
@@ -1813,10 +1925,16 @@ class GovernanceSession:
             passport_token=data["passport_token"],
             passport_claims=dict(data["passport_claims"]),
         )
-        session.events = [PolicyEvent.from_dict(item) for item in data.get("events", [])]
+        session.events = [
+            PolicyEvent.from_dict(item) for item in data.get("events", [])
+        ]
         session.tool_call_count = int(data.get("tool_call_count", 0))
-        session.tool_call_count_by_class = dict(data.get("tool_call_count_by_class", {}))
-        session.delegated_budget_reserved = int(data.get("delegated_budget_reserved", 0))
+        session.tool_call_count_by_class = dict(
+            data.get("tool_call_count_by_class", {})
+        )
+        session.delegated_budget_reserved = int(
+            data.get("delegated_budget_reserved", 0)
+        )
         session.delegated_children = list(data.get("delegated_children", []))
         raw_run_nonce = data.get("run_nonce")
         if isinstance(raw_run_nonce, str) and raw_run_nonce:
@@ -1833,7 +1951,9 @@ class GovernanceSession:
                     raw_end_time = None
         session.end_time = float(raw_end_time) if raw_end_time is not None else None
         session.attestation_token = data.get("attestation_token")
-        session.memory_compromised_stores = set(data.get("memory_compromised_stores", []))
+        session.memory_compromised_stores = set(
+            data.get("memory_compromised_stores", [])
+        )
         session.last_receipt_id = data.get("last_receipt_id")
         session.last_receipt_full_hash = data.get("last_receipt_full_hash")
         session.memory_stores = {}
@@ -1883,8 +2003,12 @@ class GovernanceProxy:
             "parent_jti": str(parent_jti),
             "child_agent_id": str(child_agent_id),
             "child_mission": str(child_mission),
-            "child_allowed_tools": cls._normalized_delegation_string_list(child_allowed_tools),
-            "child_resource_scope": cls._normalized_delegation_string_list(child_resource_scope),
+            "child_allowed_tools": cls._normalized_delegation_string_list(
+                child_allowed_tools
+            ),
+            "child_resource_scope": cls._normalized_delegation_string_list(
+                child_resource_scope
+            ),
             "child_ttl_s": int(child_ttl_s) if child_ttl_s is not None else None,
             "child_max_tool_calls": int(child_max_tool_calls)
             if child_max_tool_calls is not None
@@ -1961,22 +2085,22 @@ class GovernanceProxy:
         # tests that want to bypass it pass None and populate
         # additional_policies directly in a mission dict.
         self.policy_store = policy_store
-        self.log_path = Path(log_path).expanduser() if log_path is not None else DEFAULT_LOG_PATH
+        self.log_path = (
+            Path(log_path).expanduser() if log_path is not None else DEFAULT_LOG_PATH
+        )
         if receipts_log_path is not None:
             self.receipts_log_path = Path(receipts_log_path).expanduser()
         elif log_path is not None:
             self.receipts_log_path = self.log_path.with_name("receipts_log.jsonl")
         else:
             self.receipts_log_path = DEFAULT_RECEIPTS_LOG_PATH
-        self.state_dir = Path(state_dir).expanduser() if state_dir is not None else DEFAULT_STATE_DIR
+        self.state_dir = (
+            Path(state_dir).expanduser() if state_dir is not None else DEFAULT_STATE_DIR
+        )
         # When any path falls through to a DEFAULT_HOME-derived default,
         # materialise the home with 0o700 before we start creating state
         # directories inside it.
-        if (
-            log_path is None
-            or state_dir is None
-            or receipts_log_path is None
-        ):
+        if log_path is None or state_dir is None or receipts_log_path is None:
             _ensure_default_home_dir()
         self._ensure_private_state_directory(self.state_dir, label="state_dir")
         self.sessions_dir = self.state_dir / "sessions"
@@ -2017,15 +2141,12 @@ class GovernanceProxy:
             if not isinstance(keys, list) or not keys:
                 raise ValueError("Biscuit peer trust bundle must contain JWT keys")
             if not any(
-                isinstance(key, dict) and key.get("use") == "jwt-svid"
-                for key in keys
+                isinstance(key, dict) and key.get("use") == "jwt-svid" for key in keys
             ):
                 raise ValueError(
                     "Biscuit peer trust bundle has no JWT-SVID signing keys"
                 )
-        self._biscuit_peer_trust_bundle = copy.deepcopy(
-            biscuit_peer_trust_bundle
-        )
+        self._biscuit_peer_trust_bundle = copy.deepcopy(biscuit_peer_trust_bundle)
         self._biscuit_svid_audience = biscuit_svid_audience.strip()
         self.receipt_private_key = private_key or load_private_key(keys_dir=keys_dir)
         self.receipt_public_key = self.receipt_private_key.public_key()
@@ -2119,7 +2240,10 @@ class GovernanceProxy:
         passport_claims: dict[str, Any],
         arguments: dict[str, Any],
     ) -> str | None:
-        for raw_value in (passport_claims.get("operator_id"), arguments.get("operator_id")):
+        for raw_value in (
+            passport_claims.get("operator_id"),
+            arguments.get("operator_id"),
+        ):
             if isinstance(raw_value, str):
                 normalized = raw_value.strip()
                 if normalized:
@@ -2141,7 +2265,9 @@ class GovernanceProxy:
         actor = str(session.passport_claims.get("sub", "unknown"))
         target = _policy_event_target(tool_name, arguments)
         action_class = _policy_action_class(tool_name)
-        resource_family = _policy_resource_family(tool_name, arguments, target, action_class)
+        resource_family = _policy_resource_family(
+            tool_name, arguments, target, action_class
+        )
         session.events.append(
             PolicyEvent(
                 timestamp=timestamp,
@@ -2194,7 +2320,9 @@ class GovernanceProxy:
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         target = _policy_event_target(tool_name, arguments)
         action_class = _policy_action_class(tool_name)
-        resource_family = _policy_resource_family(tool_name, arguments, target, action_class)
+        resource_family = _policy_resource_family(
+            tool_name, arguments, target, action_class
+        )
         return PolicyEvent(
             timestamp=timestamp,
             step_id=_receipt_step_id(session.jti, timestamp, tool_name, arguments),
@@ -2205,7 +2333,9 @@ class GovernanceProxy:
             action_class=action_class,
             target=target,
             resource_family=resource_family,
-            side_effect_class=_policy_side_effect_class(tool_name, action_class, resource_family),
+            side_effect_class=_policy_side_effect_class(
+                tool_name, action_class, resource_family
+            ),
             decision=decision,
             reason=reason,
             passport_jti=session.jti,
@@ -2236,12 +2366,14 @@ class GovernanceProxy:
         audit_reason: str,
     ) -> list[dict[str, Any]]:
         if not event.policy_decisions:
-            return [{
-                "backend": "native",
-                "decision": "Allow" if decision == Decision.PERMIT else "Deny",
-                "reason": audit_reason or None,
-                "rule_id": "ardur_builtin",
-            }]
+            return [
+                {
+                    "backend": "native",
+                    "decision": "Allow" if decision == Decision.PERMIT else "Deny",
+                    "reason": audit_reason or None,
+                    "rule_id": "ardur_builtin",
+                }
+            ]
         compact: list[dict[str, Any]] = []
         for item in event.policy_decisions:
             backend = str(item.get("backend", "unknown"))
@@ -2265,7 +2397,9 @@ class GovernanceProxy:
         policy_claims: dict[str, Any],
     ) -> dict[str, int]:
         remaining: dict[str, int] = {}
-        for key, raw_cap in dict(policy_claims.get("max_tool_calls_per_class", {}) or {}).items():
+        for key, raw_cap in dict(
+            policy_claims.get("max_tool_calls_per_class", {}) or {}
+        ).items():
             try:
                 cap = int(raw_cap)
             except (TypeError, ValueError):
@@ -2336,7 +2470,9 @@ class GovernanceProxy:
         # ``sys.modules`` cache lookup per call to this method.
         from .receipt import build_receipt, sign_receipt
 
-        signed_policy_decisions = self._signed_policy_decisions(event, decision, audit_reason)
+        signed_policy_decisions = self._signed_policy_decisions(
+            event, decision, audit_reason
+        )
         if event.budget_delta is None:
             event.budget_delta = self._receipt_budget_delta(
                 session,
@@ -2409,7 +2545,7 @@ class GovernanceProxy:
                     Decision.VIOLATION,
                     "revoked",
                     DenialReason.REVOKED,
-            )
+                )
             claims = mission.policy_claims()
             claims["mission_ref"] = copy.deepcopy(mission_ref_raw)
             claims["mission_digest"] = mission.payload_digest
@@ -2485,7 +2621,9 @@ class GovernanceProxy:
         session.memory_stores[store_id] = store
         return store
 
-    def _proxy_memory_write(self, session: GovernanceSession, arguments: dict[str, Any]) -> None:
+    def _proxy_memory_write(
+        self, session: GovernanceSession, arguments: dict[str, Any]
+    ) -> None:
         store_id = arguments.get("store_id")
         content = arguments.get("content")
         if not isinstance(store_id, str) or not store_id:
@@ -2511,7 +2649,9 @@ class GovernanceProxy:
         store = self._get_or_create_memory_store(session, arguments)
         session.last_memory_record_id = store.write(content, actor_key)
 
-    def _proxy_memory_read(self, session: GovernanceSession, arguments: dict[str, Any]) -> None:
+    def _proxy_memory_read(
+        self, session: GovernanceSession, arguments: dict[str, Any]
+    ) -> None:
         store_id = arguments.get("store_id")
         record_id = arguments.get("record_id")
         if not isinstance(store_id, str) or not store_id:
@@ -2585,7 +2725,9 @@ class GovernanceProxy:
         # -- Check 3: Visibility (MIC-State, MIC-Evidence) -------------------
         visibility = arguments.get("visibility")
         if not isinstance(visibility, str) or visibility.strip().lower() != "full":
-            label = visibility if isinstance(visibility, str) else type(visibility).__name__
+            label = (
+                visibility if isinstance(visibility, str) else type(visibility).__name__
+            )
             return (
                 Decision.INSUFFICIENT_EVIDENCE,
                 f"visibility_insufficient:{label}",
@@ -2764,6 +2906,7 @@ class GovernanceProxy:
         # JWT and the public key passes trivially. The KB-JWT proves the
         # presenter holds the PRIVATE key right now.
         from .passport import verify_pop
+
         # 2026-04-21 audit fix: `claims.get("cnf")` previously used a
         # truthy check, which treated `cnf={}`, `cnf=""`, `cnf=0`,
         # `cnf=False`, `cnf=[]` as bearer mode and silently skipped PoP.
@@ -2777,13 +2920,16 @@ class GovernanceProxy:
             if kb_jwt is not None:
                 import jwt as _jwt
                 from .passport import assert_iat_in_window
+
                 # Decode outside the nonce lock — decoding touches no shared
                 # state. Failure here is fail-closed: a malformed KB-JWT must
                 # not be accepted just because verify_pop already passed (the
                 # signature/freshness path validates a different code path).
                 try:
                     kb_claims = _jwt.decode(
-                        kb_jwt, holder_public_key, algorithms=["ES256"],
+                        kb_jwt,
+                        holder_public_key,
+                        algorithms=["ES256"],
                         options={"verify_aud": False, "verify_iat": False},
                     )
                 except _jwt.PyJWTError as exc:
@@ -2865,8 +3011,7 @@ class GovernanceProxy:
                 # sub so pre-H1 credentials in flight don't lose
                 # policy resolution.
                 mission_id_lookup = str(
-                    claims.get("mission_id")
-                    or claims.get("sub", "")
+                    claims.get("mission_id") or claims.get("sub", "")
                 )
                 stored_policies = self.policy_store.get_policies(
                     mission_id=mission_id_lookup,
@@ -2875,7 +3020,9 @@ class GovernanceProxy:
                 if stored_policies is not None:
                     claims["additional_policies"] = list(stored_policies)
 
-            session = GovernanceSession(passport_token=passport_token, passport_claims=claims)
+            session = GovernanceSession(
+                passport_token=passport_token, passport_claims=claims
+            )
             with self._sessions_lock:
                 # Double-check under lock (TOCTOU defense)
                 if jti in self.sessions:
@@ -3016,9 +3163,7 @@ class GovernanceProxy:
             if peer_trust_bundle is not None
             else issuer_public_key
         )
-        context = verify_biscuit_passport(
-            biscuit_token, verification_key, now=now
-        )
+        context = verify_biscuit_passport(biscuit_token, verification_key, now=now)
 
         # The verifier owns both the bundle and expected audience. The peer
         # supplies only its credential.
@@ -3038,9 +3183,7 @@ class GovernanceProxy:
                     f"peer JWT-SVID verification failed: {exc}"
                 ) from exc
 
-            verified_trust_domain = SpiffeId(
-                svid_claims.spiffe_id
-            ).trust_domain.name
+            verified_trust_domain = SpiffeId(svid_claims.spiffe_id).trust_domain.name
             if verified_trust_domain != peer_trust_bundle.trust_domain:
                 raise PermissionError(
                     f"SVID trust domain {verified_trust_domain!r} does not match "
@@ -3082,9 +3225,7 @@ class GovernanceProxy:
             "allowed_tools": list(context.allowed_tools),
             "forbidden_tools": list(context.forbidden_tools),
             "resource_scope": list(context.resource_scope),
-            "allowed_side_effect_classes": list(
-                context.allowed_side_effect_classes
-            ),
+            "allowed_side_effect_classes": list(context.allowed_side_effect_classes),
             "max_tool_calls": context.max_tool_calls,
             "max_duration_s": context.max_duration_s,
             "delegation_allowed": context.delegation_allowed,
@@ -3094,9 +3235,7 @@ class GovernanceProxy:
             "svid_bound": svid_bound,
         }
         if context.max_tool_calls_per_class:
-            claims["max_tool_calls_per_class"] = dict(
-                context.max_tool_calls_per_class
-            )
+            claims["max_tool_calls_per_class"] = dict(context.max_tool_calls_per_class)
         if context.cwd is not None:
             claims["cwd"] = context.cwd
         if context.parent_jti is not None:
@@ -3300,7 +3439,8 @@ class GovernanceProxy:
                 elif (
                     tool_name == MEMORY_STORE_READ_TOOL
                     and isinstance(arguments_snapshot.get("store_id"), str)
-                    and arguments_snapshot["store_id"] in target.memory_compromised_stores
+                    and arguments_snapshot["store_id"]
+                    in target.memory_compromised_stores
                 ):
                     self._record_tool_policy_event(
                         target,
@@ -3356,11 +3496,14 @@ class GovernanceProxy:
                             ap = policy_claims.get("approval_policy")
                             need_rate = (
                                 isinstance(ap, dict)
-                                and ap.get("max_approvals_per_hour_per_operator") is not None
+                                and ap.get("max_approvals_per_hour_per_operator")
+                                is not None
                             )
                             if need_rate:
                                 try:
-                                    max_ap = int(ap["max_approvals_per_hour_per_operator"])
+                                    max_ap = int(
+                                        ap["max_approvals_per_hour_per_operator"]
+                                    )
                                     window_s = float(ap.get("window_s", 3600.0))
                                     tracker = self._approval_tracker(max_ap, window_s)
                                 except (TypeError, ValueError):
@@ -3416,15 +3559,21 @@ class GovernanceProxy:
                                         event = target.events[-1]
                                         self._persist_session(target)
                                     else:
-                                        decision, reason, _event = target.check_and_record(
-                                            tool_name,
-                                            arguments_snapshot,
-                                            policy_claims=policy_claims,
-                                            verifier_id=self.verifier_id,
+                                        decision, reason, _event = (
+                                            target.check_and_record(
+                                                tool_name,
+                                                arguments_snapshot,
+                                                policy_claims=policy_claims,
+                                                verifier_id=self.verifier_id,
+                                            )
                                         )
                                         if decision == Decision.PERMIT:
-                                            decision, reason = self._apply_memory_post_permit(
-                                                target, tool_name, arguments_snapshot
+                                            decision, reason = (
+                                                self._apply_memory_post_permit(
+                                                    target,
+                                                    tool_name,
+                                                    arguments_snapshot,
+                                                )
                                             )
                                         if decision == Decision.PERMIT:
                                             tracker.record_approval(operator_id, ts)
@@ -3479,7 +3628,9 @@ class GovernanceProxy:
                 if target.summary is not None:
                     raise PermissionError("session already ended")
                 if not target.events:
-                    raise ValueError("cannot record tool result without a prior tool event")
+                    raise ValueError(
+                        "cannot record tool result without a prior tool event"
+                    )
                 target.events[-1].response = response
                 target.events[-1].duration_ms = duration_ms
                 self._persist_session(target)
@@ -3513,7 +3664,9 @@ class GovernanceProxy:
             with target._lock:
                 summary, created_summary = self._finalize_session_locked(target)
                 if target.attestation_token is None:
-                    lifecycle_claims = self._lifecycle_rollup_for_session_unlocked(target)
+                    lifecycle_claims = self._lifecycle_rollup_for_session_unlocked(
+                        target
+                    )
                     extra_claims: dict[str, Any] = {}
                     if int(lifecycle_claims["delegation_count"]) > 0:
                         extra_claims.update(lifecycle_claims)
@@ -3555,7 +3708,9 @@ class GovernanceProxy:
             with target._lock:
                 return self._lifecycle_rollup_for_session_unlocked(target)
 
-    def _finalize_session_locked(self, session: GovernanceSession) -> tuple[dict[str, Any], bool]:
+    def _finalize_session_locked(
+        self, session: GovernanceSession
+    ) -> tuple[dict[str, Any], bool]:
         if session.summary is not None:
             return dict(session.summary), False
         session.end_time = time.time()
@@ -3607,9 +3762,7 @@ class GovernanceProxy:
             for record in session.delegated_children
         ]
         child_jtis = [
-            str(child["child_jti"])
-            for child in children
-            if child.get("child_jti")
+            str(child["child_jti"]) for child in children if child.get("child_jti")
         ]
         closed_child_count = sum(
             1
@@ -3619,14 +3772,10 @@ class GovernanceProxy:
             and child["attestation_present"]
         )
         delegation_attempts = [
-            event
-            for event in session.events
-            if event.tool_name == "delegate_passport"
+            event for event in session.events if event.tool_name == "delegate_passport"
         ]
         delegation_denials = sum(
-            1
-            for event in delegation_attempts
-            if event.decision != Decision.PERMIT
+            1 for event in delegation_attempts if event.decision != Decision.PERMIT
         )
         return {
             "lifecycle_schema": LIFECYCLE_ATTESTATION_SCHEMA,
@@ -3685,7 +3834,9 @@ class GovernanceProxy:
                 "receipt_count": len(child_session.events),
                 "permits": int(child_summary.get("permits", 0)),
                 "denials": int(child_summary.get("denials", 0)),
-                "total_events": int(child_summary.get("total_events", len(child_session.events))),
+                "total_events": int(
+                    child_summary.get("total_events", len(child_session.events))
+                ),
                 "scope_compliance": child_summary.get("scope_compliance", "unknown"),
                 "no_out_of_scope_permits": self._session_no_out_of_scope_permits(
                     child_session
@@ -3763,7 +3914,9 @@ class GovernanceProxy:
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")
-        return hmac.new(self._session_receipt_integrity_key, material, "sha256").hexdigest()
+        return hmac.new(
+            self._session_receipt_integrity_key, material, "sha256"
+        ).hexdigest()
 
     def _add_session_receipt_integrity(
         self,
@@ -3811,7 +3964,9 @@ class GovernanceProxy:
         ):
             raise ValueError("session receipt-chain anchor is malformed")
         if not isinstance(integrity, dict):
-            raise ValueError("session receipt-chain anchor is missing its integrity tag")
+            raise ValueError(
+                "session receipt-chain anchor is missing its integrity tag"
+            )
         if integrity.get("version") != _SESSION_RECEIPT_INTEGRITY_VERSION:
             raise ValueError("session receipt-chain integrity version mismatch")
         mac = integrity.get("mac")
@@ -3877,7 +4032,9 @@ class GovernanceProxy:
 
     def _initialize_passport_state_files(self) -> None:
         with self._passport_state_lock():
-            can_bootstrap = self._passport_state_can_bootstrap_locked(ignore_lockfile=True)
+            can_bootstrap = self._passport_state_can_bootstrap_locked(
+                ignore_lockfile=True
+            )
             try:
                 self._replay_cache_sentinel = self._initialize_replay_cache_locked(
                     can_bootstrap=can_bootstrap
@@ -4075,9 +4232,13 @@ class GovernanceProxy:
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise PassportStateUnavailableError(error_code, f"{path.name} is invalid JSON") from exc
+            raise PassportStateUnavailableError(
+                error_code, f"{path.name} is invalid JSON"
+            ) from exc
         if not isinstance(payload, dict):
-            raise PassportStateUnavailableError(error_code, f"{path.name} must contain a JSON object")
+            raise PassportStateUnavailableError(
+                error_code, f"{path.name} must contain a JSON object"
+            )
         return payload
 
     def _parse_replay_cache_payload(
@@ -4263,7 +4424,8 @@ class GovernanceProxy:
                     "lineage_hashes.json contains malformed parent_jti metadata",
                 )
             if parent_hash is not None and (
-                not isinstance(parent_hash, str) or not _SHA256_HEX_RE.match(parent_hash)
+                not isinstance(parent_hash, str)
+                or not _SHA256_HEX_RE.match(parent_hash)
             ):
                 raise PassportStateUnavailableError(
                     "lineage_hashes_unavailable",
@@ -4284,7 +4446,10 @@ class GovernanceProxy:
         if session.summary is not None or session.end_time is not None:
             return "session already ended"
         with self._passport_state_lock():
-            if self._first_revoked_jti_in_lineage_locked(session.passport_claims) is not None:
+            if (
+                self._first_revoked_jti_in_lineage_locked(session.passport_claims)
+                is not None
+            ):
                 return "passport_revoked"
         return None
 
@@ -4362,18 +4527,24 @@ class GovernanceProxy:
                 return lineage
             current_jti = parent_jti
 
-    def _first_revoked_jti_in_lineage_locked(self, claims: dict[str, Any]) -> str | None:
+    def _first_revoked_jti_in_lineage_locked(
+        self, claims: dict[str, Any]
+    ) -> str | None:
         revoked = self._load_revoked_locked()
         for lineage_jti in self._passport_lineage_jtis(claims):
             if lineage_jti in revoked:
                 return lineage_jti
         return None
 
-    def _assert_passport_lineage_not_revoked_locked(self, claims: dict[str, Any]) -> None:
+    def _assert_passport_lineage_not_revoked_locked(
+        self, claims: dict[str, Any]
+    ) -> None:
         if self._first_revoked_jti_in_lineage_locked(claims) is not None:
             raise PermissionError("passport_revoked")
 
-    def _copy_session_state(self, target: GovernanceSession, source: GovernanceSession) -> None:
+    def _copy_session_state(
+        self, target: GovernanceSession, source: GovernanceSession
+    ) -> None:
         # B.9: in-process memory store state is not fully rehydrated from disk
         # (dict-backed prototype). Refreshing from JSON must not wipe live
         # GovernedMemoryStore instances or compromise flags mid-session.
@@ -4391,7 +4562,11 @@ class GovernanceProxy:
         target.end_time = source.end_time
         target.summary = source.summary
         target.attestation_token = source.attestation_token
-        target.memory_stores = preserved_stores if preserved_stores else getattr(source, "memory_stores", {})
+        target.memory_stores = (
+            preserved_stores
+            if preserved_stores
+            else getattr(source, "memory_stores", {})
+        )
         target.memory_compromised_stores = preserved_compromised | set(
             getattr(source, "memory_compromised_stores", ())
         )
@@ -4399,7 +4574,9 @@ class GovernanceProxy:
         target.last_receipt_full_hash = getattr(source, "last_receipt_full_hash", None)
         target.run_nonce = getattr(source, "run_nonce", target.run_nonce)
         target.last_memory_record_id = (
-            preserved_last if preserved_last is not None else getattr(source, "last_memory_record_id", None)
+            preserved_last
+            if preserved_last is not None
+            else getattr(source, "last_memory_record_id", None)
         )
 
     def _install_or_refresh_session(
@@ -4422,11 +4599,15 @@ class GovernanceProxy:
 
     @contextlib.contextmanager
     def _locked_persisted_session(self, session: GovernanceSession | str):
-        session_id = session.jti if isinstance(session, GovernanceSession) else str(session)
+        session_id = (
+            session.jti if isinstance(session, GovernanceSession) else str(session)
+        )
         preferred = session if isinstance(session, GovernanceSession) else None
         with self._session_coordination_lock(session_id):
             fresh = self._load_session_from_disk(session_id)
-            yield self._install_or_refresh_session(session_id, fresh, preferred=preferred)
+            yield self._install_or_refresh_session(
+                session_id, fresh, preferred=preferred
+            )
 
     def _delegation_parent_token_and_claims(
         self,
@@ -4454,7 +4635,10 @@ class GovernanceProxy:
                     f"and AAT validation ({aat_err})"
                 ) from aat_err
             session = self.get_session(str(aat_claims["jti"]))
-            if session.passport_claims.get("credential_format") != AAT_CREDENTIAL_FORMAT:
+            if (
+                session.passport_claims.get("credential_format")
+                != AAT_CREDENTIAL_FORMAT
+            ):
                 raise PermissionError(
                     "AAT delegation parent session is not active"
                 ) from passport_err
@@ -4472,8 +4656,8 @@ class GovernanceProxy:
         child_resource_scope: list[str] | None = None,
         delegation_request_id: str | None = None,
     ) -> tuple[str, dict[str, Any], int]:
-        derivation_parent_token, parent_claims = self._delegation_parent_token_and_claims(
-            parent_token
+        derivation_parent_token, parent_claims = (
+            self._delegation_parent_token_and_claims(parent_token)
         )
         parent_jti = str(parent_claims["jti"])
         request_id = delegation_request_id or uuid.uuid4().hex
@@ -4520,7 +4704,10 @@ class GovernanceProxy:
                     for child in parent_session.delegated_children:
                         if child.get("delegation_request_id") != request_id:
                             continue
-                        if child.get("delegation_request_fingerprint") != request_fingerprint:
+                        if (
+                            child.get("delegation_request_fingerprint")
+                            != request_fingerprint
+                        ):
                             raise LineageBudgetConflictError(
                                 "delegation_request_id already used for a different reservation"
                             )
@@ -4548,7 +4735,9 @@ class GovernanceProxy:
                             raise LineageBudgetConflictError(
                                 "delegation_request_id already used for a different reservation"
                             )
-                        replay_remaining = child.get("parent_calls_remaining_at_delegation")
+                        replay_remaining = child.get(
+                            "parent_calls_remaining_at_delegation"
+                        )
                         if replay_remaining is None:
                             replay_remaining = max(
                                 0,
@@ -4607,14 +4796,13 @@ class GovernanceProxy:
                     child_jti=str(child_claims.get("jti")),
                     floor_reserved_total=parent_session.delegated_budget_reserved,
                 )
-                if (
-                    not reservation.accepted
-                    or (
-                        not reservation.idempotent
-                        and child_budget > reservation.remaining_before
-                    )
+                if not reservation.accepted or (
+                    not reservation.idempotent
+                    and child_budget > reservation.remaining_before
                 ):
-                    raise PermissionError("child delegation would over-reserve parent budget")
+                    raise PermissionError(
+                        "child delegation would over-reserve parent budget"
+                    )
                 parent_session.delegated_budget_reserved = reservation.reserved_total
                 child_record = {
                     "delegation_request_id": request_id,
@@ -4626,12 +4814,16 @@ class GovernanceProxy:
                     "child_agent_id": child_agent_id,
                     "child_mission": child_mission,
                     "child_allowed_tools": list(child_claims.get("allowed_tools", [])),
-                    "child_resource_scope": list(child_claims.get("resource_scope", [])),
+                    "child_resource_scope": list(
+                        child_claims.get("resource_scope", [])
+                    ),
                     "child_tool_scope_mode": child_claims.get(
                         "tool_scope_mode",
                         "allowlist",
                     ),
-                    "child_forbidden_tools": list(child_claims.get("forbidden_tools", [])),
+                    "child_forbidden_tools": list(
+                        child_claims.get("forbidden_tools", [])
+                    ),
                     "child_max_tool_calls": child_budget,
                     "delegated_budget_reserved": reservation.amount,
                     "parent_calls_remaining_at_delegation": reservation.remaining_before,
@@ -4775,7 +4967,10 @@ class GovernanceProxy:
                 "replay_cache.json requires operator re-initialization",
             )
         ordered_entries = dict(
-            sorted(entries.items(), key=lambda item: (item[1]["exp"], item[1]["first_seen"]))
+            sorted(
+                entries.items(),
+                key=lambda item: (item[1]["exp"], item[1]["first_seen"]),
+            )
         )
         self._persist_json_file(
             self.replay_cache_path,
@@ -4919,7 +5114,9 @@ class GovernanceProxy:
             )
         return normalized_parent_jti, parent_hash.lower()
 
-    def _load_lineage_index_locked(self) -> tuple[dict[str, str], dict[str, LineageEdge]]:
+    def _load_lineage_index_locked(
+        self,
+    ) -> tuple[dict[str, str], dict[str, LineageEdge]]:
         if self._lineage_hashes_sentinel is None:
             self._lineage_hashes_sentinel = self._try_initialize_lineage_hashes_locked()
             if self._lineage_hashes_sentinel is None:
@@ -5072,14 +5269,22 @@ def _public_key_to_jwk(public_key: ec.EllipticCurvePublicKey) -> dict[str, str]:
 
 def _generate_api_token() -> str:
     """Generate a 32-byte random token, base64-encoded (urlsafe, no padding)."""
-    return base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
+    return (
+        base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
+    )
 
 
 def _api_token_compare_material(token: bytes) -> bytes:
     """Return fixed-length bearer-token material for constant-time compare."""
     if len(token) > _API_TOKEN_COMPARE_MAX_BYTES:
         raise ValueError("bearer token too long")
-    return len(token).to_bytes(4, "big") + token.ljust(_API_TOKEN_COMPARE_MAX_BYTES, b"\0")
+    return len(token).to_bytes(4, "big") + token.ljust(
+        _API_TOKEN_COMPARE_MAX_BYTES, b"\0"
+    )
+
+
+class TLSConfigurationError(RuntimeError):
+    """TLS was required but no usable server context could be constructed."""
 
 
 def serve_proxy(
@@ -5138,6 +5343,26 @@ def serve_proxy(
     # flagged as MED-NEW-1.
     api_token_compare_material = _api_token_compare_material(api_token.encode("ascii"))
 
+    tls_context = None
+    cert_fingerprint = None
+    if not no_tls:
+        try:
+            tls_result = resolve_tls_paths(tls_cert, tls_key, hostname=host)
+            if tls_result is None:
+                raise TLSConfigurationError(
+                    "TLS configuration is unavailable; use --no-tls only when "
+                    "plain HTTP is explicitly intended"
+                )
+            cert_path, key_path, cert_fingerprint = tls_result
+            tls_context = create_ssl_context(cert_path, key_path)
+        except TLSConfigurationError:
+            raise
+        except (OSError, ValueError) as exc:
+            raise TLSConfigurationError(
+                "TLS configuration is unavailable; verify the certificate and key"
+            ) from exc
+    tls_active = tls_context is not None
+
     active_session_ref = {"id": initial_session_id}
     active_session_lock = threading.Lock()
 
@@ -5160,11 +5385,15 @@ def serve_proxy(
 
             # Snapshot under proxy._sessions_lock — same reason as active_session_count
             with proxy._sessions_lock:
-                active_session_ids = [sid for sid, s in proxy.sessions.items() if s.summary is None]
+                active_session_ids = [
+                    sid for sid, s in proxy.sessions.items() if s.summary is None
+                ]
             if not active_session_ids:
                 raise ValueError("no active session; call POST /session/start first")
             if len(active_session_ids) > 1:
-                raise ValueError("multiple active sessions; specify session_id explicitly")
+                raise ValueError(
+                    "multiple active sessions; specify session_id explicitly"
+                )
 
             active_session_ref["id"] = active_session_ids[0]
             return active_session_ids[0]
@@ -5198,7 +5427,9 @@ def serve_proxy(
                 raise ValueError("unsupported Transfer-Encoding")
             length = int(self.headers.get("Content-Length", "0"))
             if length > MAX_REQUEST_BODY:
-                raise ValueError(f"request body too large ({length} bytes, max {MAX_REQUEST_BODY})")
+                raise ValueError(
+                    f"request body too large ({length} bytes, max {MAX_REQUEST_BODY})"
+                )
             if length < 0:
                 raise ValueError("invalid Content-Length")
             raw = self.rfile.read(length) if length else b"{}"
@@ -5292,7 +5523,9 @@ def serve_proxy(
                 return True
             header = self.headers.get("Authorization", "")
             if not header or not header.lower().startswith("bearer "):
-                self._send_json(401, {"error": "missing or malformed Authorization header"})
+                self._send_json(
+                    401, {"error": "missing or malformed Authorization header"}
+                )
                 return False
             # FIX-R9-5 (round-9, 2026-04-29): symmetric ASCII handling.
             # Round-8 audit (LOW-NEW-4) flagged asymmetric error
@@ -5315,7 +5548,7 @@ def serve_proxy(
             except ValueError:
                 self._send_json(401, {"error": "invalid bearer token"})
                 return False
-            if not hmac.compare_digest(provided_compare_material, api_token_compare_material):
+            if not hmac.compare_digest(provided_compare_material, api_token_compare_material):  # fmt: skip
                 self._send_json(401, {"error": "invalid bearer token"})
                 return False
             return True
@@ -5407,12 +5640,12 @@ def serve_proxy(
                     if not isinstance(mission_payload, dict):
                         raise ValueError("mission must be a JSON object")
                     mission = MissionPassport.from_dict(mission_payload)
-                    token = issue_passport(mission, private_key, ttl_s=payload.get("ttl_s"))
+                    token = issue_passport(
+                        mission, private_key, ttl_s=payload.get("ttl_s")
+                    )
                     claims = verify_passport(token, proxy.public_key)
                     response: dict[str, Any] = {"token": token, "claims": claims}
-                    if mission.resource_scope == [
-                        UNRESTRICTED_RESOURCE_SCOPE_PATTERN
-                    ]:
+                    if mission.resource_scope == [UNRESTRICTED_RESOURCE_SCOPE_PATTERN]:
                         response["warnings"] = [
                             "resource_scope explicitly permits all resources via "
                             "the sole '**' pattern"
@@ -5421,7 +5654,9 @@ def serve_proxy(
                     return
 
                 if path == "/verify":
-                    claims = proxy.verify_passport_token(str(self._require_field(payload, "token")))
+                    claims = proxy.verify_passport_token(
+                        str(self._require_field(payload, "token"))
+                    )
                     self._send_json(200, {"claims": claims})
                     return
 
@@ -5430,8 +5665,12 @@ def serve_proxy(
                     token_type = str(payload.get("token_type", "passport")).lower()
                     if token_type == "aat":
                         parent_aat_token = payload.get("parent_token")
-                        if parent_aat_token is not None and not isinstance(parent_aat_token, str):
-                            raise ValueError("parent_token must be a string when token_type=aat")
+                        if parent_aat_token is not None and not isinstance(
+                            parent_aat_token, str
+                        ):
+                            raise ValueError(
+                                "parent_token must be a string when token_type=aat"
+                            )
                         # PoP plumbing — defaults secure (require_pop=True). The
                         # adapter only enforces PoP for AATs that actually carry
                         # a `cnf` claim, so bearer-mode AATs continue to work
@@ -5450,7 +5689,9 @@ def serve_proxy(
                                 "holder_public_key_pem must be a PEM-encoded string"
                             )
                         kb_jwt_field = payload.get("kb_jwt")
-                        if kb_jwt_field is not None and not isinstance(kb_jwt_field, str):
+                        if kb_jwt_field is not None and not isinstance(
+                            kb_jwt_field, str
+                        ):
                             raise ValueError("kb_jwt must be a string when provided")
                         # Round 3 (2026-04-28) DoS guard: a well-formed
                         # KB-JWT is small (<2KB). Bound the field length
@@ -5472,10 +5713,9 @@ def serve_proxy(
                             from cryptography.hazmat.primitives.serialization import (
                                 load_pem_public_key,
                             )
+
                             try:
-                                loaded = load_pem_public_key(
-                                    holder_pem.encode("utf-8")
-                                )
+                                loaded = load_pem_public_key(holder_pem.encode("utf-8"))
                             except Exception as exc:  # noqa: BLE001
                                 raise ValueError(
                                     f"invalid holder_public_key_pem: {exc}"
@@ -5533,7 +5773,9 @@ def serve_proxy(
                             {
                                 "session_id": session.jti,
                                 "agent_id": session.passport_claims["sub"],
-                                "allowed_tools": list(session.passport_claims.get("allowed_tools", [])),
+                                "allowed_tools": list(
+                                    session.passport_claims.get("allowed_tools", [])
+                                ),
                                 "credential_format": session.passport_claims.get(
                                     "credential_format",
                                     "passport",
@@ -5541,7 +5783,10 @@ def serve_proxy(
                             },
                         )
                         return
-                    self._send_json(200, {"session_id": session.jti, "claims": session.passport_claims})
+                    self._send_json(
+                        200,
+                        {"session_id": session.jti, "claims": session.passport_claims},
+                    )
                     return
 
                 if path == "/evaluate":
@@ -5575,7 +5820,10 @@ def serve_proxy(
 
                 if path == "/result":
                     proxy.record_tool_result(
-                        str(payload.get("session_id") or self._require_field(payload, "session")),
+                        str(
+                            payload.get("session_id")
+                            or self._require_field(payload, "session")
+                        ),
                         str(payload.get("response", "")),
                         float(payload.get("duration_ms", 0.0)),
                     )
@@ -5583,21 +5831,31 @@ def serve_proxy(
                     return
 
                 if path in {"/session/end", "/end"}:
-                    session_id = str(payload.get("session_id") or self._require_field(payload, "session"))
+                    session_id = str(
+                        payload.get("session_id")
+                        or self._require_field(payload, "session")
+                    )
                     summary = proxy.end_session(session_id)
                     with active_session_lock:
                         if active_session_ref["id"] == session_id:
                             active_session_ref["id"] = None
                     if path == "/session/end":
-                        token, _ = proxy.issue_attestation_for_session(session_id, private_key)
-                        self._send_json(200, {"attestation_token": token, "summary": summary})
+                        token, _ = proxy.issue_attestation_for_session(
+                            session_id, private_key
+                        )
+                        self._send_json(
+                            200, {"attestation_token": token, "summary": summary}
+                        )
                         return
                     self._send_json(200, {"summary": summary})
                     return
 
                 if path == "/attest":
                     token, claims = proxy.issue_attestation_for_session(
-                        str(payload.get("session_id") or self._require_field(payload, "session")),
+                        str(
+                            payload.get("session_id")
+                            or self._require_field(payload, "session")
+                        ),
                         private_key,
                     )
                     self._send_json(200, {"token": token, "claims": claims})
@@ -5605,7 +5863,9 @@ def serve_proxy(
 
                 if path == "/delegate":
                     parent_token = self._require_string_field(payload, "parent_token")
-                    child_agent_id = self._require_string_field(payload, "child_agent_id")
+                    child_agent_id = self._require_string_field(
+                        payload, "child_agent_id"
+                    )
                     child_mission = self._require_string_field(payload, "child_mission")
                     child_tools = self._string_list_field(
                         self._require_field(payload, "child_allowed_tools"),
@@ -5637,36 +5897,48 @@ def serve_proxy(
                     )
 
                     try:
-                        child_token, child_claims, parent_calls_remaining = proxy.delegate_passport(
-                            parent_token=parent_token,
-                            private_key=private_key,
-                            child_agent_id=child_agent_id,
-                            child_allowed_tools=child_tools,
-                            child_mission=child_mission,
-                            child_ttl_s=child_ttl_int,
-                            child_max_tool_calls=child_max_calls_int,
-                            child_resource_scope=child_scope_list,
-                            delegation_request_id=delegation_request_id,
+                        child_token, child_claims, parent_calls_remaining = (
+                            proxy.delegate_passport(
+                                parent_token=parent_token,
+                                private_key=private_key,
+                                child_agent_id=child_agent_id,
+                                child_allowed_tools=child_tools,
+                                child_mission=child_mission,
+                                child_ttl_s=child_ttl_int,
+                                child_max_tool_calls=child_max_calls_int,
+                                child_resource_scope=child_scope_list,
+                                delegation_request_id=delegation_request_id,
+                            )
                         )
                     except LineageBudgetConflictError as exc:
                         self._send_json(409, {"error": str(exc)})
                     except ValueError:
-                        parent_jti = str(verify_passport(parent_token, proxy.public_key)["jti"])
-                        self._send_json(403, {"error": (
-                            f"delegation requires parent session to exist; "
-                            f"start the parent passport via /session/start before delegating "
-                            f"(parent_jti={parent_jti})"
-                        )})
+                        parent_jti = str(
+                            verify_passport(parent_token, proxy.public_key)["jti"]
+                        )
+                        self._send_json(
+                            403,
+                            {
+                                "error": (
+                                    f"delegation requires parent session to exist; "
+                                    f"start the parent passport via /session/start before delegating "
+                                    f"(parent_jti={parent_jti})"
+                                )
+                            },
+                        )
                     except PermissionError as exc:
                         self._send_json(403, {"error": str(exc)})
                     else:
-                        self._send_json(200, {
-                            "child_token": child_token,
-                            "child_claims": child_claims,
-                            "parent_jti": child_claims.get("parent_jti"),
-                            "parent_calls_remaining_at_delegation": parent_calls_remaining,
-                            "delegation_request_id": delegation_request_id,
-                        })
+                        self._send_json(
+                            200,
+                            {
+                                "child_token": child_token,
+                                "child_claims": child_claims,
+                                "parent_jti": child_claims.get("parent_jti"),
+                                "parent_calls_remaining_at_delegation": parent_calls_remaining,
+                                "delegation_request_id": delegation_request_id,
+                            },
+                        )
                     return
 
                 self._send_json(404, {"error": "not found"})
@@ -5702,15 +5974,9 @@ def serve_proxy(
 
     httpd = ThreadingHTTPServer((host, port), Handler)
 
-    tls_active = False
-    if not no_tls:
-        tls_result = resolve_tls_paths(tls_cert, tls_key, hostname=host)
-        if tls_result:
-            cert_path, key_path, cert_fingerprint = tls_result
-            ssl_ctx = create_ssl_context(cert_path, key_path)
-            httpd.socket = ssl_ctx.wrap_socket(httpd.socket, server_side=True)
-            tls_active = True
-            print(f"[tls] cert fingerprint: {cert_fingerprint}", file=sys.stderr)
+    if tls_context is not None:
+        httpd.socket = tls_context.wrap_socket(httpd.socket, server_side=True)
+        print(f"[tls] cert fingerprint: {cert_fingerprint}", file=sys.stderr)
     if no_tls:
         print("[tls] WARNING: TLS disabled — plain HTTP only", file=sys.stderr)
 
@@ -5729,10 +5995,14 @@ def serve_proxy(
     if require_auth:
         print("")
         print("=" * 72)
-        print(f"Bearer auth REQUIRED on all endpoints except: {', '.join(sorted(PUBLIC_PATHS))}")
+        print(
+            f"Bearer auth REQUIRED on all endpoints except: {', '.join(sorted(PUBLIC_PATHS))}"
+        )
         print(f"API token ({token_source}): [redacted]")
         if token_source == "generated":
-            print("Generated tokens are no longer printed; set VIBAP_API_TOKEN or pass --api-token for clients.")
+            print(
+                "Generated tokens are no longer printed; set VIBAP_API_TOKEN or pass --api-token for clients."
+            )
         print("Send the actual configured token as:  Authorization: Bearer ***")
         print("Export for hooks/clients:        export VIBAP_API_TOKEN='<token>'")
         print("=" * 72)
@@ -5749,7 +6019,8 @@ def serve_proxy(
             "!! WARNING: VIBAP proxy is running WITHOUT authentication.            !!\n"
             "!! All endpoints are exposed to anyone who can reach this port.       !!\n"
             "!! DO NOT use --no-require-auth in production or on untrusted networks.!!\n"
-            + "!" * 72 + "\n"
+            + "!" * 72
+            + "\n"
         )
         print(warning)
         print(warning, file=sys.stderr)
@@ -5775,7 +6046,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--revoke", metavar="JTI")
     parser.add_argument("--tls-cert", help="TLS certificate PEM file")
     parser.add_argument("--tls-key", help="TLS private key PEM file")
-    parser.add_argument("--no-tls", action="store_true", help="disable TLS (plain HTTP only)")
+    parser.add_argument(
+        "--no-tls", action="store_true", help="disable TLS (plain HTTP only)"
+    )
     args = parser.parse_args(argv)
 
     private_key, public_key = generate_keypair(keys_dir=args.keys_dir)
@@ -5791,18 +6064,22 @@ def main(argv: list[str] | None = None) -> int:
         print(f"revoked passport jti {args.revoke} in {proxy.revoked_path}")
         return 0
 
-    serve_proxy(
-        proxy=proxy,
-        private_key=private_key,
-        host=args.host,
-        port=args.port,
-        initial_session_id=args.initial_session,
-        require_auth=not args.no_require_auth,
-        api_token=args.api_token,
-        tls_cert=args.tls_cert,
-        tls_key=args.tls_key,
-        no_tls=args.no_tls,
-    )
+    try:
+        serve_proxy(
+            proxy=proxy,
+            private_key=private_key,
+            host=args.host,
+            port=args.port,
+            initial_session_id=args.initial_session,
+            require_auth=not args.no_require_auth,
+            api_token=args.api_token,
+            tls_cert=args.tls_cert,
+            tls_key=args.tls_key,
+            no_tls=args.no_tls,
+        )
+    except TLSConfigurationError as exc:
+        print(f"[tls] ERROR: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/python/vibap/tls.py
+++ b/python/vibap/tls.py
@@ -14,9 +14,21 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
 
+NO_TLS_ENV_VAR = "ARDUR_NO_TLS"
+
+
+def tls_disabled_by_environment() -> bool:
+    """Return whether the legacy transport hint requests a plaintext healthcheck."""
+
+    return os.environ.get(NO_TLS_ENV_VAR, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
 
 def _default_tls_dir(home: Path | None = None) -> Path:
-    from .passport import DEFAULT_HOME, _is_under_default_home
+    from .passport import DEFAULT_HOME
 
     return (home or DEFAULT_HOME) / "tls"
 
@@ -60,11 +72,17 @@ def generate_self_signed_cert(
         .issuer_name(subject)
         .public_key(private_key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1))
-        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365))
+        .not_valid_before(
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        )
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
+        )
         .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
         .add_extension(
-            x509.SubjectAlternativeName([x509.IPAddress(ipaddress.IPv4Address(hostname))]),
+            x509.SubjectAlternativeName(
+                [x509.IPAddress(ipaddress.IPv4Address(hostname))]
+            ),
             critical=False,
         )
         .sign(private_key, hashes.SHA256())
@@ -101,23 +119,25 @@ def resolve_tls_paths(
     hostname: str = "127.0.0.1",
 ) -> tuple[Path, Path, str] | None:
     """Resolve TLS cert/key or auto-generate. Returns (cert_path, key_path, fingerprint) or None if TLS disabled."""
-    no_tls = os.environ.get("ARDUR_NO_TLS", "").strip().lower() in ("1", "true", "yes")
+    no_tls = tls_disabled_by_environment()
 
     if tls_cert and tls_key:
         cert_path = Path(tls_cert)
         key_path = Path(tls_key)
         if not cert_path.exists():
-            print(f"TLS cert not found: {cert_path}", file=sys.stderr)
+            print("TLS certificate is unavailable", file=sys.stderr)
             return None
         if not key_path.exists():
-            print(f"TLS key not found: {key_path}", file=sys.stderr)
+            print("TLS private key is unavailable", file=sys.stderr)
             return None
         fingerprint = _cert_fingerprint(cert_path)
         return cert_path, key_path, fingerprint
 
     if not tls_cert and not tls_key and not no_tls:
         tls_dir = _default_tls_dir(home)
-        key_path, cert_path, fingerprint = generate_self_signed_cert(tls_dir, hostname=hostname)
+        key_path, cert_path, fingerprint = generate_self_signed_cert(
+            tls_dir, hostname=hostname
+        )
         print(f"[tls] auto-generated self-signed cert for {hostname}", file=sys.stderr)
         print(f"[tls] fingerprint: {fingerprint}", file=sys.stderr)
         return cert_path, key_path, fingerprint

--- a/site/content/source/docs/reference/proxy-oci-image.md
+++ b/site/content/source/docs/reference/proxy-oci-image.md
@@ -2,7 +2,7 @@
 title: "Ardur Proxy OCI Image Contract"
 description: "The first supported OCI surface is the governance proxy:"
 source_path: "docs/reference/proxy-oci-image.md"
-source_sha256: "9d046acc8ac2809d9b2a20a067f9d3a228c86a1ef8c06923a3bfe8c17f6c42ac"
+source_sha256: "80cc27f0622b712c0b1c68f462d0fdfd38327dcaf4cfc96dbce4157701962ae7"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -60,9 +60,12 @@ should use encrypted storage with access controls appropriate for signing-key
 material. Do not put API tokens, private keys, or development certificates in
 the image, build arguments, labels, or Kubernetes manifests.
 
-`ARDUR_NO_TLS=1` is supported only when a trusted local reverse proxy, sidecar,
-or service mesh terminates TLS before traffic reaches the container. Bearer
-tokens must not cross an unencrypted or untrusted network.
+Plain HTTP is supported only when a trusted local reverse proxy, sidecar, or
+service mesh terminates TLS before traffic reaches the container. Append the
+explicit `--no-tls` argument to the image command and set `ARDUR_NO_TLS=1` so
+the container healthcheck probes HTTP. The environment variable selects only
+the healthcheck scheme; by itself it cannot disable proxy TLS. Bearer tokens
+must not cross an unencrypted or untrusted network.
 
 An equivalent hardened Docker invocation is:
 


### PR DESCRIPTION
## Summary

- require usable TLS material and an SSL context before the governance proxy binds its listener
- make explicit `--no-tls` the only authority for plain HTTP; `ARDUR_NO_TLS` alone is only a container healthcheck scheme hint
- return bounded CLI/module errors without traceback or operator-path leakage
- add organic subprocess/socket/TLS regressions and update the OCI source/generated documentation pair

## Security contract

On `dev`, `resolve_tls_paths()` could return no material while `serve_proxy()` continued with an unwrapped `ThreadingHTTPServer`, exposing bearer and governance traffic over plaintext. The patch constructs the TLS context before server binding and raises a typed configuration error when TLS is expected but unavailable. Generated HTTPS, explicit certificate HTTPS, bearer/public endpoint behavior, and explicit `--no-tls` HTTP remain supported.

The equivalent Personal Hub sink is intentionally outside this focused change and is tracked by #319.

## Validation

- organic TLS startup matrix: 9 passed
- proxy/TLS/HTTP/CLI/comprehensive matrix: 234 passed
- Personal Hub/OCI/package matrix: 157 passed
- complete Python suite: 1819 passed, 34 skipped, 6 known warnings
- Ruff lint and format: clean; all configured pre-commit hooks passed without bypass
- repository quick checks, 115 source pages, 113 mirrored artifacts, 10 public claims: green
- Hugo 0.161.1: 285 pages, 116 static files
- fresh Ardur 0.2.0 wheel and sdist: distribution validation passed
- commit `21d091955cd8f3bcbf4ec38b0ca0286a49331f19`: good ED25519 signature and DCO sign-off

## Review note

The repository-mandated Ruff formatter rewrote the already-touched legacy `cli.py` and `proxy.py` modules. Runtime, full-suite, hook, site, and package gates above were rerun after formatting on the exact committed representation.

Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Proxy startup now fails safely when TLS certificates are missing, invalid, or mismatched (no listener bind, clear TLS error signaling).
  * HTTPS remains enabled by default using automatic self-signed certs or user-supplied valid cert/key pairs.
  * Authentication and request validation return clearer structured errors, including stricter bearer-token handling.

* **Configuration**
  * Plain HTTP requires the explicit `--no-tls` option and a trusted TLS-terminating proxy/sidecar; `ARDUR_NO_TLS` only affects healthcheck scheme.
  * Environment-only TLS disabling is rejected during startup.

* **Documentation**
  * Updated guidance for `--no-tls`/`ARDUR_NO_TLS`, TLS termination expectations, and bearer-token security.

* **Tests**
  * Added integration coverage for TLS startup success/failure and CLI rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->