### PR TITLE
test(go): split report publication tests by platform

### DIFF
--- a/go/cmd/ardur-agent-recognition-benchmark/main_test.go
+++ b/go/cmd/ardur-agent-recognition-benchmark/main_test.go
@@ -3,12 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
 
 func TestRunRejectsInvalidArgumentsWithoutEchoingPrivatePaths(t *testing.T) {
@@ -38,28 +35,5 @@ func TestRunRejectsUnknownProfileBeforeMeasurement(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), privatePath) {
 		t.Fatalf("stdout exposed private path: %s", stdout.String())
-	}
-}
-
-func TestWriteReportUsesOwnerOnlyAtomicOutputAndRejectsSymlinkDirectory(t *testing.T) {
-	report := &kernelcapture.AgentRecognitionBenchmarkReport{SchemaVersion: kernelcapture.AgentRecognitionBenchmarkReportSchema, ArtifactSHA256: strings.Repeat("a", 64)}
-	output := filepath.Join(t.TempDir(), "output")
-	if err := writeReport(output, report); err != nil {
-		t.Fatal(err)
-	}
-	if info, err := os.Stat(output); err != nil || info.Mode().Perm() != 0o700 {
-		t.Fatalf("output mode=%v error=%v", info.Mode().Perm(), err)
-	}
-	path := filepath.Join(output, reportFilename)
-	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
-		t.Fatalf("report mode=%v error=%v", info.Mode().Perm(), err)
-	}
-
-	link := filepath.Join(t.TempDir(), "output-link")
-	if err := os.Symlink(output, link); err != nil {
-		t.Fatal(err)
-	}
-	if err := writeReport(link, report); err == nil {
-		t.Fatal("symlink output directory was accepted")
 	}
 }

--- a/go/cmd/ardur-agent-recognition-benchmark/report_file_linux_test.go
+++ b/go/cmd/ardur-agent-recognition-benchmark/report_file_linux_test.go
@@ -17,12 +17,20 @@ func TestWriteReportUsesOwnerOnlyAtomicOutputAndRejectsSymlinkDirectory(t *testi
 	if err := writeReport(output, report); err != nil {
 		t.Fatal(err)
 	}
-	if info, err := os.Stat(output); err != nil || info.Mode().Perm() != 0o700 {
-		t.Fatalf("output mode=%v error=%v", info.Mode().Perm(), err)
+	outputInfo, err := os.Stat(output)
+	if err != nil {
+		t.Fatalf("stat output directory: %v", err)
+	}
+	if outputInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("output mode=%v, want 0700", outputInfo.Mode().Perm())
 	}
 	path := filepath.Join(output, reportFilename)
-	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
-		t.Fatalf("report mode=%v error=%v", info.Mode().Perm(), err)
+	reportInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat report: %v", err)
+	}
+	if reportInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("report mode=%v, want 0600", reportInfo.Mode().Perm())
 	}
 
 	link := filepath.Join(t.TempDir(), "output-link")

--- a/go/cmd/ardur-agent-recognition-benchmark/report_file_linux_test.go
+++ b/go/cmd/ardur-agent-recognition-benchmark/report_file_linux_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
 )
 
+func TestWriteReportUsesOwnerOnlyAtomicOutputAndRejectsSymlinkDirectory(t *testing.T) {
+	report := &kernelcapture.AgentRecognitionBenchmarkReport{SchemaVersion: kernelcapture.AgentRecognitionBenchmarkReportSchema, ArtifactSHA256: strings.Repeat("a", 64)}
+	output := filepath.Join(t.TempDir(), "output")
+	if err := writeReport(output, report); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(output); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("output mode=%v error=%v", info.Mode().Perm(), err)
+	}
+	path := filepath.Join(output, reportFilename)
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("report mode=%v error=%v", info.Mode().Perm(), err)
+	}
+
+	link := filepath.Join(t.TempDir(), "output-link")
+	if err := os.Symlink(output, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeReport(link, report); err == nil {
+		t.Fatal("symlink output directory was accepted")
+	}
+}
+
 func TestWriteReportRejectsSymlinkedParentAndExistingDestination(t *testing.T) {
 	report := &kernelcapture.AgentRecognitionBenchmarkReport{SchemaVersion: kernelcapture.AgentRecognitionBenchmarkReportSchema, ArtifactSHA256: strings.Repeat("a", 64)}
 	realParent := t.TempDir()

--- a/go/cmd/ardur-agent-recognition-benchmark/report_file_unsupported_test.go
+++ b/go/cmd/ardur-agent-recognition-benchmark/report_file_unsupported_test.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArdurAI/ardur/go/pkg/kernelcapture"
+)
+
+func TestWriteReportFailsClosedOnUnsupportedPlatform(t *testing.T) {
+	report := &kernelcapture.AgentRecognitionBenchmarkReport{
+		SchemaVersion:  kernelcapture.AgentRecognitionBenchmarkReportSchema,
+		ArtifactSHA256: strings.Repeat("a", 64),
+	}
+	output := filepath.Join(t.TempDir(), "output")
+
+	err := writeReport(output, report)
+	if err == nil || !strings.Contains(err.Error(), "secure benchmark report publication is unsupported outside Linux") {
+		t.Fatalf("writeReport() error = %v, want unsupported-platform error", err)
+	}
+	if _, statErr := os.Stat(output); !os.IsNotExist(statErr) {
+		t.Fatalf("unsupported platform created output: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

- keep portable argument and private-path-redaction tests active on every Go host
- move the unchanged owner-only mode and symlink-directory assertions into the existing Linux test suite
- add an explicit `!linux` fail-closed test that requires the unsupported error and no output creation

Closes #337.

## Root cause

`main_test.go` compiled Linux secure-publication success expectations on every host, while production intentionally selects `report_file_unsupported.go` outside Linux. macOS therefore failed the full Go sweep even though the runtime boundary was behaving as designed.

## Security and cost

No production file changes. Linux descriptor-relative no-follow traversal, owner-only modes, atomic no-replace publication, durability calls, and symlink-rejection coverage remain intact. Unsupported platforms remain fail closed. No IAM, secret, runtime, storage, or cloud-resource change; cost is limited to normal CI minutes.

A sealed diff-scoped security review covered all three changed files with full-file receipts and found zero candidates. Official `govulncheck` v1.6.0 reported no vulnerabilities; scoped secret scanning passed.

## Validation

- `cd go && go test -count=1 ./...`
- `cd go && go test -race -count=1 ./cmd/ardur-agent-recognition-benchmark`
- `cd go && go vet ./...`
- 20 repeated non-Linux fail-closed and argument tests on macOS
- cross-compiled Linux ARM64 test binary executed in a Linux container; all four package tests passed
- `./scripts/check-local.sh --quick`
- `govulncheck ./cmd/ardur-agent-recognition-benchmark`
- `git diff --check`

## Documentation

README and `docs/TESTING.md` were reviewed. No update is needed because runtime support and documented commands are unchanged; this patch corrects test selection only.

## Separate follow-ups

- #339 records bootstrap graph-artifact contract drift discovered during setup.
- #340 records the pre-existing Windows cross-build failure on Unix-only `syscall.Stat_t`.

Signed source head: `41852b330b5c97464bd235b2251f2e42cca23575`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded security coverage for report generation by verifying owner-only directory permissions and owner-only report file permissions.
  * Added a check that using a symlinked output directory is rejected.
  * Added a non-Linux test to confirm report generation fails safely without creating output files.
  * Consolidated benchmark execution tests to keep argument-validation coverage while removing redundant cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->