### PR TITLE
docs(security): ground known limitations in public code

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -183,7 +183,7 @@ The full set of bounded-iat surfaces is now:
 - `vibap.attestation.verify_attestation` (round-4 FIX-R4-3)
 - `vibap.spiffe_identity.verify_jwt_svid` (round-4 FIX-R4-4)
 - `vibap.memory.GovernedMemoryStore.read` (round-5 FIX-R5-M3)
-- `vibap.tool_response_provenance.verify_tool_response_envelope` (round-5 FIX-R5-M4; uses tighter ±60s future window for short-lived tokens)
+- `vibap.tool_response_provenance.verify_envelope` (round-5 FIX-R5-M4; uses tighter ±60s future window for short-lived tokens)
 
 **Python parallel-format / non-JWT verifiers:**
 - `vibap.biscuit_passport.verify_biscuit_passport` (round-4 FIX-R4-1; round-5 FIX-R5-H5 walks every block, not just leaf)
@@ -253,42 +253,32 @@ sidecar today. Production deployments MUST configure one. This is
 documented here as a known limitation rather than a code-level fix
 because the right answer is deployment-environment-specific.
 
-## Bearer-token authentication on Go control-plane services (2026-04-29 round-5)
+## Python proxy bearer authentication is a shared-secret boundary
 
-Round-4 audit flagged that the Go Authority and Governor HTTP services
-were unauthenticated — anyone with network reach could mint credentials
-or ingest fabricated governance events. Round-5 closes both:
+The public tree does not ship the Go Authority or Governor HTTP services
+described by earlier audit-round documentation. The shipped HTTP control plane
+is `vibap.proxy.serve_proxy`. It requires authentication by default on every
+endpoint except `/health`, `/healthz`, and `/.well-known/jwks.json`.
 
-- `go/cmd/authority`: `/sign` and `/status` require
-  `Authorization: Bearer <authority-token>` matching `ARDUR_AUTHORITY_TOKEN`
-  (≥32 bytes). The binary refuses to start unless the token is set or
-  `--no-require-auth` is passed for explicit local-dev opt-out. Public
-  endpoints (`/attestation`, `/public-key`, `/healthz`) remain
-  unauthenticated since they advertise the trust anchor.
-- `go/pkg/governance.NewHandlerWithAuth` wires every `/v1/*` route
-  through a constant-time bearer-check. `cmd/governor/main.go` reads
-  `ARDUR_GOVERNOR_TOKEN` from env; `Validate()` refuses to start
-  without it (or without explicit `ARDUR_GOVERNOR_NO_REQUIRE_AUTH=1`
-  opt-out). `/healthz` and `/readyz` stay public for K8s probes.
+`VIBAP_API_TOKEN` takes precedence over the `--api-token` argument. When neither
+is supplied, the proxy generates a random 32-byte token. Expected and presented
+tokens are stripped at their entry points, the bearer scheme is accepted
+case-insensitively, and `vibap.proxy._api_token_compare_material` converts both
+values to equal-length material before `hmac.compare_digest` compares them. An
+explicit `--no-require-auth` remains available only for trusted local
+development.
 
-Both services use `crypto/subtle.ConstantTimeCompare` to defeat timing
-side-channel inference of the token. **Round-7+ also SHA-256-normalizes
-both presented and expected tokens before the constant-time compare**
-(`sha256.Sum256(token)` on each side, comparison over the 32-byte
-digests) — this defeats the length oracle that
-`subtle.ConstantTimeCompare` short-circuits on length-mismatched
-inputs. The Python proxy's `hmac.compare_digest` path does the same
-SHA-256 normalization. Production deployments SHOULD also front the
-services with mTLS at the ingress / service-mesh layer for
-defense-in-depth.
-
-Operator-supplied bearer tokens are `strings.TrimSpace`-ed (Go) /
-`.strip()`-ed (Python) at every entry point — env vars
-(`ARDUR_AUTHORITY_TOKEN`, `ARDUR_GOVERNOR_TOKEN`, `VIBAP_API_TOKEN`)
-and CLI args (`--api-token`) — so YAML-quoted secrets with leading
-or trailing whitespace authenticate correctly without operator
-debugging time. The bearer-scheme parse is RFC 9110-compliant
-case-insensitive (`Bearer`, `bearer`, `BEARER` all accepted).
+This is one process-wide bearer secret, not per-client identity or delegated
+authorization. The proxy does not assign client-specific scopes or expiry, and
+rotation requires restarting it with a new token. Any party holding the token
+can call every protected endpoint. Protect it in storage and in transit: bearer
+possession alone grants access, as defined by
+[RFC 6750](https://www.rfc-editor.org/rfc/rfc6750.html#section-1.2), and the RFC
+requires transport confidentiality. Ardur enables TLS by default; do not use
+`--no-tls` across an untrusted network. Python also documents that different
+input lengths can expose length information even when using
+[`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest),
+which is why Ardur compares fixed-width material.
 
 ## `_pinned_urlopen` semantics (2026-04-28 round-3)
 
@@ -305,7 +295,8 @@ error.
 
 ## AAT proof-of-possession default (2026-04-28 hardening)
 
-`material_from_aat_grant` and `GovernanceProxy.start_session_from_aat`
+`vibap.aat_adapter.material_from_aat_grant` and
+`vibap.proxy.GovernanceProxy.start_session_from_aat`
 default to `require_pop=True`. A cnf-bearing AAT presented without
 `holder_public_key` + `kb_jwt` now fails closed. Bearer-mode AATs
 (no `cnf` claim) continue to be accepted; library callers that

--- a/python/tests/test_known_limitations_references.py
+++ b/python/tests/test_known_limitations_references.py
@@ -1,0 +1,125 @@
+"""Keep code references in the known-limitations contract tied to this tree."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCUMENT = REPO_ROOT / "docs" / "known-limitations.md"
+
+CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+PYTHON_SYMBOL_RE = re.compile(
+    r"^vibap\.[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+$",
+)
+GO_PACKAGE_SYMBOL_RE = re.compile(
+    r"^(go/(?:cmd|pkg)/[A-Za-z0-9_./-]+)\.([A-Za-z_]\w*)$",
+)
+GO_DECLARATION_TEMPLATE = (
+    r"(?m)^\s*(?:func\s+(?:\([^\n)]*\)\s*)?|type\s+|var\s+|const\s+){}\b"
+)
+REPOSITORY_PREFIXES = (".github/", "deploy/", "docs/", "go/", "python/")
+
+
+def _code_spans() -> set[str]:
+    return set(CODE_SPAN_RE.findall(DOCUMENT.read_text(encoding="utf-8")))
+
+
+def _python_symbol_exists(reference: str) -> bool:
+    _, module_name, *symbol_path = reference.split(".")
+    module_path = REPO_ROOT / "python" / "vibap" / f"{module_name}.py"
+    if not module_path.is_file():
+        return False
+
+    nodes: list[ast.stmt] = ast.parse(
+        module_path.read_text(encoding="utf-8"),
+        filename=str(module_path),
+    ).body
+    for symbol in symbol_path:
+        match = next(
+            (
+                node
+                for node in nodes
+                if isinstance(
+                    node,
+                    (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef),
+                )
+                and node.name == symbol
+            ),
+            None,
+        )
+        if match is None:
+            return False
+        nodes = match.body if isinstance(match, ast.ClassDef) else []
+    return True
+
+
+def _go_symbol_exists(path: Path, symbol: str) -> bool:
+    sources = [path] if path.is_file() else sorted(path.glob("*.go"))
+    declaration = re.compile(GO_DECLARATION_TEMPLATE.format(re.escape(symbol)))
+    return any(
+        declaration.search(source.read_text(encoding="utf-8")) for source in sources
+    )
+
+
+def _repository_reference_error(reference: str) -> str | None:
+    if "::" in reference:
+        raw_path, symbol = reference.split("::", 1)
+        path = REPO_ROOT / raw_path
+        if not path.is_file():
+            return f"missing file {raw_path}"
+        if not _go_symbol_exists(path, symbol):
+            return f"missing Go symbol {symbol} in {raw_path}"
+        return None
+
+    package_symbol = GO_PACKAGE_SYMBOL_RE.fullmatch(reference)
+    if package_symbol:
+        raw_path, symbol = package_symbol.groups()
+        path = REPO_ROOT / raw_path
+        if not path.is_dir():
+            return f"missing Go package {raw_path}"
+        if not _go_symbol_exists(path, symbol):
+            return f"missing Go symbol {symbol} in {raw_path}"
+        return None
+
+    if reference.startswith("cmd/"):
+        path = REPO_ROOT / "go" / reference
+    elif reference.startswith(REPOSITORY_PREFIXES):
+        path = REPO_ROOT / reference
+    elif "/" not in reference and reference.endswith(".md"):
+        path = DOCUMENT.parent / reference
+    else:
+        return None
+
+    if not path.exists():
+        return f"missing repository path {reference}"
+    return None
+
+
+def test_qualified_python_symbols_resolve() -> None:
+    references = sorted(filter(PYTHON_SYMBOL_RE.fullmatch, _code_spans()))
+    missing = [
+        reference for reference in references if not _python_symbol_exists(reference)
+    ]
+
+    assert len(references) >= 10, "qualified Python reference discovery became vacuous"
+    assert not missing, f"stale qualified Python references: {missing}"
+
+
+def test_repository_paths_and_go_symbols_resolve() -> None:
+    checked: dict[str, str] = {}
+    for reference in sorted(_code_spans()):
+        error = _repository_reference_error(reference)
+        if error is not None:
+            checked[reference] = error
+
+    candidate_count = sum(
+        1
+        for reference in _code_spans()
+        if reference.startswith((*REPOSITORY_PREFIXES, "cmd/"))
+        or ("/" not in reference and reference.endswith(".md"))
+    )
+    assert candidate_count >= 15, "repository reference discovery became vacuous"
+    assert not checked, f"stale repository references: {checked}"

--- a/site/content/source/docs/known-limitations.md
+++ b/site/content/source/docs/known-limitations.md
@@ -2,7 +2,7 @@
 title: "Known Limitations"
 description: "This page distinguishes documented product boundaries from implementation bugs."
 source_path: "docs/known-limitations.md"
-source_sha256: "12c3bd4b2f90ec65e0f4f6d13937515ef0f1e6937d0dfd88607ea4b1c1624de8"
+source_sha256: "1b12458b1dfbdb486470bb3521ac5518288b4a87869b5919d370f44074f795c1"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["limitation"]
@@ -200,7 +200,7 @@ The full set of bounded-iat surfaces is now:
 - `vibap.attestation.verify_attestation` (round-4 FIX-R4-3)
 - `vibap.spiffe_identity.verify_jwt_svid` (round-4 FIX-R4-4)
 - `vibap.memory.GovernedMemoryStore.read` (round-5 FIX-R5-M3)
-- `vibap.tool_response_provenance.verify_tool_response_envelope` (round-5 FIX-R5-M4; uses tighter ±60s future window for short-lived tokens)
+- `vibap.tool_response_provenance.verify_envelope` (round-5 FIX-R5-M4; uses tighter ±60s future window for short-lived tokens)
 
 **Python parallel-format / non-JWT verifiers:**
 - `vibap.biscuit_passport.verify_biscuit_passport` (round-4 FIX-R4-1; round-5 FIX-R5-H5 walks every block, not just leaf)
@@ -270,42 +270,32 @@ sidecar today. Production deployments MUST configure one. This is
 documented here as a known limitation rather than a code-level fix
 because the right answer is deployment-environment-specific.
 
-## Bearer-token authentication on Go control-plane services (2026-04-29 round-5)
+## Python proxy bearer authentication is a shared-secret boundary
 
-Round-4 audit flagged that the Go Authority and Governor HTTP services
-were unauthenticated — anyone with network reach could mint credentials
-or ingest fabricated governance events. Round-5 closes both:
+The public tree does not ship the Go Authority or Governor HTTP services
+described by earlier audit-round documentation. The shipped HTTP control plane
+is `vibap.proxy.serve_proxy`. It requires authentication by default on every
+endpoint except `/health`, `/healthz`, and `/.well-known/jwks.json`.
 
-- `go/cmd/authority`: `/sign` and `/status` require
-  `Authorization: Bearer <authority-token>` matching `ARDUR_AUTHORITY_TOKEN`
-  (≥32 bytes). The binary refuses to start unless the token is set or
-  `--no-require-auth` is passed for explicit local-dev opt-out. Public
-  endpoints (`/attestation`, `/public-key`, `/healthz`) remain
-  unauthenticated since they advertise the trust anchor.
-- `go/pkg/governance.NewHandlerWithAuth` wires every `/v1/*` route
-  through a constant-time bearer-check. `cmd/governor/main.go` reads
-  `ARDUR_GOVERNOR_TOKEN` from env; `Validate()` refuses to start
-  without it (or without explicit `ARDUR_GOVERNOR_NO_REQUIRE_AUTH=1`
-  opt-out). `/healthz` and `/readyz` stay public for K8s probes.
+`VIBAP_API_TOKEN` takes precedence over the `--api-token` argument. When neither
+is supplied, the proxy generates a random 32-byte token. Expected and presented
+tokens are stripped at their entry points, the bearer scheme is accepted
+case-insensitively, and `vibap.proxy._api_token_compare_material` converts both
+values to equal-length material before `hmac.compare_digest` compares them. An
+explicit `--no-require-auth` remains available only for trusted local
+development.
 
-Both services use `crypto/subtle.ConstantTimeCompare` to defeat timing
-side-channel inference of the token. **Round-7+ also SHA-256-normalizes
-both presented and expected tokens before the constant-time compare**
-(`sha256.Sum256(token)` on each side, comparison over the 32-byte
-digests) — this defeats the length oracle that
-`subtle.ConstantTimeCompare` short-circuits on length-mismatched
-inputs. The Python proxy's `hmac.compare_digest` path does the same
-SHA-256 normalization. Production deployments SHOULD also front the
-services with mTLS at the ingress / service-mesh layer for
-defense-in-depth.
-
-Operator-supplied bearer tokens are `strings.TrimSpace`-ed (Go) /
-`.strip()`-ed (Python) at every entry point — env vars
-(`ARDUR_AUTHORITY_TOKEN`, `ARDUR_GOVERNOR_TOKEN`, `VIBAP_API_TOKEN`)
-and CLI args (`--api-token`) — so YAML-quoted secrets with leading
-or trailing whitespace authenticate correctly without operator
-debugging time. The bearer-scheme parse is RFC 9110-compliant
-case-insensitive (`Bearer`, `bearer`, `BEARER` all accepted).
+This is one process-wide bearer secret, not per-client identity or delegated
+authorization. The proxy does not assign client-specific scopes or expiry, and
+rotation requires restarting it with a new token. Any party holding the token
+can call every protected endpoint. Protect it in storage and in transit: bearer
+possession alone grants access, as defined by
+[RFC 6750](https://www.rfc-editor.org/rfc/rfc6750.html#section-1.2), and the RFC
+requires transport confidentiality. Ardur enables TLS by default; do not use
+`--no-tls` across an untrusted network. Python also documents that different
+input lengths can expose length information even when using
+[`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest),
+which is why Ardur compares fixed-width material.
 
 ## `_pinned_urlopen` semantics (2026-04-28 round-3)
 
@@ -322,7 +312,8 @@ error.
 
 ## AAT proof-of-possession default (2026-04-28 hardening)
 
-`material_from_aat_grant` and `GovernanceProxy.start_session_from_aat`
+`vibap.aat_adapter.material_from_aat_grant` and
+`vibap.proxy.GovernanceProxy.start_session_from_aat`
 default to `require_pop=True`. A cnf-bearing AAT presented without
 `holder_public_key` + `kb_jwt` now fails closed. Bearer-mode AATs
 (no `cnf` claim) continue to be accepted; library callers that


### PR DESCRIPTION
## Summary

- replace deleted Go Authority and Governor references with the authentication boundary actually shipped by the Python proxy
- correct an additional stale qualified Python verifier symbol
- add a static, side-effect-free regression for repository paths and qualified Python and Go code claims
- regenerate the source-backed known-limitations page

## Root cause and design

The affected documentation was accurate when commit 53ecbde contained the named Go services. Public-cleanup commit aa04c26 removed that implementation but left the limitation text behind.

This change does not reconstruct deleted or private behavior. Current public source and tests are the authority. The replacement documents the real process-wide bearer secret, public endpoints, comparison material, TLS requirement, and lack of per-client scope, expiry, or hot rotation.

The regression intentionally checks code-like references rather than every inline code span, so endpoints, flags, and wire values are not mistaken for repository symbols.

## Validation

- red baseline: exactly four stale references on the entry tree
- focused reference regression: 2 passed
- full Python suite: 1954 passed, 34 skipped
- Ruff check and format: passed for the new test
- source sync: 120 source pages / 117 artifacts; check passed
- package assets and public claims: passed
- repository quick check: passed
- Go vet: passed
- Hugo 0.161.1: 291 pages; rendered documentation links passed
- pre-commit: all configured hooks passed on changed files
- Gitleaks: 576 commits scanned, no leaks
- pip-audit: no known vulnerabilities, editable local package excluded
- diff hygiene: passed

The full Go sweep has one unrelated macOS baseline failure in the Linux-secure recognition benchmark report test. It reproduces from untouched dev and is tracked in #337. All other Go packages passed locally; hosted Linux checks remain the gate for this PR.

## Security and cost

The documentation no longer implies authentication controls on nonexistent services and now states the blast radius of a shared bearer secret. The security claims are grounded in RFC 6750, Python hmac documentation, and current implementation tests. This PR changes no runtime behavior, cloud resources, IAM, data flow, or paid service. Cost is limited to normal CI minutes.

## Documentation

README impact was reviewed. The root README contains none of the stale references, and docs/README.md already links this canonical page, so no README edit is needed.

Closes #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication and verification limitations, including Python proxy bearer-token behavior and exempt health/discovery endpoints.
  * Clarified token configuration, generation, rotation, comparison, and TLS expectations.
  * Updated references for bounded JWT timing and AAT proof-of-possession behavior.
  * Refreshed the mirrored documentation source hash.

* **Tests**
  * Added checks to ensure documented Python symbols, repository paths, and Go declarations remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->