### PR TITLE
fix(security): ignore generated key material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,23 @@ site/.hugo_build.lock
 # as defense-in-depth so an accidental `git add .` does not stage them even
 # if the gitleaks PEM rule were to miss a format variant.
 keys/
+*.pem
+*.key
+
+# Reviewed public-key fixtures remain normal source artifacts. Keep these
+# exceptions narrower than the generated-key rules so a new PEM elsewhere
+# requires an explicit security review before it can be added.
+!/docs/specs/**/*.pem
+!/site/static/repo/docs/specs/**/*.pem
+
+# Legacy/default-in-CWD proxy state. Standard managed state under `.ardur/`
+# and `.vibap/` is already ignored above; root anchors avoid hiding an
+# unrelated JSON fixture with the same basename in another source directory.
+/passport_state.lock
+/replay_cache.json
+/revoked.json
+/lineage_hashes.json
+
 active_mission.jwt
 claude-code-pre_tool_use
 claude-code-pre_tool_use.sha256

--- a/python/tests/test_gitignore_policy.py
+++ b/python/tests/test_gitignore_policy.py
@@ -1,0 +1,79 @@
+"""Regression coverage for generated key and runtime artifact ignore policy."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+GENERATED_ARTIFACTS = (
+    "passport_private.pem",
+    "passport_public.pem",
+    "scratch/private.pem",
+    "scratch/private.key",
+    "passport_state.lock",
+    "replay_cache.json",
+    "revoked.json",
+    "lineage_hashes.json",
+)
+
+VISIBLE_FILES = (
+    "ordinary.txt",
+    "runtime/replay_cache.json",
+    "docs/specs/fixtures/new-public.pem",
+    "docs/specs/conformance/runtime-evidence-v0.1/new-public.pem",
+    "site/static/repo/docs/specs/fixtures/new-public.pem",
+)
+
+REVIEWED_PEM_PREFIXES = (
+    "docs/specs/",
+    "site/static/repo/docs/specs/",
+)
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", *args),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_recursive_staging_skips_generated_artifacts_but_keeps_public_fixtures(
+    tmp_path: Path,
+) -> None:
+    """Normal recursive staging must exclude runtime output without hiding fixtures."""
+
+    shutil.copy2(REPO_ROOT / ".gitignore", tmp_path / ".gitignore")
+    _git("init", "--quiet", cwd=tmp_path)
+
+    for relative in (*GENERATED_ARTIFACTS, *VISIBLE_FILES):
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture\n", encoding="utf-8")
+
+    _git("add", "--all", cwd=tmp_path)
+    staged = set(
+        _git("diff", "--cached", "--name-only", "-z", cwd=tmp_path)
+        .stdout.rstrip("\0")
+        .split("\0")
+    )
+
+    assert set(GENERATED_ARTIFACTS).isdisjoint(staged)
+    assert {".gitignore", *VISIBLE_FILES} == staged
+
+
+def test_tracked_pem_files_stay_in_reviewed_public_fixture_trees() -> None:
+    """A force-added PEM outside the public fixture trees must fail repository tests."""
+
+    tracked = (
+        _git("ls-files", "-z", "*.pem", cwd=REPO_ROOT).stdout.rstrip("\0").split("\0")
+    )
+
+    assert tracked
+    assert all(path.startswith(REVIEWED_PEM_PREFIXES) for path in tracked)


### PR DESCRIPTION
## Summary

- ignore generated PEM and key files at every depth while explicitly re-including only reviewed public fixture trees
- ignore legacy/default-in-CWD proxy state names at the repository root without hiding same-named nested fixtures
- add organic Git staging regressions and a tracked-PEM placement guard

## Security boundary

This is defense in depth for normal recursive staging, not access control. A deliberate force-add remains possible, so detect-private-key and Gitleaks remain enabled and unchanged. The public fixture exceptions are intentionally narrow; a new PEM tree requires explicit review.

Blast radius is limited to Git staging behavior. Root anchors prevent unrelated nested JSON files from being concealed.

## Validation

- red baseline: 1 failed, 1 passed before the ignore policy change
- focused regression: 2 passed
- full Python suite: 1952 passed, 34 skipped
- Ruff check and format: passed
- changed-file pre-commit hooks: passed, including detect-private-key and Gitleaks
- full Gitleaks history scan: 574 commits, no leaks
- pip-audit: no known vulnerabilities in installed third-party dependencies; editable local package skipped
- repository quick checks, source/mirror parity, package assets, Hugo build, rendered links, and public claims: passed
- git diff --check: passed

## Documentation and cost

README was explicitly reviewed and does not need a change; the policy rationale is adjacent to the rules and covered by regression tests. No cloud resources or paid API usage are introduced; only normal CI minutes are consumed.

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated key material and runtime state files from being accidentally included in source control.
  * Preserved approved PEM fixture files used by documentation and public examples.

* **Tests**
  * Added automated checks to verify generated artifacts are excluded while approved fixtures remain available.
  * Added validation ensuring tracked PEM files are non-empty and stored only in approved fixture locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->