### PR TITLE
test(cli): exercise API token trimming through startup

### DIFF
--- a/python/tests/test_cli_api_token_loading.py
+++ b/python/tests/test_cli_api_token_loading.py
@@ -1,0 +1,132 @@
+"""Organic CLI argument-loading coverage for proxy bearer-token normalization.
+
+The lower-level HTTP characterization passes ``api_token`` directly to
+``serve_proxy``. This module deliberately crosses the real module entrypoint,
+argument parser, command dispatch, startup, and HTTP authentication boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+_PYTHON_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _wait_for_health(process: subprocess.Popen[str], base_url: str) -> None:
+    deadline = time.monotonic() + 8
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(
+                f"ardur start exited before health check: rc={process.returncode}"
+            )
+        try:
+            with urllib.request.urlopen(base_url + "/health", timeout=0.5) as response:
+                if response.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.05)
+    raise AssertionError(f"ardur start did not become healthy: {last_error}")
+
+
+def _post_issue_with_bearer(
+    base_url: str,
+    token: str | None,
+) -> tuple[int, dict[str, object]]:
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        base_url + "/issue",
+        data=b"{}",
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            return int(response.status), json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), json.loads(exc.read().decode("utf-8"))
+
+
+def _stop_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+    return process.communicate(timeout=5)
+
+
+def test_start_cli_trims_padded_api_token_through_real_argument_loading(
+    tmp_path: Path,
+    unused_tcp_port: int,
+) -> None:
+    canonical_token = "cli-test-token-32-bytes-DEFGHIJ"
+    environment = dict(os.environ)
+    environment.pop("VIBAP_API_TOKEN", None)
+    environment["PYTHONPATH"] = str(_PYTHON_ROOT)
+    base_url = f"http://127.0.0.1:{unused_tcp_port}"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "vibap.cli",
+            "start",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(unused_tcp_port),
+            "--keys-dir",
+            str(tmp_path / "keys"),
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--log-path",
+            str(tmp_path / "audit.log"),
+            "--api-token",
+            f"   {canonical_token}   ",
+            "--no-tls",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _wait_for_health(process, base_url)
+
+        missing_status, missing_body = _post_issue_with_bearer(base_url, None)
+        wrong_status, wrong_body = _post_issue_with_bearer(
+            base_url,
+            "synthetic-wrong-token",
+        )
+        canonical_status, canonical_body = _post_issue_with_bearer(
+            base_url,
+            canonical_token,
+        )
+
+        assert missing_status == 401
+        assert missing_body["error"] == "missing or malformed Authorization header"
+        assert wrong_status == 401
+        assert wrong_body["error"] == "invalid bearer token"
+        assert canonical_status != 401, canonical_body
+    finally:
+        stdout, stderr = _stop_process(process)
+
+    assert process.returncode is not None
+    assert "source=argument" in stderr
+    assert "token=redacted" in stderr
+    assert canonical_token not in stdout
+    assert canonical_token not in stderr

--- a/python/tests/test_cli_api_token_loading.py
+++ b/python/tests/test_cli_api_token_loading.py
@@ -59,13 +59,15 @@ def _post_issue_with_bearer(
 
 
 def _stop_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    # Drain the pipes as part of the wait. ``process.wait()`` on a PIPE-backed
+    # child deadlocks once the child has filled a pipe buffer, which would turn
+    # a chatty CLI into a spurious timeout/kill.
     if process.poll() is None:
         process.terminate()
         try:
-            process.wait(timeout=5)
+            return process.communicate(timeout=5)
         except subprocess.TimeoutExpired:
             process.kill()
-            process.wait(timeout=5)
     return process.communicate(timeout=5)
 
 
@@ -121,7 +123,13 @@ def test_start_cli_trims_padded_api_token_through_real_argument_loading(
         assert missing_body["error"] == "missing or malformed Authorization header"
         assert wrong_status == 401
         assert wrong_body["error"] == "invalid bearer token"
-        assert canonical_status != 401, canonical_body
+        # The trimmed token must get PAST authentication. Asserting only
+        # ``!= 401`` would also pass on a 500, so pin the specific post-auth
+        # outcome instead: this request carries an empty ``{}`` body, so
+        # reaching missing-field validation is itself the proof that the
+        # bearer token was accepted.
+        assert canonical_status == 400, canonical_body
+        assert "agent_id" in canonical_body["error"], canonical_body
     finally:
         stdout, stderr = _stop_process(process)
 


### PR DESCRIPTION
## Summary

- add an organic regression test that crosses the real `python -m vibap.cli start` parser, dispatch, and serving boundary
- prove a whitespace-padded synthetic `--api-token` is normalized when `VIBAP_API_TOKEN` is absent
- retain exact `401` behavior for missing and incorrect bearers, redacted diagnostics, bounded process cleanup, and no production test seam

This closes a test-reachability gap: the existing lower-level characterization passes its token directly to `serve_proxy()` and therefore cannot detect parser/dispatch/argument-forwarding regressions. No production failure was reproduced and no runtime behavior changed.

## Verification

- focused organic subprocess test: `1 passed`
- 10 independent real-process repetitions: `10/10 passed`
- relevant CLI/HTTP/auth/failure set: `185 passed in 7.06s`
- full Python suite: `1812 passed, 33 skipped, 6 warnings in 83.44s`
- Ruff lint and format checks: passed
- exact-file hooks, private-key detection, and Gitleaks: passed
- repository quick checks, docs sync, public claims, and Hugo build: passed
- fresh wheel/sdist structural validation and strict Twine 6.2.0: passed
- mutation proof: removing explicit-token `.strip()` made the canonical bearer fail with `401 invalid bearer token`, while missing/wrong negative assertions passed first
- privacy review: no host paths, private-key material, real credentials, or raw bearer output

README/public docs are unchanged because command syntax, runtime behavior, operator contracts, and support boundaries are unchanged. The new module docstring records the test boundary.

Human review remains mandatory before merge to `dev`; promotion from `dev` to `main` is outside this PR.

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end CLI integration test covering API token handling.
  * Verified padded tokens are normalized during module entrypoint argument loading.
  * Confirmed requests with missing or invalid bearer credentials are rejected, while valid credentials are accepted.
  * Added assertions that token values are redacted and not leaked via CLI stdout/stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->