### PR TITLE
fix(go): make daemon preflight ownership portable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,6 +179,17 @@ jobs:
         working-directory: go
         run: go vet ./...
 
+      - name: Cross-compile Windows portability targets
+        working-directory: go
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+        run: |
+          go test -c -o "${{ runner.temp }}/kernelcapture-windows.test.exe" ./pkg/kernelcapture
+          go test -c -o "${{ runner.temp }}/kernelcaptured-windows.test.exe" ./cmd/ardur-kernelcaptured
+          go test -c -o "${{ runner.temp }}/recognition-benchmark-windows.test.exe" ./cmd/ardur-agent-recognition-benchmark
+
       - name: Upload agent-recognition corpus report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -160,6 +160,11 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
   directories unless a test explicitly directs output elsewhere. Coverage data
   and the uploaded XML report are written to the GitHub runner temp directory.
 - **Go job**: runs `go test -count=1 ./...` and `go vet ./...` from `go/`.
+- **Windows portability compile**: the Go job also cross-compiles
+  `pkg/kernelcapture`, `ardur-kernelcaptured`, and the agent-recognition
+  benchmark command for `windows/amd64` without executing them. This guards
+  portable import boundaries; it does not claim Windows kernel capture or
+  enforcement support.
 - **Demo stack smoke**: starts the exact `make demo` target from fresh Compose
   volumes in detached/wait mode, then runs `scripts/verify-mvp.sh`. The job
   requires healthy public endpoints, authenticated issue/start, one `PERMIT`,

--- a/go/pkg/kernelcapture/daemon_preflight.go
+++ b/go/pkg/kernelcapture/daemon_preflight.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 const (
@@ -441,10 +440,6 @@ func (osDaemonPreflightFS) EvalSymlinks(path string) (string, error) {
 }
 
 func daemonPreflightPathInfoFromFileInfo(info fs.FileInfo) daemonPreflightPathInfo {
-	out := daemonPreflightPathInfo{Mode: info.Mode(), UID: -1, GID: -1}
-	if st, ok := info.Sys().(*syscall.Stat_t); ok {
-		out.UID = int(st.Uid)
-		out.GID = int(st.Gid)
-	}
-	return out
+	uid, gid := daemonPreflightFileOwner(info.Sys())
+	return daemonPreflightPathInfo{Mode: info.Mode(), UID: uid, GID: gid}
 }

--- a/go/pkg/kernelcapture/daemon_preflight_owner_unix.go
+++ b/go/pkg/kernelcapture/daemon_preflight_owner_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package kernelcapture
+
+import "syscall"
+
+func daemonPreflightFileOwner(systemInfo any) (int, int) {
+	if stat, ok := systemInfo.(*syscall.Stat_t); ok {
+		return int(stat.Uid), int(stat.Gid)
+	}
+	return -1, -1
+}

--- a/go/pkg/kernelcapture/daemon_preflight_owner_unix_test.go
+++ b/go/pkg/kernelcapture/daemon_preflight_owner_unix_test.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package kernelcapture
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDaemonPreflightFileOwnerExtractsUnixOwnership(t *testing.T) {
+	t.Parallel()
+
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temporary directory: %v", err)
+	}
+	uid, gid := daemonPreflightFileOwner(info.Sys())
+	if uid != os.Getuid() || gid != os.Getgid() {
+		t.Fatalf("owner = %d:%d, want current process owner %d:%d", uid, gid, os.Getuid(), os.Getgid())
+	}
+}

--- a/go/pkg/kernelcapture/daemon_preflight_owner_unsupported.go
+++ b/go/pkg/kernelcapture/daemon_preflight_owner_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package kernelcapture
+
+func daemonPreflightFileOwner(_ any) (int, int) {
+	return -1, -1
+}

--- a/go/pkg/kernelcapture/daemon_preflight_test.go
+++ b/go/pkg/kernelcapture/daemon_preflight_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func TestDaemonPreflightFileOwnerDefaultsToUnknown(t *testing.T) {
+	t.Parallel()
+
+	uid, gid := daemonPreflightFileOwner(nil)
+	if uid != -1 || gid != -1 {
+		t.Fatalf("owner = %d:%d, want unknown -1:-1", uid, gid)
+	}
+}
+
 func TestInspectDaemonCustodyPreflightSafeDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/site/content/source/docs/TESTING.md
+++ b/site/content/source/docs/TESTING.md
@@ -2,7 +2,7 @@
 title: "Testing"
 description: "The public tree includes curated Python and Go runtime code under `python/`"
 source_path: "docs/TESTING.md"
-source_sha256: "330d9522a5d47a28e43be71088afc8f5a8111b9121c4852c240f934b79014c34"
+source_sha256: "1e2831af42ca865d13e1238028e56b672da9a842b2ecb5c671ef06d03f6d3108"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -177,6 +177,11 @@ This workflow exists because a misplaced comma in a JSON schema or a stray inden
   directories unless a test explicitly directs output elsewhere. Coverage data
   and the uploaded XML report are written to the GitHub runner temp directory.
 - **Go job**: runs `go test -count=1 ./...` and `go vet ./...` from `go/`.
+- **Windows portability compile**: the Go job also cross-compiles
+  `pkg/kernelcapture`, `ardur-kernelcaptured`, and the agent-recognition
+  benchmark command for `windows/amd64` without executing them. This guards
+  portable import boundaries; it does not claim Windows kernel capture or
+  enforcement support.
 - **Demo stack smoke**: starts the exact `make demo` target from fresh Compose
   volumes in detached/wait mode, then runs `scripts/verify-mvp.sh`. The job
   requires healthy public endpoints, authenticated issue/start, one `PERMIT`,

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -179,6 +179,17 @@ jobs:
         working-directory: go
         run: go vet ./...
 
+      - name: Cross-compile Windows portability targets
+        working-directory: go
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+        run: |
+          go test -c -o "${{ runner.temp }}/kernelcapture-windows.test.exe" ./pkg/kernelcapture
+          go test -c -o "${{ runner.temp }}/kernelcaptured-windows.test.exe" ./cmd/ardur-kernelcaptured
+          go test -c -o "${{ runner.temp }}/recognition-benchmark-windows.test.exe" ./cmd/ardur-agent-recognition-benchmark
+
       - name: Upload agent-recognition corpus report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Relevant issues

Fixes #340

## Type

- [x] `fix` — bug fix
- [x] `ci` — CI / workflow / tooling

## Changes

- move Unix UID/GID extraction behind the standard `unix` build constraint while keeping mode handling portable
- return explicit unknown ownership (`-1:-1`) on non-Unix targets so custody preflight remains fail closed
- test the nil-metadata fallback and the real Unix `fs.FileInfo.Sys()` adapter
- cross-compile the kernelcapture package and both representative commands for `windows/amd64` in the required Go job
- document that this is a compile-portability gate, not Windows kernel capture or enforcement support

## Testing

- reproduced the untouched-base `GOOS=windows` failure in `pkg/kernelcapture` and the recognition benchmark importer
- `go test -count=1 ./...`
- `go test -race` for `pkg/kernelcapture`, `ardur-kernelcaptured`, and the recognition benchmark
- `go vet ./...`
- cross-compiled all three required targets for `windows/amd64`
- cross-compiled representative Unix targets; iOS used its required cgo/external-link mode
- executed fresh Linux arm64 package and command test binaries in isolated Alpine containers
- `./scripts/check-local.sh --quick`
- parsed the changed workflow YAML and ran `git diff --check`
- `govulncheck v1.6.0`: no reachable vulnerabilities
- Trivy: no high/critical dependency vulnerabilities and no secrets in changed files
- exhaustive sealed security diff review: complete seven-file coverage, no deferred rows, no findings

## Security and cost

The ownership check remains fail closed when platform metadata is unavailable. The change adds bounded CI compile time only; it introduces no dependency, service, cloud, IAM, data-transfer, or runtime cost.

## Graduation gates (for `dev → main` PRs only)

Not applicable; this PR targets `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix preflight handling for determining file ownership during checks, with more reliable UID/GID extraction and graceful fallback when ownership data can’t be read.

* **Tests**
  * Added unit coverage for Unix ownership extraction and for unknown owner/group default behavior.
  * Added CI cross-compilation verification for key Go components targeting Windows/amd64.

* **Documentation**
  * Updated testing documentation to reflect the additional Windows portability cross-compilation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->