### PR TITLE
fix(proxy): correct TLS and configuration gates

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,6 +63,13 @@ certificate and private-key PEM files, and `--no-tls` disables TLS only for
 plain-HTTP loopback development. This is not a production TLS, release, or
 hosted-website visibility claim.
 
+Newly generated material uses a DNS SAN for a DNS bind name and an IP SAN for
+a concrete IPv4 or IPv6 bind address. Because an unspecified wildcard bind
+such as `0.0.0.0` or `::` is not a client-verifiable identity, newly generated
+local material uses `localhost` in that case. Supply an explicit certificate
+and key whose SAN matches the client-facing identity for any non-loopback
+deployment.
+
 Invalid explicit TLS material fails closed before keys, state files, audit logs,
 sessions, or the proxy startup path are created. If either `--tls-cert` or
 `--tls-key` is provided, both values must point to existing files unless TLS is
@@ -555,6 +562,12 @@ before the Hub binds a listening socket; the command exits `1` with
 `condition: hub_tls_material_invalid`, placeholder-only recovery steps, empty
 stderr, and no raw path, file-name, certificate, or private-key disclosure.
 Port, host, and Personal home validation retain their existing precedence.
+
+Newly generated managed local material uses a DNS SAN for a DNS bind name and
+an IP SAN for a concrete IPv4 or IPv6 bind address. An unspecified wildcard
+bind uses `localhost` as the generated certificate identity; operators
+exposing the Hub beyond loopback must provide a certificate whose SAN matches
+the identity used by clients.
 
 `--no-tls` is the only intentional plaintext Hub mode and is intended for
 explicit local development. Environment configuration such as

--- a/python/tests/test_claude_code_doctor.py
+++ b/python/tests/test_claude_code_doctor.py
@@ -1,0 +1,51 @@
+"""Focused regressions for Claude Code doctor validation gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibap.cli import claude_code_doctor
+
+
+@pytest.mark.parametrize("missing_hook", ["subagent_start", "subagent_stop"])
+def test_claude_code_doctor_skips_validation_when_lifecycle_hook_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_hook: str,
+) -> None:
+    plugin_dir = tmp_path / "incomplete-plugin"
+    (plugin_dir / ".claude-plugin").mkdir(parents=True)
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text("{}")
+    hooks_dir = plugin_dir / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text("{}")
+    for hook_name in (
+        "pre_tool_use",
+        "post_tool_use",
+        "subagent_start",
+        "subagent_stop",
+    ):
+        if hook_name != missing_hook:
+            (hooks_dir / hook_name).write_text("#!/bin/sh\ntrue\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "active_mission.jwt").write_text("test")
+
+    monkeypatch.setattr("vibap.cli.shutil.which", lambda _command: "/fake/claude")
+
+    def _unexpected_validation(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("plugin validation must not run when a lifecycle hook is missing")
+
+    monkeypatch.setattr("vibap.cli.subprocess.run", _unexpected_validation)
+
+    response = claude_code_doctor(plugin_dir=plugin_dir, home=home)
+
+    checks = {check["name"]: check for check in response["checks"]}
+    assert checks[missing_hook]["ok"] is False
+    assert checks["plugin_validate"] == {
+        "name": "plugin_validate",
+        "ok": False,
+        "detail": "skipped; missing claude binary or plugin files",
+    }

--- a/python/tests/test_proxy_default_paths.py
+++ b/python/tests/test_proxy_default_paths.py
@@ -1,0 +1,43 @@
+"""Focused regressions for proxy default-path materialization."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_proxy_with_explicit_paths_does_not_create_unused_default_home(
+    tmp_path: Path,
+) -> None:
+    """An omitted receipts path derives from the explicit log, not DEFAULT_HOME."""
+
+    unused_home = tmp_path / "unused-home"
+    explicit_root = tmp_path / "explicit"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "from cryptography.hazmat.primitives.asymmetric import ec; "
+                "from vibap.proxy import GovernanceProxy; "
+                "key = ec.generate_private_key(ec.SECP256R1()); "
+                "GovernanceProxy(log_path=sys.argv[1], state_dir=sys.argv[2], "
+                "keys_dir=sys.argv[3], private_key=key, "
+                "public_key=key.public_key())"
+            ),
+            str(explicit_root / "audit.jsonl"),
+            str(explicit_root / "state"),
+            str(explicit_root / "keys"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={**os.environ, "VIBAP_HOME": str(unused_home)},
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not unused_home.exists()

--- a/python/tests/test_tls.py
+++ b/python/tests/test_tls.py
@@ -30,6 +30,28 @@ def test_generated_certificate_uses_dns_san_for_dns_identity(tmp_path: Path) -> 
     assert san.get_values_for_type(x509.IPAddress) == []
 
 
+def test_existing_managed_certificate_preserves_original_identity(
+    tmp_path: Path,
+) -> None:
+    tls_dir = tmp_path / "tls"
+    _key_path, cert_path, original_fingerprint = generate_self_signed_cert(
+        tls_dir,
+        hostname="localhost",
+    )
+    original_certificate = cert_path.read_bytes()
+
+    _key_path, reused_cert_path, reused_fingerprint = generate_self_signed_cert(
+        tls_dir,
+        hostname="127.0.0.1",
+    )
+
+    assert reused_cert_path.read_bytes() == original_certificate
+    assert reused_fingerprint == original_fingerprint
+    san = _subject_alt_name(reused_cert_path)
+    assert san.get_values_for_type(x509.DNSName) == ["localhost"]
+    assert san.get_values_for_type(x509.IPAddress) == []
+
+
 @pytest.mark.parametrize("identity", ["127.0.0.1", "::1"])
 def test_generated_certificate_uses_ip_san_for_ip_identity(
     tmp_path: Path,

--- a/python/tests/test_tls.py
+++ b/python/tests/test_tls.py
@@ -1,0 +1,59 @@
+"""Regression tests for generated TLS certificate identities."""
+
+from __future__ import annotations
+
+import ipaddress
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
+
+from vibap.tls import generate_self_signed_cert, resolve_tls_paths
+
+
+def _subject_alt_name(cert_path: Path) -> x509.SubjectAlternativeName:
+    certificate = x509.load_pem_x509_certificate(cert_path.read_bytes())
+    return certificate.extensions.get_extension_for_oid(
+        ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+    ).value
+
+
+def test_generated_certificate_uses_dns_san_for_dns_identity(tmp_path: Path) -> None:
+    _key_path, cert_path, _fingerprint = generate_self_signed_cert(
+        tmp_path / "tls",
+        hostname="localhost",
+    )
+
+    san = _subject_alt_name(cert_path)
+    assert san.get_values_for_type(x509.DNSName) == ["localhost"]
+    assert san.get_values_for_type(x509.IPAddress) == []
+
+
+@pytest.mark.parametrize("identity", ["127.0.0.1", "::1"])
+def test_generated_certificate_uses_ip_san_for_ip_identity(
+    tmp_path: Path,
+    identity: str,
+) -> None:
+    _key_path, cert_path, _fingerprint = generate_self_signed_cert(
+        tmp_path / "tls",
+        hostname=identity,
+    )
+
+    san = _subject_alt_name(cert_path)
+    assert san.get_values_for_type(x509.IPAddress) == [ipaddress.ip_address(identity)]
+    assert san.get_values_for_type(x509.DNSName) == []
+
+
+@pytest.mark.parametrize("wildcard_bind", ["0.0.0.0", "::"])
+def test_auto_generated_certificate_does_not_use_wildcard_bind_as_identity(
+    tmp_path: Path,
+    wildcard_bind: str,
+) -> None:
+    result = resolve_tls_paths(home=tmp_path, hostname=wildcard_bind)
+
+    assert result is not None
+    cert_path, _key_path, _fingerprint = result
+    san = _subject_alt_name(cert_path)
+    assert san.get_values_for_type(x509.DNSName) == ["localhost"]
+    assert san.get_values_for_type(x509.IPAddress) == []

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -4284,7 +4284,8 @@ def claude_code_doctor(
     plugin_dir: Path | None = None, home: Path | None = None
 ) -> dict[str, object]:
     plugin = (plugin_dir or _default_claude_plugin_dir()).expanduser().resolve()
-    checks = _claude_code_plugin_checks(plugin)
+    plugin_checks = _claude_code_plugin_checks(plugin)
+    checks = list(plugin_checks)
     claude_binary = shutil.which("claude")
     checks.append(
         {
@@ -4305,7 +4306,7 @@ def claude_code_doctor(
             "detail": f"expected file at {_ARDUR_HOME_PLACEHOLDER}/active_mission.jwt",
         }
     )
-    if claude_binary and all(check["ok"] for check in checks[:5]):
+    if claude_binary and all(check["ok"] for check in plugin_checks):
         result = subprocess.run(
             [claude_binary, "plugin", "validate", str(plugin)],
             capture_output=True,

--- a/python/vibap/proxy.py
+++ b/python/vibap/proxy.py
@@ -2182,7 +2182,7 @@ class GovernanceProxy:
         # When any path falls through to a DEFAULT_HOME-derived default,
         # materialise the home with 0o700 before we start creating state
         # directories inside it.
-        if log_path is None or state_dir is None or receipts_log_path is None:
+        if log_path is None or state_dir is None:
             _ensure_default_home_dir()
         self._ensure_private_state_directory(self.state_dir, label="state_dir")
         self.sessions_dir = self.state_dir / "sessions"

--- a/python/vibap/tls.py
+++ b/python/vibap/tls.py
@@ -33,6 +33,24 @@ def _default_tls_dir(home: Path | None = None) -> Path:
     return (home or DEFAULT_HOME) / "tls"
 
 
+def _certificate_identity(hostname: str) -> tuple[str, x509.GeneralName]:
+    """Return a usable certificate identity and its matching SAN value."""
+
+    identity = hostname.strip()
+    if not identity:
+        raise ValueError("certificate identity must not be empty")
+
+    try:
+        address = ipaddress.ip_address(identity)
+    except ValueError:
+        return identity, x509.DNSName(identity)
+
+    # A wildcard bind address is not an identity that a client can verify.
+    if address.is_unspecified:
+        return "localhost", x509.DNSName("localhost")
+    return identity, x509.IPAddress(address)
+
+
 def generate_self_signed_cert(
     tls_dir: Path,
     *,
@@ -42,6 +60,8 @@ def generate_self_signed_cert(
 ) -> tuple[Path, Path, str]:
     """Generate a self-signed EC P-256 cert with a SHA-256 fingerprint."""
     from .passport import _ensure_default_home_dir, _is_under_default_home
+
+    certificate_identity, subject_alternative_name = _certificate_identity(hostname)
 
     # When tls_dir is under DEFAULT_HOME, materialise the home with 0o700
     # first so the mkdir(parents=True) doesn't create it with the process umask.
@@ -65,7 +85,7 @@ def generate_self_signed_cert(
     key_path.write_bytes(key_pem)
     key_path.chmod(0o600)
 
-    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, certificate_identity)])
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -80,9 +100,7 @@ def generate_self_signed_cert(
         )
         .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
         .add_extension(
-            x509.SubjectAlternativeName(
-                [x509.IPAddress(ipaddress.IPv4Address(hostname))]
-            ),
+            x509.SubjectAlternativeName([subject_alternative_name]),
             critical=False,
         )
         .sign(private_key, hashes.SHA256())
@@ -135,10 +153,14 @@ def resolve_tls_paths(
 
     if not tls_cert and not tls_key and not no_tls:
         tls_dir = _default_tls_dir(home)
+        certificate_identity, _ = _certificate_identity(hostname)
         key_path, cert_path, fingerprint = generate_self_signed_cert(
-            tls_dir, hostname=hostname
+            tls_dir, hostname=certificate_identity
         )
-        print(f"[tls] auto-generated self-signed cert for {hostname}", file=sys.stderr)
+        print(
+            f"[tls] auto-generated self-signed cert for {certificate_identity}",
+            file=sys.stderr,
+        )
         print(f"[tls] fingerprint: {fingerprint}", file=sys.stderr)
         return cert_path, key_path, fingerprint
 

--- a/site/content/source/docs/reference/cli.md
+++ b/site/content/source/docs/reference/cli.md
@@ -2,7 +2,7 @@
 title: "ardur` CLI Reference"
 description: "The `ardur` console entry point ships with the Python package. After"
 source_path: "docs/reference/cli.md"
-source_sha256: "ef7eebbb24724ef570e025ce256815a614aa34c1ec25701ea1b586f1724b37dd"
+source_sha256: "72543e5381c88627e284534cc4ab32e986547f4be6138c5bb40d835d45efcb82"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -79,6 +79,13 @@ local self-signed TLS material; `--tls-cert` and `--tls-key` select explicit
 certificate and private-key PEM files, and `--no-tls` disables TLS only for
 plain-HTTP loopback development. This is not a production TLS, release, or
 hosted-website visibility claim.
+
+Newly generated material uses a DNS SAN for a DNS bind name and an IP SAN for
+a concrete IPv4 or IPv6 bind address. Because an unspecified wildcard bind
+such as `0.0.0.0` or `::` is not a client-verifiable identity, newly generated
+local material uses `localhost` in that case. Supply an explicit certificate
+and key whose SAN matches the client-facing identity for any non-loopback
+deployment.
 
 Invalid explicit TLS material fails closed before keys, state files, audit logs,
 sessions, or the proxy startup path are created. If either `--tls-cert` or
@@ -572,6 +579,12 @@ before the Hub binds a listening socket; the command exits `1` with
 `condition: hub_tls_material_invalid`, placeholder-only recovery steps, empty
 stderr, and no raw path, file-name, certificate, or private-key disclosure.
 Port, host, and Personal home validation retain their existing precedence.
+
+Newly generated managed local material uses a DNS SAN for a DNS bind name and
+an IP SAN for a concrete IPv4 or IPv6 bind address. An unspecified wildcard
+bind uses `localhost` as the generated certificate identity; operators
+exposing the Hub beyond loopback must provide a certificate whose SAN matches
+the identity used by clients.
 
 `--no-tls` is the only intentional plaintext Hub mode and is intended for
 explicit local development. Environment configuration such as


### PR DESCRIPTION
## Relevant issues

Closes #324.

## Type

- [ ] `feat` — new capability or surface
- [x] `fix` — bug fix
- [ ] `docs` — article, README, or doc change
- [ ] `refactor` — internal change, no behaviour change
- [ ] `test` — test-only change
- [ ] `ci` — CI / workflow / tooling
- [ ] `chore` — housekeeping
- [ ] `dev → main graduation` — promoting reviewed work to release branch

## Changes

- Generate DNS SANs for DNS identities and IP SANs for concrete IPv4/IPv6 identities.
- Use `localhost` as the newly generated local certificate identity for wildcard binds instead of encoding `0.0.0.0` or `::` in the SAN.
- Avoid materializing the default home when explicit log/state paths make every effective proxy path explicit.
- Gate `claude plugin validate` on the complete named plugin-file check set, including both subagent lifecycle hooks.
- Document the generated identity contract and refresh the source-backed site mirror.
- Add focused regressions for all three pre-existing defects.

Existing managed certificates are deliberately not rotated: silent replacement changes the fingerprint and can break pinned clients. Non-loopback deployments must continue to provide an explicit certificate whose SAN matches the client-facing identity.

## Testing

- Issue regressions: `8 passed`.
- Related TLS startup, Personal Hub, Claude profile, and lazy-home tests: `94 passed`.
- Clean-layout full Python suite: `1947 passed, 34 skipped`.
- `ruff check` and `ruff format --check` on changed Python files.
- All configured pre-commit hooks, including private-key detection and the repository-pinned Gitleaks hook.
- Checksum-verified Gitleaks 8.21.2 scan across 566 commits: no leaks.
- `pip-audit` 2.10.1: no known vulnerabilities in audited third-party dependencies.
- `scripts/check-local.sh --quick`.
- Source mirror check, public claim validation, Hugo 0.161.1 build, rendered documentation link validation, and source provenance scan.
- Python package asset sync, wheel/sdist build, distribution validation, and strict Twine checks.

Go sources are unchanged; the local Go toolchain is below the repository requirement, so hosted CI is the authoritative Go signal.

## Graduation gates (for `dev → main` PRs only)

Not applicable: this PR targets `dev` and does not touch `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified TLS certificate identity and SAN generation for `ardur start` and `ardur hub`, including wildcard bind behavior and requirements for non-loopback deployments.
* **Bug Fixes**
  * Fixed generated TLS certificates to use correct DNS/IP SANs and map wildcard binds to a `localhost` identity.
  * Ensured existing managed certificates preserve their original identity.
  * Avoided unnecessary default home-directory creation when explicit proxy paths are provided.
  * Tightened plugin validation gating when requirements are missing.
* **Tests**
  * Added regression coverage for TLS SAN identity selection, proxy default-path behavior, and plugin validation gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->