### PR TITLE
fix(docs): make bootstrap graph artifacts conditional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,14 @@ Run the Conductor bootstrap before doing task-specific work:
 ./scripts/conductor-bootstrap.sh
 ```
 
-Then read `.context/ARDUR_CONTEXT.md` and `.context/ardur-graph.md`. The JSON
-graph at `.context/ardur-graph.json` is the machine-readable map of the repo.
+Then read `.context/ARDUR_CONTEXT.md`. Its **Generated Graph** section is the
+authority for graph availability:
+
+- When the status is `available`, read `.context/ardur-graph.md` and use
+  `.context/ardur-graph.json` as the machine-readable map of the repo.
+- When the status is `unavailable`, continue with the live source and workflow
+  files listed in the context. Missing graph artifacts are optional in this
+  path and are not a bootstrap failure.
 
 If the bootstrap fails, stop and inspect the failure before editing files. A
 failed bootstrap usually means the local toolchain, branch state, or generated
@@ -91,7 +97,7 @@ tracked.
 ## Local Commands
 
 ```bash
-# Generate fresh Conductor context and graph.
+# Generate fresh Conductor context and, when supported, graph artifacts.
 ./scripts/conductor-bootstrap.sh
 
 # Create/update local Python dev env and check Go toolchain.

--- a/docs/agent-instructions/claude.md
+++ b/docs/agent-instructions/claude.md
@@ -12,7 +12,7 @@ plus the Claude-specific rules below.
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/docs/agent-instructions/claude.md
+++ b/docs/agent-instructions/claude.md
@@ -13,8 +13,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Claude-Specific Rules
 

--- a/docs/agent-instructions/codex.md
+++ b/docs/agent-instructions/codex.md
@@ -13,8 +13,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Codex-Specific Rules
 

--- a/docs/agent-instructions/codex.md
+++ b/docs/agent-instructions/codex.md
@@ -12,7 +12,7 @@ Codex-specific rules below.
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/docs/agent-instructions/conductor.md
+++ b/docs/agent-instructions/conductor.md
@@ -13,8 +13,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Conductor-Specific Rules
 

--- a/docs/agent-instructions/conductor.md
+++ b/docs/agent-instructions/conductor.md
@@ -12,7 +12,7 @@ Conductor workspaces are parallel, branch-isolated working areas. Follow the
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/docs/agent-instructions/shared.md
+++ b/docs/agent-instructions/shared.md
@@ -7,9 +7,12 @@ future automation.
 
 1. Run `./scripts/conductor-bootstrap.sh`.
 2. Read `.context/ARDUR_CONTEXT.md`.
-3. Read `.context/ardur-graph.md`.
-4. Use `.context/ardur-graph.json` as the structural map, then verify exact
-   behavior with source files and tests.
+3. Check its **Generated Graph** section.
+4. When the graph status is `available`, read `.context/ardur-graph.md` and use
+   `.context/ardur-graph.json` as the structural map, then verify exact behavior
+   with source files and tests.
+5. When the graph status is `unavailable`, use the listed live source and
+   workflow files directly. Missing graph artifacts are optional in this path.
 
 If bootstrap fails, stop and fix or report the bootstrap problem before making
 task-specific edits.

--- a/docs/conductor-bootstrap.md
+++ b/docs/conductor-bootstrap.md
@@ -1,13 +1,15 @@
 # Conductor Bootstrap
 
 The Conductor bootstrap script (`scripts/conductor-bootstrap.sh`) generates a
-machine-readable context map for coding agents that work in this repository.
+human-readable context summary for coding agents that work in this repository.
+It also generates graph artifacts when the public checkout contains the graph
+builder.
 
 ## Prerequisites
 
-- Python 3.10+ with the repo's virtual environment at `python/.venv/`
+- Python 3.10+
 - Git (the script checks branch state and remote defaults)
-- A clean working tree (the script will warn if there are uncommitted changes)
+- A working tree whose current state should be recorded in the context summary
 
 ## Running it
 
@@ -15,11 +17,22 @@ machine-readable context map for coding agents that work in this repository.
 ./scripts/conductor-bootstrap.sh
 ```
 
-This produces:
+This always produces:
 
 - `.context/ARDUR_CONTEXT.md` — human-readable context summary
+- `.context/skills/README.md` — local-only skill-storage guardrails
+
+When `scripts/build-knowledge-graph.py` is present, a successful run also
+produces all three graph artifacts:
+
 - `.context/ardur-graph.md` — dependency graph of repo modules
 - `.context/ardur-graph.json` — machine-readable graph (JSON)
+- `.context/ardur-graph.mmd` — Mermaid graph view
+
+When the builder is absent, bootstrap still succeeds and marks the graph as
+`unavailable` in `.context/ARDUR_CONTEXT.md`. The graph files are optional in
+that path. If the builder is present but fails to produce any required graph
+artifact, bootstrap fails instead of advertising a partial result.
 
 All `.context/` artifacts are local-only and excluded from version control.
 They are regenerated each run, not accumulated.
@@ -29,16 +42,22 @@ They are regenerated each run, not accumulated.
 After bootstrap succeeds, read these in order:
 
 1. `.context/ARDUR_CONTEXT.md` — your session context summary
-2. `.context/ardur-graph.md` — module dependency graph
-3. `AGENTS.md` — mandatory agent instructions (this file lives at the repo root)
-4. `docs/engineering-standards.md` — foundation, testing, review, and security rules
+2. If its **Generated Graph** status is `available`, read
+   `.context/ardur-graph.md` and use `.context/ardur-graph.json` as the
+   machine-readable map
+3. If its graph status is `unavailable`, use the listed live source and
+   workflow files directly
+4. `AGENTS.md` — mandatory agent instructions (this file lives at the repo root)
+5. `docs/engineering-standards.md` — foundation, testing, review, and security rules
 
 ## If bootstrap fails
 
 A failed bootstrap usually means one of:
 
-- The Python virtual environment is missing (`./scripts/setup-dev.sh`)
-- The knowledge-graph script is not yet implemented (expected — see `scripts/check-local.sh`)
+- A usable Python interpreter or graph-builder dependency is missing when the
+  optional builder is present
+- A present knowledge-graph builder returned invalid data or omitted a required
+  graph artifact
 - The working tree has untracked files that conflict with generated paths
 
 Inspect the failure message before editing files. A failed bootstrap means the
@@ -49,7 +68,7 @@ local toolchain, branch state, or generated context is not trustworthy yet.
 Agents working in this repo must:
 
 1. Run `./scripts/conductor-bootstrap.sh` at session start
-2. Read `.context/ARDUR_CONTEXT.md` and `.context/ardur-graph.md`
+2. Read `.context/ARDUR_CONTEXT.md` and follow its graph-availability status
 3. Follow the workspace contract in `AGENTS.md`
 4. Preserve user WIP — do not reset, checkout, or clean unrelated local changes
 5. Keep all generated context under `.context/` (gitignored)

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -38,7 +38,8 @@ specific company.
 
 ## Work Process
 
-- Start every Conductor session with `./scripts/conductor-bootstrap.sh`.
+- Start every Conductor session with `./scripts/conductor-bootstrap.sh`, then
+  follow the generated context's graph-availability status.
 - Target `dev` for normal implementation work. `main` is release-only and
   should receive promoted work from `dev` after verification.
 - Before editing, state the task-specific success criteria in plain language.
@@ -154,7 +155,9 @@ specific company.
 
 - Bootstrap first, then inspect.
 - Do not trust memory when the repo can answer directly.
-- Use `.context/ardur-graph.json` to find likely files, then verify with source.
+- When the generated context reports the graph as available, use
+  `.context/ardur-graph.json` to find likely files, then verify with source. If
+  it is unavailable, inspect live source and workflow files directly.
 - Do not edit generated `.context/` files except by running bootstrap/index
   scripts.
 - Never create secret-bearing fixtures for convenience.

--- a/python/tests/test_conductor_bootstrap_contract.py
+++ b/python/tests/test_conductor_bootstrap_contract.py
@@ -39,7 +39,14 @@ def _section(document: str, heading: str) -> str:
     return match.group("body")
 
 
-def _fixture_repo(tmp_path: Path, *, complete_graph: bool | None) -> Path:
+def _fixture_repo(
+    tmp_path: Path,
+    *,
+    complete_graph: bool | None,
+    empty_graph_artifact: str | None = None,
+) -> Path:
+    assert empty_graph_artifact in (None, "ardur-graph.md", "ardur-graph.mmd")
+    assert empty_graph_artifact is None or complete_graph is True
     repo = tmp_path / "repo"
     scripts = repo / "scripts"
     scripts.mkdir(parents=True)
@@ -66,8 +73,14 @@ output.mkdir(parents=True, exist_ok=True)
     encoding="utf-8",
 )
 if {complete_graph!r}:
-    (output / "ardur-graph.md").write_text("# Graph\\n", encoding="utf-8")
-    (output / "ardur-graph.mmd").write_text("graph TD\\n", encoding="utf-8")
+    (output / "ardur-graph.md").write_text(
+        {"" if empty_graph_artifact == "ardur-graph.md" else "# Graph\\n"!r},
+        encoding="utf-8",
+    )
+    (output / "ardur-graph.mmd").write_text(
+        {"" if empty_graph_artifact == "ardur-graph.mmd" else "graph TD\\n"!r},
+        encoding="utf-8",
+    )
 """,
             encoding="utf-8",
         )
@@ -191,6 +204,23 @@ def test_present_graph_builder_must_produce_the_complete_artifact_set(
     stale_context = repo / ".context" / "ARDUR_CONTEXT.md"
     stale_context.parent.mkdir()
     stale_context.write_text("# stale successful context\n", encoding="utf-8")
+    completed = _run_fixture_bootstrap(repo)
+
+    assert completed.returncode != 0
+    assert "graph builder did not produce required artifact" in completed.stderr
+    assert not (repo / ".context" / "ARDUR_CONTEXT.md").exists()
+
+
+def test_present_graph_builder_must_produce_nonempty_artifacts(
+    tmp_path: Path,
+) -> None:
+    """An empty graph artifact must fail before success context is emitted."""
+
+    repo = _fixture_repo(
+        tmp_path,
+        complete_graph=True,
+        empty_graph_artifact="ardur-graph.mmd",
+    )
     completed = _run_fixture_bootstrap(repo)
 
     assert completed.returncode != 0

--- a/python/tests/test_conductor_bootstrap_contract.py
+++ b/python/tests/test_conductor_bootstrap_contract.py
@@ -53,6 +53,12 @@ def _fixture_repo(
     shutil.copy2(BOOTSTRAP, scripts / BOOTSTRAP.name)
     (repo / ".gitignore").write_text(".context/\n", encoding="utf-8")
     if complete_graph is not None:
+        graph_markdown = (
+            "" if empty_graph_artifact == "ardur-graph.md" else "# Graph\n"
+        )
+        graph_mermaid = (
+            "" if empty_graph_artifact == "ardur-graph.mmd" else "graph TD\n"
+        )
         (scripts / "build-knowledge-graph.py").write_text(
             f"""\
 import json
@@ -74,11 +80,11 @@ output.mkdir(parents=True, exist_ok=True)
 )
 if {complete_graph!r}:
     (output / "ardur-graph.md").write_text(
-        {"" if empty_graph_artifact == "ardur-graph.md" else "# Graph\\n"!r},
+        {graph_markdown!r},
         encoding="utf-8",
     )
     (output / "ardur-graph.mmd").write_text(
-        {"" if empty_graph_artifact == "ardur-graph.mmd" else "graph TD\\n"!r},
+        {graph_mermaid!r},
         encoding="utf-8",
     )
 """,

--- a/python/tests/test_conductor_bootstrap_contract.py
+++ b/python/tests/test_conductor_bootstrap_contract.py
@@ -1,0 +1,220 @@
+"""Regression coverage for the Conductor bootstrap output contract."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "scripts" / "conductor-bootstrap.sh"
+GRAPH_ARTIFACTS = (
+    ".context/ardur-graph.json",
+    ".context/ardur-graph.md",
+    ".context/ardur-graph.mmd",
+)
+LOCAL_ARTIFACTS = (
+    ".context/ARDUR_CONTEXT.md",
+    *GRAPH_ARTIFACTS,
+    ".context/skills/README.md",
+)
+AUTHORITATIVE_STARTUP_DOCS = (
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "docs" / "agent-instructions" / "shared.md",
+    REPO_ROOT / "docs" / "conductor-bootstrap.md",
+)
+
+
+def _section(document: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^## |\Z)",
+        document,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"missing section: {heading}"
+    return match.group("body")
+
+
+def _fixture_repo(tmp_path: Path, *, complete_graph: bool | None) -> Path:
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(BOOTSTRAP, scripts / BOOTSTRAP.name)
+    (repo / ".gitignore").write_text(".context/\n", encoding="utf-8")
+    if complete_graph is not None:
+        (scripts / "build-knowledge-graph.py").write_text(
+            f"""\
+import json
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[sys.argv.index("--output-dir") + 1])
+output.mkdir(parents=True, exist_ok=True)
+(output / "ardur-graph.json").write_text(
+    json.dumps({{
+        "counts": {{"nodes": 1, "edges": 0, "nodes_by_type": {{"test": 1}}}},
+        "repo": {{
+            "indexed_file_count": 1,
+            "tracked_file_count": 2,
+            "untracked_file_count": 0,
+        }},
+    }}),
+    encoding="utf-8",
+)
+if {complete_graph!r}:
+    (output / "ardur-graph.md").write_text("# Graph\\n", encoding="utf-8")
+    (output / "ardur-graph.mmd").write_text("graph TD\\n", encoding="utf-8")
+""",
+            encoding="utf-8",
+        )
+    subprocess.run(("git", "init", "--quiet"), cwd=repo, check=True)
+    subprocess.run(("git", "add", "--all"), cwd=repo, check=True)
+    subprocess.run(
+        (
+            "git",
+            "-c",
+            "user.name=Bootstrap Contract Test",
+            "-c",
+            "user.email=bootstrap-contract@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ),
+        cwd=repo,
+        check=True,
+    )
+    return repo
+
+
+def _run_fixture_bootstrap(repo: Path) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "ARDUR_BASE_REF": "HEAD",
+            "ARDUR_RELEASE_REF": "HEAD",
+            "PYTHON_BIN": sys.executable,
+        }
+    )
+    return subprocess.run(
+        (str(repo / "scripts" / BOOTSTRAP.name),),
+        cwd=repo,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_no_generator_bootstrap_only_advertises_existing_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Successful fallback bootstrap output must not require absent graph files."""
+
+    repo = _fixture_repo(tmp_path, complete_graph=None)
+    context_dir = tmp_path / "generated" / ".context"
+    context_dir.mkdir(parents=True)
+    for filename in ("ardur-graph.json", "ardur-graph.md", "ardur-graph.mmd"):
+        (context_dir / filename).write_text("stale graph\n", encoding="utf-8")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "ARDUR_BASE_REF": "HEAD",
+            "ARDUR_RELEASE_REF": "HEAD",
+            "ARDUR_CONTEXT_DIR": str(context_dir),
+        }
+    )
+
+    completed = subprocess.run(
+        (str(repo / "scripts" / BOOTSTRAP.name),),
+        cwd=repo,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    context = (context_dir / "ARDUR_CONTEXT.md").read_text(encoding="utf-8")
+    required_reading = _section(context, "## Required Reading Order")
+    graph_status = _section(context, "## Generated Graph")
+    generated_files = _section(context, "## Generated Files")
+
+    assert "unavailable" in graph_status.lower()
+    assert "live source files and workflow files" in graph_status
+    for relative in GRAPH_ARTIFACTS:
+        assert relative not in required_reading
+        assert relative not in generated_files
+        assert not (context_dir / Path(relative).name).exists()
+
+    advertised = re.findall(r"^- `(?P<path>[^`]+)`$", generated_files, re.MULTILINE)
+    assert advertised
+    for relative in advertised:
+        path = Path(relative)
+        assert path.is_absolute()
+        assert path.is_file(), relative
+
+
+def test_bootstrap_artifacts_are_local_only() -> None:
+    """Every possible bootstrap output must remain excluded from normal staging."""
+
+    for relative in LOCAL_ARTIFACTS:
+        completed = subprocess.run(
+            ("git", "check-ignore", "--quiet", relative),
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        assert completed.returncode == 0, relative
+
+
+def test_authoritative_startup_docs_make_graph_reads_conditional() -> None:
+    """The public startup contract must describe both graph availability paths."""
+
+    for path in AUTHORITATIVE_STARTUP_DOCS:
+        content = path.read_text(encoding="utf-8")
+        assert "Generated Graph" in content, path
+        assert "`available`" in content, path
+        assert "`unavailable`" in content, path
+        assert "optional" in content.lower(), path
+
+
+def test_present_graph_builder_must_produce_the_complete_artifact_set(
+    tmp_path: Path,
+) -> None:
+    """A partial graph build must fail before success-looking context is emitted."""
+
+    repo = _fixture_repo(tmp_path, complete_graph=False)
+    stale_context = repo / ".context" / "ARDUR_CONTEXT.md"
+    stale_context.parent.mkdir()
+    stale_context.write_text("# stale successful context\n", encoding="utf-8")
+    completed = _run_fixture_bootstrap(repo)
+
+    assert completed.returncode != 0
+    assert "graph builder did not produce required artifact" in completed.stderr
+    assert not (repo / ".context" / "ARDUR_CONTEXT.md").exists()
+
+
+def test_complete_graph_builder_advertises_every_generated_artifact(
+    tmp_path: Path,
+) -> None:
+    """The graph-present path must list only the complete readable artifact set."""
+
+    repo = _fixture_repo(tmp_path, complete_graph=True)
+    completed = _run_fixture_bootstrap(repo)
+
+    assert completed.returncode == 0, completed.stderr
+    context = (repo / ".context" / "ARDUR_CONTEXT.md").read_text(encoding="utf-8")
+    required_reading = _section(context, "## Required Reading Order")
+    graph_status = _section(context, "## Generated Graph")
+    generated_files = _section(context, "## Generated Files")
+
+    assert "Status: available" in graph_status
+    for relative in GRAPH_ARTIFACTS:
+        assert relative in generated_files
+        assert (repo / relative).is_file()
+    assert ".context/ardur-graph.md" in required_reading
+    assert ".context/ardur-graph.json" in required_reading

--- a/scripts/conductor-bootstrap.sh
+++ b/scripts/conductor-bootstrap.sh
@@ -8,6 +8,9 @@ BASE_REF="${ARDUR_BASE_REF:-origin/dev}"
 RELEASE_REF="${ARDUR_RELEASE_REF:-origin/main}"
 CONTEXT_DIR="${ARDUR_CONTEXT_DIR:-.context}"
 CONTEXT_FILE="$CONTEXT_DIR/ARDUR_CONTEXT.md"
+GRAPH_JSON="$CONTEXT_DIR/ardur-graph.json"
+GRAPH_MARKDOWN="$CONTEXT_DIR/ardur-graph.md"
+GRAPH_MERMAID="$CONTEXT_DIR/ardur-graph.mmd"
 PYTHON_BIN="${PYTHON_BIN:-}"
 
 if [ -z "$PYTHON_BIN" ]; then
@@ -97,10 +100,20 @@ else
   worktree_diff_names="$(printf '%s\n%s\n' "$worktree_diff_names" "$untracked_names" | sed '/^$/d')"
 fi
 
+rm -f -- "$CONTEXT_FILE" "$GRAPH_JSON" "$GRAPH_MARKDOWN" "$GRAPH_MERMAID"
+
+graph_required_reading=""
 if [ -f scripts/build-knowledge-graph.py ]; then
   "$PYTHON_BIN" scripts/build-knowledge-graph.py --output-dir "$CONTEXT_DIR"
 
-  graph_summary="$("$PYTHON_BIN" - "$CONTEXT_DIR/ardur-graph.json" <<'PY'
+  for graph_file in "$GRAPH_JSON" "$GRAPH_MARKDOWN" "$GRAPH_MERMAID"; do
+    if [ ! -f "$graph_file" ] || [ ! -s "$graph_file" ]; then
+      printf 'error: graph builder did not produce required artifact: %s\n' "$graph_file" >&2
+      exit 1
+    fi
+  done
+
+  graph_counts="$("$PYTHON_BIN" - "$GRAPH_JSON" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -117,10 +130,47 @@ for kind, count in counts["nodes_by_type"].items():
         print(f"- {kind}: `{count}`")
 PY
 )"
+  graph_summary="- Status: available
+$graph_counts"
+  graph_required_reading="- \`$GRAPH_MARKDOWN\`
+- \`$GRAPH_JSON\`"
+  generated_files="- \`$CONTEXT_FILE\`
+- \`$GRAPH_JSON\`
+- \`$GRAPH_MARKDOWN\`
+- \`$GRAPH_MERMAID\`
+- \`$CONTEXT_DIR/skills/README.md\`"
+  graph_rule="The generated graph is available. Use its Markdown view to choose a
+neighborhood and its JSON form as the machine-readable map, then verify exact
+behavior with \`rg\`, tests, and source files."
 else
-  graph_summary="- Graph build skipped: scripts/build-knowledge-graph.py is not tracked in this checkout. Use live source files and workflow files directly."
+  graph_summary="- Status: unavailable
+- Reason: \`scripts/build-knowledge-graph.py\` is not tracked in this checkout.
+- Fallback: use live source files and workflow files directly."
+  generated_files="- \`$CONTEXT_FILE\`
+- \`$CONTEXT_DIR/skills/README.md\`"
+  graph_rule="Graph artifacts are optional and unavailable in this checkout. Use \`rg\`,
+tests, live source files, and workflow files directly; do not treat an absent
+graph as a bootstrap failure."
 fi
 
+required_reading="- \`AGENTS.md\`"
+if [ -n "$graph_required_reading" ]; then
+  required_reading="$required_reading
+$graph_required_reading"
+fi
+required_reading="$required_reading
+- \`README.md\`
+- \`STATUS.md\`
+- \`docs/agent-instructions/README.md\`
+- \`docs/agent-instructions/shared.md\`
+- \`docs/engineering-standards.md\`
+- \`docs/conductor-bootstrap.md\`
+- \`docs/public-import-plan.md\`
+- \`docs/TESTING.md\`
+- \`.github/workflows/tests.yml\`"
+
+# sed uses an EOL anchor and literal Markdown backticks.
+# shellcheck disable=SC2016
 workflow_list="$(git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' | sed 's/^/- `/; s/$/`/')"
 if [ -z "$workflow_list" ]; then
   workflow_list="- no workflows tracked"
@@ -188,17 +238,7 @@ of truth and update stale docs when touching that area.
 
 ## Required Reading Order
 
-1. \`AGENTS.md\`
-2. \`.context/ardur-graph.md\`
-3. \`README.md\`
-4. \`STATUS.md\`
-5. \`docs/agent-instructions/README.md\`
-6. \`docs/agent-instructions/shared.md\`
-7. \`docs/engineering-standards.md\`
-8. \`docs/conductor-bootstrap.md\`
-9. \`docs/public-import-plan.md\`
-10. \`docs/TESTING.md\`
-11. \`.github/workflows/tests.yml\`
+$required_reading
 
 ## Branch Flow
 
@@ -211,12 +251,9 @@ of truth and update stale docs when touching that area.
 
 $graph_summary
 
-Files:
+## Generated Files
 
-- \`.context/ardur-graph.json\`
-- \`.context/ardur-graph.md\`
-- \`.context/ardur-graph.mmd\`
-- \`.context/skills/README.md\`
+$generated_files
 
 ## Local-Only Skill Guardrail
 
@@ -229,9 +266,10 @@ become tracked.
 
 ## Bootstrap Rule For Agents
 
-Use the graph to pick a neighborhood, then use \`rg\`, tests, and source files
-to verify exact behavior. Do not infer current state from memory or articles
-when the repo can answer the question directly.
+$graph_rule
+
+Do not infer current state from memory or articles when the repo can
+answer the question directly.
 EOF
 
 printf 'wrote %s\n' "$CONTEXT_FILE"

--- a/site/content/source/AGENTS.md
+++ b/site/content/source/AGENTS.md
@@ -2,7 +2,7 @@
 title: "Ardur Agent Instructions"
 description: "These instructions are mandatory for coding agents working in this repository."
 source_path: "AGENTS.md"
-source_sha256: "0af09f7ce695fdbc95368bffa4e09aef0f5069014a67d0f08569d224ce1c9ad0"
+source_sha256: "9a9057e71657585b4eaf5cf06e4fc45f0f8f08978392f9884ee9bd3185c855b1"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -27,8 +27,14 @@ Run the Conductor bootstrap before doing task-specific work:
 ./scripts/conductor-bootstrap.sh
 ```
 
-Then read `.context/ARDUR_CONTEXT.md` and `.context/ardur-graph.md`. The JSON
-graph at `.context/ardur-graph.json` is the machine-readable map of the repo.
+Then read `.context/ARDUR_CONTEXT.md`. Its **Generated Graph** section is the
+authority for graph availability:
+
+- When the status is `available`, read `.context/ardur-graph.md` and use
+  `.context/ardur-graph.json` as the machine-readable map of the repo.
+- When the status is `unavailable`, continue with the live source and workflow
+  files listed in the context. Missing graph artifacts are optional in this
+  path and are not a bootstrap failure.
 
 If the bootstrap fails, stop and inspect the failure before editing files. A
 failed bootstrap usually means the local toolchain, branch state, or generated
@@ -108,7 +114,7 @@ tracked.
 ## Local Commands
 
 ```bash
-# Generate fresh Conductor context and graph.
+# Generate fresh Conductor context and, when supported, graph artifacts.
 ./scripts/conductor-bootstrap.sh
 
 # Create/update local Python dev env and check Go toolchain.

--- a/site/content/source/docs/agent-instructions/claude.md
+++ b/site/content/source/docs/agent-instructions/claude.md
@@ -2,7 +2,7 @@
 title: "Claude Agent Instructions"
 description: "Claude and Claude Code should follow the [Shared Agent Contract](shared.md),"
 source_path: "docs/agent-instructions/claude.md"
-source_sha256: "e674a89d2abb2b9c3a23ad2d016a060b30d218f5183d4af060a72565c822a3cb"
+source_sha256: "1557a4416d1009f1b9f0569bcf00436e96e5eb748ed59a907ab8d1f691351361"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -29,7 +29,7 @@ plus the Claude-specific rules below.
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/site/content/source/docs/agent-instructions/claude.md
+++ b/site/content/source/docs/agent-instructions/claude.md
@@ -2,7 +2,7 @@
 title: "Claude Agent Instructions"
 description: "Claude and Claude Code should follow the [Shared Agent Contract](shared.md),"
 source_path: "docs/agent-instructions/claude.md"
-source_sha256: "1557a4416d1009f1b9f0569bcf00436e96e5eb748ed59a907ab8d1f691351361"
+source_sha256: "86d99ce5c67aa048f302a13b008c265aa4dd92154f039140995c8a7e13e6b427"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -30,8 +30,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Claude-Specific Rules
 

--- a/site/content/source/docs/agent-instructions/codex.md
+++ b/site/content/source/docs/agent-instructions/codex.md
@@ -2,7 +2,7 @@
 title: "Codex Agent Instructions"
 description: "Codex should follow the [Shared Agent Contract](shared.md), plus the"
 source_path: "docs/agent-instructions/codex.md"
-source_sha256: "9ad8d444ba6db07ef4f44d9de0fa82f268790c2095043ec50b69962b8322425e"
+source_sha256: "ce605f060c46c2fec17855433927cadc7ffffd31e7ea7be90f65e65fb21a2c8d"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -29,7 +29,7 @@ Codex-specific rules below.
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/site/content/source/docs/agent-instructions/codex.md
+++ b/site/content/source/docs/agent-instructions/codex.md
@@ -2,7 +2,7 @@
 title: "Codex Agent Instructions"
 description: "Codex should follow the [Shared Agent Contract](shared.md), plus the"
 source_path: "docs/agent-instructions/codex.md"
-source_sha256: "ce605f060c46c2fec17855433927cadc7ffffd31e7ea7be90f65e65fb21a2c8d"
+source_sha256: "195a90da11751be898de5dcf5f9a47e56f75cf68e60d744d33e718458b7a80eb"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -30,8 +30,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Codex-Specific Rules
 

--- a/site/content/source/docs/agent-instructions/conductor.md
+++ b/site/content/source/docs/agent-instructions/conductor.md
@@ -2,7 +2,7 @@
 title: "Conductor Agent Instructions"
 description: "Conductor workspaces are parallel, branch-isolated working areas. Follow the"
 source_path: "docs/agent-instructions/conductor.md"
-source_sha256: "2c6c067edf6b67751c13ac36aaced944b5b626df277fedc2ec0275189f202420"
+source_sha256: "f639a28961925b8beecfca2da7bfd93e88e403f1dfae7de74f41ae90dd3b9849"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -29,7 +29,7 @@ Conductor workspaces are parallel, branch-isolated working areas. Follow the
 Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
-2. `.context/ardur-graph.md`
+2. Graph artifacts only when its **Generated Graph** status is `available`
 3. `AGENTS.md`
 4. `docs/engineering-standards.md`
 

--- a/site/content/source/docs/agent-instructions/conductor.md
+++ b/site/content/source/docs/agent-instructions/conductor.md
@@ -2,7 +2,7 @@
 title: "Conductor Agent Instructions"
 description: "Conductor workspaces are parallel, branch-isolated working areas. Follow the"
 source_path: "docs/agent-instructions/conductor.md"
-source_sha256: "f639a28961925b8beecfca2da7bfd93e88e403f1dfae7de74f41ae90dd3b9849"
+source_sha256: "830b523cf8089829ac842fd6c9da5aad8354f2e6faa5644a1461f1c5fe00474b"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -30,8 +30,10 @@ Then read:
 
 1. `.context/ARDUR_CONTEXT.md`
 2. Graph artifacts only when its **Generated Graph** status is `available`
-3. `AGENTS.md`
-4. `docs/engineering-standards.md`
+3. When its graph status is `unavailable`, use the live source and applicable
+   workflow files; missing graph artifacts are optional in this path
+4. `AGENTS.md`
+5. `docs/engineering-standards.md`
 
 ## Conductor-Specific Rules
 

--- a/site/content/source/docs/agent-instructions/shared.md
+++ b/site/content/source/docs/agent-instructions/shared.md
@@ -2,7 +2,7 @@
 title: "Shared Agent Contract"
 description: "These rules apply to every agent runtime: Conductor, Codex, Claude, and any"
 source_path: "docs/agent-instructions/shared.md"
-source_sha256: "26fd3b26f61614859200cd57520fb7141e0932875296a0039125487f30012085"
+source_sha256: "4e01b92503123af06412d2f35eda0c16c75a3dd3f563bb480c12b28438d22965"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -24,9 +24,12 @@ future automation.
 
 1. Run `./scripts/conductor-bootstrap.sh`.
 2. Read `.context/ARDUR_CONTEXT.md`.
-3. Read `.context/ardur-graph.md`.
-4. Use `.context/ardur-graph.json` as the structural map, then verify exact
-   behavior with source files and tests.
+3. Check its **Generated Graph** section.
+4. When the graph status is `available`, read `.context/ardur-graph.md` and use
+   `.context/ardur-graph.json` as the structural map, then verify exact behavior
+   with source files and tests.
+5. When the graph status is `unavailable`, use the listed live source and
+   workflow files directly. Missing graph artifacts are optional in this path.
 
 If bootstrap fails, stop and fix or report the bootstrap problem before making
 task-specific edits.

--- a/site/content/source/docs/conductor-bootstrap.md
+++ b/site/content/source/docs/conductor-bootstrap.md
@@ -2,7 +2,7 @@
 title: "Conductor Bootstrap"
 description: "The Conductor bootstrap script (`scripts/conductor-bootstrap.sh`) generates a"
 source_path: "docs/conductor-bootstrap.md"
-source_sha256: "08173aefb47212cbb876fa99048dbb543092d96f293f569a1df6c945e72d13fa"
+source_sha256: "310024f731b15b78747ec34e46754e68befc479db297b33c67c7577845e9951b"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -18,13 +18,15 @@ This page is generated from the public repository source file. Edit the source f
 {{< /proof-status >}}
 
 The Conductor bootstrap script (`scripts/conductor-bootstrap.sh`) generates a
-machine-readable context map for coding agents that work in this repository.
+human-readable context summary for coding agents that work in this repository.
+It also generates graph artifacts when the public checkout contains the graph
+builder.
 
 ## Prerequisites
 
-- Python 3.10+ with the repo's virtual environment at `python/.venv/`
+- Python 3.10+
 - Git (the script checks branch state and remote defaults)
-- A clean working tree (the script will warn if there are uncommitted changes)
+- A working tree whose current state should be recorded in the context summary
 
 ## Running it
 
@@ -32,11 +34,22 @@ machine-readable context map for coding agents that work in this repository.
 ./scripts/conductor-bootstrap.sh
 ```
 
-This produces:
+This always produces:
 
 - `.context/ARDUR_CONTEXT.md` — human-readable context summary
+- `.context/skills/README.md` — local-only skill-storage guardrails
+
+When `scripts/build-knowledge-graph.py` is present, a successful run also
+produces all three graph artifacts:
+
 - `.context/ardur-graph.md` — dependency graph of repo modules
 - `.context/ardur-graph.json` — machine-readable graph (JSON)
+- `.context/ardur-graph.mmd` — Mermaid graph view
+
+When the builder is absent, bootstrap still succeeds and marks the graph as
+`unavailable` in `.context/ARDUR_CONTEXT.md`. The graph files are optional in
+that path. If the builder is present but fails to produce any required graph
+artifact, bootstrap fails instead of advertising a partial result.
 
 All `.context/` artifacts are local-only and excluded from version control.
 They are regenerated each run, not accumulated.
@@ -46,16 +59,22 @@ They are regenerated each run, not accumulated.
 After bootstrap succeeds, read these in order:
 
 1. `.context/ARDUR_CONTEXT.md` — your session context summary
-2. `.context/ardur-graph.md` — module dependency graph
-3. `AGENTS.md` — mandatory agent instructions (this file lives at the repo root)
-4. `docs/engineering-standards.md` — foundation, testing, review, and security rules
+2. If its **Generated Graph** status is `available`, read
+   `.context/ardur-graph.md` and use `.context/ardur-graph.json` as the
+   machine-readable map
+3. If its graph status is `unavailable`, use the listed live source and
+   workflow files directly
+4. `AGENTS.md` — mandatory agent instructions (this file lives at the repo root)
+5. `docs/engineering-standards.md` — foundation, testing, review, and security rules
 
 ## If bootstrap fails
 
 A failed bootstrap usually means one of:
 
-- The Python virtual environment is missing (`./scripts/setup-dev.sh`)
-- The knowledge-graph script is not yet implemented (expected — see `scripts/check-local.sh`)
+- A usable Python interpreter or graph-builder dependency is missing when the
+  optional builder is present
+- A present knowledge-graph builder returned invalid data or omitted a required
+  graph artifact
 - The working tree has untracked files that conflict with generated paths
 
 Inspect the failure message before editing files. A failed bootstrap means the
@@ -66,7 +85,7 @@ local toolchain, branch state, or generated context is not trustworthy yet.
 Agents working in this repo must:
 
 1. Run `./scripts/conductor-bootstrap.sh` at session start
-2. Read `.context/ARDUR_CONTEXT.md` and `.context/ardur-graph.md`
+2. Read `.context/ARDUR_CONTEXT.md` and follow its graph-availability status
 3. Follow the workspace contract in `AGENTS.md`
 4. Preserve user WIP — do not reset, checkout, or clean unrelated local changes
 5. Keep all generated context under `.context/` (gitignored)

--- a/site/content/source/docs/engineering-standards.md
+++ b/site/content/source/docs/engineering-standards.md
@@ -2,7 +2,7 @@
 title: "Engineering Standards"
 description: "These rules define the working standard for Ardur. They are inspired by public"
 source_path: "docs/engineering-standards.md"
-source_sha256: "b06fe3b1a6fc38682e53997877c9906ffd14fb848e030206084ed8accb9953dd"
+source_sha256: "d671e1346b8346a196848a95b7029e695f2b7397fbe8e81364eb657b3554f415"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -55,7 +55,8 @@ specific company.
 
 ## Work Process
 
-- Start every Conductor session with `./scripts/conductor-bootstrap.sh`.
+- Start every Conductor session with `./scripts/conductor-bootstrap.sh`, then
+  follow the generated context's graph-availability status.
 - Target `dev` for normal implementation work. `main` is release-only and
   should receive promoted work from `dev` after verification.
 - Before editing, state the task-specific success criteria in plain language.
@@ -171,7 +172,9 @@ specific company.
 
 - Bootstrap first, then inspect.
 - Do not trust memory when the repo can answer directly.
-- Use `.context/ardur-graph.json` to find likely files, then verify with source.
+- When the generated context reports the graph as available, use
+  `.context/ardur-graph.json` to find likely files, then verify with source. If
+  it is unavailable, inspect live source and workflow files directly.
 - Do not edit generated `.context/` files except by running bootstrap/index
   scripts.
 - Never create secret-bearing fixtures for convenience.


### PR DESCRIPTION
Closes #339

## Problem

A successful Conductor bootstrap skipped graph generation when the builder was absent, but still required and advertised three graph artifacts that did not exist. Stale graph or context files could also survive into a later failed run and look authoritative.

## Change

- report graph status explicitly as available or unavailable
- advertise only files produced by the current successful run
- clear prior context and graph outputs before regeneration
- fail closed when a present builder omits any required JSON, Markdown, or Mermaid artifact
- direct the no-builder path to live source and workflow files
- align root, shared, runtime-specific, engineering, and Conductor docs
- regenerate the source-backed Hugo mirrors
- add isolated regressions for no-builder, stale-state, partial-builder, complete-builder, public-doc, and ignore-policy behavior

## Validation

- 7 focused bootstrap and ignore-policy tests passed
- final clean Python 3.13 sweep: 1,960 passed, 35 expected skips
- scripts/check-local.sh --quick passed
- ShellCheck and bash syntax passed
- source mirror check: 120 pages and 126 artifacts
- 10 public claim validations passed
- Hugo build passed with 291 pages
- diff and targeted secret-pattern checks passed
- independent security diff review: zero unresolved findings

## Security and cost

Generated state remains confined to ignored .context paths. Partial builder output cannot create an authoritative context, and no credentials or runtime/session state are captured. The change adds no runtime, cloud, IAM, network, or per-request cost surface; CI adds only small deterministic subprocess tests.

## Notes

The root README was reviewed; it only inventories the bootstrap surface, so the behavior contract remains in AGENTS.md and docs/conductor-bootstrap.md. Local Go 1.25.4 is below the declared repository toolchain and this lane changes no Go, so hosted CI remains the Go authority. Hosted secret-scan is required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated session and agent instruction docs to follow “Generated Graph” availability from the generated context, conditionally reading graph artifacts when available and falling back to live source/workflow inspection when unavailable.
  * Refreshed bootstrap, engineering standards, and mirrored source guidance, including clearer failure-mode descriptions.

* **Improvements**
  * Updated the bootstrap script to treat graph artifacts as optional when unsupported, generate them conditionally when supported, and validate completeness/non-empty output when produced.

* **Tests**
  * Added contract regression tests covering available, unavailable, and incomplete/empty graph-generation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->