### PR TITLE
fix(ci): replace flaky execsnoop citation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -122,8 +122,12 @@ while Linux benchmark stress is manual.
 
 [`/.github/workflows/link-check.yml`](../.github/workflows/link-check.yml)
 
-- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
+- Runs on every pull request and weekly via cron, scanning `**/*.md`. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
 - Currently excludes five URL patterns/domains. One (`security/advisories/new`) requires being signed in to GitHub, so an unauthenticated checker gets a 404. Four bot-blocking domains (`developers.redhat.com`, `medium.com`, `answers.uillinois.edu`, `theregister.com`) return 403 to automated requests; these are legitimate research citations excluded rather than removed. The earlier Discussions-tab exclude was removed once Discussions was enabled on the repo.
+- Timeouts remain failures. Prefer an immutable upstream primary reference over
+  excluding a slow mirror or enabling `--accept-timeouts`; exclusions are for
+  sources that are legitimate but structurally unavailable to automation, not
+  a substitute for maintaining citations.
 
 ### `validate-formats` — JSON and YAML parsers
 

--- a/docs/research/epic-b-performance-fp-budget.md
+++ b/docs/research/epic-b-performance-fp-budget.md
@@ -55,8 +55,7 @@ of every `execve` the machine does. This section budgets that cost.
 - **How often execs happen:** Brendan Gregg's `execsnoop` documentation states the
   exec rate is "expected to be low" — **< 500/s** (ftrace build), **< 1000/s**
   (bcc/eBPF build)
-  ([bcc execsnoop man page](https://github.com/iovisor/bcc/blob/master/man/man8/execsnoop.8);
-  [Ubuntu execsnoop-bpfcc](https://manpages.ubuntu.com/manpages/focal/en/man8/execsnoop-bpfcc.8.html)).
+  ([bcc execsnoop man page](https://github.com/iovisor/bcc/blob/6ebeb451656d75e599dc34af12b479c02a3fc041/man/man8/execsnoop.8)).
   Tetragon in the field reports ~200 process events/s typical, 1,000–2,000/s under
   a synthetic connect-storm
   ([tetragon.io events docs](https://tetragon.io/docs/concepts/events/)).
@@ -333,8 +332,7 @@ one-time pass.**
 - [InfoQ — eBPF for security observability (Falco 2–5% CPU)](https://www.infoq.com/articles/ebpf-for-security-observability/)
 - [Syairozi & Arizal, "Comparative Analysis of eBPF-Based Runtime Security Monitoring Tools," RITECH 2025 (SCITEPRESS)](https://www.scitepress.org/Papers/2025/142727/142727.pdf)
 - [CrowdStrike Deployment FAQ (≤1% CPU claim)](https://www.crowdstrike.com/en-us/products/faq/)
-- [Brendan Gregg / iovisor — bcc execsnoop man page (exec rate < 1000/s)](https://github.com/iovisor/bcc/blob/master/man/man8/execsnoop.8)
-- [Ubuntu — execsnoop-bpfcc man page](https://manpages.ubuntu.com/manpages/focal/en/man8/execsnoop-bpfcc.8.html)
+- [Brendan Gregg / iovisor — bcc execsnoop man page (exec rate < 1000/s)](https://github.com/iovisor/bcc/blob/6ebeb451656d75e599dc34af12b479c02a3fc041/man/man8/execsnoop.8)
 - [lmbench — process creation latency (USENIX)](https://www.usenix.org/legacy/publications/library/proceedings/usenix01/freenix01/full_papers/loscocco/loscocco_html/node16.html)
 - [Red Hat Developer — measuring BPF performance (kprobe cycle costs)](https://developers.redhat.com/articles/2022/06/22/measuring-bpf-performance-tips-tricks-and-best-practices)
 - [iximiuz Labs — tracepoints vs kprobes vs fprobes](https://labs.iximiuz.com/tutorials/ebpf-tracing-46a570d1)

--- a/python/tests/test_link_check_policy.py
+++ b/python/tests/test_link_check_policy.py
@@ -1,0 +1,39 @@
+"""Regression coverage for the required Markdown link-check policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_DOC = REPO_ROOT / "docs/research/epic-b-performance-fp-budget.md"
+MIRROR_DOC = (
+    REPO_ROOT / "site/content/source/docs/research/epic-b-performance-fp-budget.md"
+)
+LINK_WORKFLOW = REPO_ROOT / ".github/workflows/link-check.yml"
+
+FRAGILE_UBUNTU_MIRROR = (
+    "https://manpages.ubuntu.com/manpages/focal/en/man8/execsnoop-bpfcc.8.html"
+)
+IMMUTABLE_UPSTREAM_SOURCE = (
+    "https://github.com/iovisor/bcc/blob/"
+    "6ebeb451656d75e599dc34af12b479c02a3fc041/man/man8/execsnoop.8"
+)
+
+
+def test_exec_rate_citation_uses_immutable_upstream_source() -> None:
+    """The required gate must not depend on the redundant timeout-prone mirror."""
+
+    for path in (SOURCE_DOC, MIRROR_DOC):
+        content = path.read_text(encoding="utf-8")
+        assert FRAGILE_UBUNTU_MIRROR not in content
+        assert content.count(IMMUTABLE_UPSTREAM_SOURCE) == 2
+
+
+def test_required_link_check_keeps_timeouts_fail_closed() -> None:
+    """Reliability fixes must preserve the required check instead of hiding failures."""
+
+    workflow = LINK_WORKFLOW.read_text(encoding="utf-8")
+    normalized_workflow = workflow.replace("\\.", ".")
+    assert "--accept-timeouts" not in workflow
+    assert "manpages.ubuntu.com" not in normalized_workflow
+    assert 'if [ "$LYCHEE" != "success" ]' in workflow

--- a/python/tests/test_link_check_policy.py
+++ b/python/tests/test_link_check_policy.py
@@ -36,4 +36,8 @@ def test_required_link_check_keeps_timeouts_fail_closed() -> None:
     normalized_workflow = workflow.replace("\\.", ".")
     assert "--accept-timeouts" not in workflow
     assert "manpages.ubuntu.com" not in normalized_workflow
+    assert "fail: true" in workflow
+    assert "needs: lychee" in workflow
+    assert "if: ${{ always() }}" in workflow
+    assert "LYCHEE: ${{ needs.lychee.result }}" in workflow
     assert 'if [ "$LYCHEE" != "success" ]' in workflow

--- a/site/content/source/docs/TESTING.md
+++ b/site/content/source/docs/TESTING.md
@@ -2,7 +2,7 @@
 title: "Testing"
 description: "The public tree includes curated Python and Go runtime code under `python/`"
 source_path: "docs/TESTING.md"
-source_sha256: "96b50ba6c61a2dedf0bcda3aee59cc4824d69c193831da0d5a1507d5df1af335"
+source_sha256: "330d9522a5d47a28e43be71088afc8f5a8111b9121c4852c240f934b79014c34"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -139,8 +139,12 @@ while Linux benchmark stress is manual.
 
 [`/.github/workflows/link-check.yml`](/__ardur_internal__/repo/.github/workflows/link-check.yml)
 
-- Runs on PRs touching `**/*.md` and weekly via cron. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
+- Runs on every pull request and weekly via cron, scanning `**/*.md`. Uses `lycheeverse/lychee-action@v2.9.0` (commit-pinned).
 - Currently excludes five URL patterns/domains. One (`security/advisories/new`) requires being signed in to GitHub, so an unauthenticated checker gets a 404. Four bot-blocking domains (`developers.redhat.com`, `medium.com`, `answers.uillinois.edu`, `theregister.com`) return 403 to automated requests; these are legitimate research citations excluded rather than removed. The earlier Discussions-tab exclude was removed once Discussions was enabled on the repo.
+- Timeouts remain failures. Prefer an immutable upstream primary reference over
+  excluding a slow mirror or enabling `--accept-timeouts`; exclusions are for
+  sources that are legitimate but structurally unavailable to automation, not
+  a substitute for maintaining citations.
 
 ### `validate-formats` — JSON and YAML parsers
 

--- a/site/content/source/docs/research/epic-b-performance-fp-budget.md
+++ b/site/content/source/docs/research/epic-b-performance-fp-budget.md
@@ -2,7 +2,7 @@
 title: "Epic B — The \"CrowdStrike Tax\": Cost & Reliability Budget of Always-On Host-Wide Agent Detection"
 description: "Status: **research document only** (2026-07-03). Read-only pass; no code changed."
 source_path: "docs/research/epic-b-performance-fp-budget.md"
-source_sha256: "4fc094f11f111009851b0e07eb84b26323f6c534a2168d2444ae62901da04775"
+source_sha256: "cb6bd5219e8df21d30a7ed1f79e25defd802554bd82d210a6e6cc63289a7b7d4"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -72,8 +72,7 @@ of every `execve` the machine does. This section budgets that cost.
 - **How often execs happen:** Brendan Gregg's `execsnoop` documentation states the
   exec rate is "expected to be low" — **< 500/s** (ftrace build), **< 1000/s**
   (bcc/eBPF build)
-  ([bcc execsnoop man page](https://github.com/iovisor/bcc/blob/master/man/man8/execsnoop.8);
-  [Ubuntu execsnoop-bpfcc](https://manpages.ubuntu.com/manpages/focal/en/man8/execsnoop-bpfcc.8.html)).
+  ([bcc execsnoop man page](https://github.com/iovisor/bcc/blob/6ebeb451656d75e599dc34af12b479c02a3fc041/man/man8/execsnoop.8)).
   Tetragon in the field reports ~200 process events/s typical, 1,000–2,000/s under
   a synthetic connect-storm
   ([tetragon.io events docs](https://tetragon.io/docs/concepts/events/)).
@@ -350,8 +349,7 @@ one-time pass.**
 - [InfoQ — eBPF for security observability (Falco 2–5% CPU)](https://www.infoq.com/articles/ebpf-for-security-observability/)
 - [Syairozi & Arizal, "Comparative Analysis of eBPF-Based Runtime Security Monitoring Tools," RITECH 2025 (SCITEPRESS)](https://www.scitepress.org/Papers/2025/142727/142727.pdf)
 - [CrowdStrike Deployment FAQ (≤1% CPU claim)](https://www.crowdstrike.com/en-us/products/faq/)
-- [Brendan Gregg / iovisor — bcc execsnoop man page (exec rate < 1000/s)](https://github.com/iovisor/bcc/blob/master/man/man8/execsnoop.8)
-- [Ubuntu — execsnoop-bpfcc man page](https://manpages.ubuntu.com/manpages/focal/en/man8/execsnoop-bpfcc.8.html)
+- [Brendan Gregg / iovisor — bcc execsnoop man page (exec rate < 1000/s)](https://github.com/iovisor/bcc/blob/6ebeb451656d75e599dc34af12b479c02a3fc041/man/man8/execsnoop.8)
 - [lmbench — process creation latency (USENIX)](https://www.usenix.org/legacy/publications/library/proceedings/usenix01/freenix01/full_papers/loscocco/loscocco_html/node16.html)
 - [Red Hat Developer — measuring BPF performance (kprobe cycle costs)](https://developers.redhat.com/articles/2022/06/22/measuring-bpf-performance-tips-tricks-and-best-practices)
 - [iximiuz Labs — tracepoints vs kprobes vs fprobes](https://labs.iximiuz.com/tutorials/ebpf-tracing-46a570d1)


### PR DESCRIPTION
## Relevant issues

Closes #334.

Also removes the external dependency blocking #328 and #329, but neither PR is merged or bypassed by this change.

## Type

- [x] `fix` — bug fix
- [x] `docs` — maintained testing policy and research citation
- [x] `test` — deterministic policy regression
- [ ] `dev → main graduation`

## Changes

- replace the repeatedly timing-out Ubuntu execsnoop mirror with the primary upstream BCC manpage pinned to commit `6ebeb451656d75e599dc34af12b479c02a3fc041`
- preserve fail-closed link validation: no `--accept-timeouts`, no domain exclusion, no required-check change
- add a regression covering the source document, generated mirror, and required aggregate
- correct the testing guide to reflect that link-check runs on every PR and document the citation-maintenance policy
- regenerate only the two affected Hugo source mirrors

## Root cause and trade-off

The unchanged mirror exhausted lychee v0.24.2 defaults of three retries and a 20-second request timeout on three independent #328 heads and in an exact local reproduction. Accepting timeouts or excluding the whole domain would hide unrelated failures. The immutable primary source removes the redundant dependency while retaining the security and correctness signal. The trade-off is intentional: future upstream corrections require an explicit citation update.

## Testing

- red/green regression: policy test changed from 1 failed / 1 passed to 2 passed
- full Python suite: 1,941 passed, 34 skipped
- full repository lychee policy: 564 total, 557 OK, 7 documented exclusions; one unrelated transient man7 connection error occurred on the first run and an immediate unchanged retry passed
- changed-document lychee policy: 35 total, 31 OK, 4 documented exclusions
- `./scripts/check-local.sh --quick`: passed
- source mirror sync, claim validation, rendered-document link validation, and provenance: passed
- Hugo v0.161.1: 291 pages built
- applicable pre-commit hooks: passed
- Gitleaks v8.30.1 history and working tree: no leaks
- pip-audit v2.10.1: no known vulnerabilities

## Security, operations, and cost

The required link gate remains fail-closed. No secrets, IAM, runtime permissions, encryption boundaries, deployments, or cloud resources change. Cost remains ordinary GitHub Actions minutes; the change avoids repeated timeout waits for this redundant citation.

## README review

No README update is needed. `docs/TESTING.md` is the maintained operational source for this policy, while the README product overview and dated verification snapshot remain accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified link-check CI behavior: runs on every pull request plus weekly cron, scans all Markdown files, explains current exclusions, and specifies that timeouts fail.
  * Updated performance research citations to use stable, pinned `execsnoop` references and removed unreliable/unpinned links.
  * Synced site documentation mirror metadata with the latest source content.
* **Tests**
  * Added regression coverage to ensure fragile citations are removed and that link validation “fails closed” when timeouts or errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->