### PR TITLE
feat(site): generate validated llms.txt

### DIFF
--- a/.github/workflows/hugo-site.yml
+++ b/.github/workflows/hugo-site.yml
@@ -33,6 +33,11 @@ jobs:
           set -euo pipefail
           python3 site/scripts/validate_claims.py
 
+      - name: Test llms.txt validation contract
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s site/tests -p 'test_*.py' -v
+
       - name: Install Hugo
         run: |
           set -euo pipefail
@@ -52,6 +57,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 site/scripts/validate_rendered_docs_links.py site/public
+
+      - name: Verify generated llms.txt
+        run: |
+          set -euo pipefail
+          python3 site/scripts/validate_llms_output.py site/public
 
       - name: Verify rendered source provenance
         run: |

--- a/site/README.md
+++ b/site/README.md
@@ -28,11 +28,23 @@ Extended.
 ```sh
 python3 site/scripts/sync_source_docs.py --check
 python3 site/scripts/validate_claims.py
+python3 -m unittest discover -s site/tests -p 'test_*.py' -v
 hugo --source site --gc --minify
+python3 site/scripts/validate_rendered_docs_links.py site/public
+python3 site/scripts/validate_llms_output.py site/public
 ```
 
 `validate_claims.py` fails when a claim card is missing required evidence
 metadata or points at a repo path that does not exist.
+
+The build also generates `site/public/llms.txt` from Hugo's regular-page
+collection. It lists current public pages first, generated source-backed
+repository documentation second, and already-public pages without the
+`public-now` maturity label under the standard `Optional` section. Entries are
+ordered by their rendered routes; drafts and files outside Hugo's public
+content tree are not eligible. `validate_llms_output.py` checks the required
+plain-text structure, canonical HTTPS routes, duplicate URLs, rendered targets,
+path traversal, and source-provenance placeholders.
 
 `sync_source_docs.py` generates the `site/content/source/` mirrors from all
 public Markdown files in the repo, including root docs, articles, package

--- a/site/content/source/site/README.md
+++ b/site/content/source/site/README.md
@@ -2,7 +2,7 @@
 title: "Ardur Public Evidence Site"
 description: "This Hugo project renders Ardur's public evidence and documentation surface."
 source_path: "site/README.md"
-source_sha256: "cfbb9a9a37992119d8c1363ae4fc45b6bfa56fb3e03b5f22c41a2a87f63bc5e6"
+source_sha256: "dc495a11378eaf9f5bca0cf396ff3dc1102ab722b08043dac73a82a5a688c919"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -45,11 +45,23 @@ Extended.
 ```sh
 python3 site/scripts/sync_source_docs.py --check
 python3 site/scripts/validate_claims.py
+python3 -m unittest discover -s site/tests -p 'test_*.py' -v
 hugo --source site --gc --minify
+python3 site/scripts/validate_rendered_docs_links.py site/public
+python3 site/scripts/validate_llms_output.py site/public
 ```
 
 `validate_claims.py` fails when a claim card is missing required evidence
 metadata or points at a repo path that does not exist.
+
+The build also generates `site/public/llms.txt` from Hugo's regular-page
+collection. It lists current public pages first, generated source-backed
+repository documentation second, and already-public pages without the
+`public-now` maturity label under the standard `Optional` section. Entries are
+ordered by their rendered routes; drafts and files outside Hugo's public
+content tree are not eligible. `validate_llms_output.py` checks the required
+plain-text structure, canonical HTTPS routes, duplicate URLs, rendered targets,
+path traversal, and source-provenance placeholders.
 
 `sync_source_docs.py` generates the `site/content/source/` mirrors from all
 public Markdown files in the repo, including root docs, articles, package

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -6,6 +6,18 @@ disableKinds:
   - RSS
 summaryLength: 28
 
+outputFormats:
+  llms:
+    baseName: "llms"
+    isPlainText: true
+    mediaType: "text/plain"
+    notAlternative: true
+
+outputs:
+  home:
+    - HTML
+    - llms
+
 params:
   repoURL: "https://github.com/ArdurAI/ardur"
   sourceRef: "dev"

--- a/site/layouts/home.llms.txt
+++ b/site/layouts/home.llms.txt
@@ -1,0 +1,40 @@
+{{- $pages := sort site.RegularPages "RelPermalink" -}}
+# Ardur
+
+> Open-source runtime governance and signed evidence for configured AI-agent tool paths.
+
+This file is generated from Ardur's public Hugo evidence site. Curated pages describe the current public surface, source-backed pages mirror public repository documentation, and optional pages retain visible maturity boundaries.
+
+## Curated Documentation
+
+{{ range $pages -}}
+  {{- if and (not .Draft) (ne .Section "source") (in (.Param "maturity") "public-now") -}}
+    {{- $title := .LinkTitle | plainify | htmlUnescape | replaceRE `[\[\]]` `` | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- $description := .Description | plainify | htmlUnescape | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- printf "- [%s](%s)" $title .Permalink -}}
+    {{- with $description }}{{ printf ": %s" . }}{{ end -}}
+    {{- printf "\n" -}}
+  {{- end -}}
+{{ end }}
+## Source-Backed Repository Documentation
+
+{{ range $pages -}}
+  {{- if and (not .Draft) (eq .Section "source") (in (.Param "maturity") "public-now") -}}
+    {{- $title := .LinkTitle | plainify | htmlUnescape | replaceRE `[\[\]]` `` | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- $description := .Description | plainify | htmlUnescape | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- printf "- [%s](%s)" $title .Permalink -}}
+    {{- with $description }}{{ printf ": %s" . }}{{ end -}}
+    {{- printf "\n" -}}
+  {{- end -}}
+{{ end }}
+## Optional
+
+{{ range $pages -}}
+  {{- if and (not .Draft) (not (in (.Param "maturity") "public-now")) -}}
+    {{- $title := .LinkTitle | plainify | htmlUnescape | replaceRE `[\[\]]` `` | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- $description := .Description | plainify | htmlUnescape | replaceRE `\s+` ` ` | strings.TrimSpace -}}
+    {{- printf "- [%s](%s)" $title .Permalink -}}
+    {{- with $description }}{{ printf ": %s" . }}{{ end -}}
+    {{- printf "\n" -}}
+  {{- end -}}
+{{ end -}}

--- a/site/scripts/validate_llms_output.py
+++ b/site/scripts/validate_llms_output.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Validate the generated llms.txt structure and its rendered-site links."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LLMS_FILENAME = "llms.txt"
+MAX_OUTPUT_BYTES = 5 * 1024 * 1024
+EXPECTED_TITLE = "# Ardur"
+EXPECTED_SECTIONS = (
+    "Curated Documentation",
+    "Source-Backed Repository Documentation",
+    "Optional",
+)
+SITE_SCHEME = "https"
+SITE_HOST = "ardurai.github.io"
+SITE_PATH_PREFIX = "/ardur/"
+FORBIDDEN_MARKERS = (
+    "blob/dev",
+    "tree/dev",
+    "__ARDUR_SOURCE_REF__",
+    "__ardur_internal__",
+    "file://",
+)
+LINK_RE = re.compile(r"^- \[([^\]\r\n]+)\]\((https://[^)\s]+)\)(?:: ([^\r\n]+))?$")
+
+
+def display_path(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def rendered_target(rendered_root: Path, url: str) -> tuple[Path | None, str | None]:
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        return None, f"link is not a valid URL: {url!r} ({exc})"
+    if parsed.scheme != SITE_SCHEME or hostname != SITE_HOST:
+        return (
+            None,
+            f"link must use the canonical {SITE_SCHEME}://{SITE_HOST} origin: {url!r}",
+        )
+    if parsed.username is not None or parsed.password is not None or port is not None:
+        return None, f"link must not contain URL credentials or a port: {url!r}"
+    if parsed.query or parsed.fragment:
+        return None, f"link must not contain a query or fragment: {url!r}"
+    if not parsed.path.startswith(SITE_PATH_PREFIX):
+        return None, f"link must stay below {SITE_PATH_PREFIX!r}: {url!r}"
+
+    relative_url = unquote(parsed.path[len(SITE_PATH_PREFIX) :])
+    if (
+        not relative_url
+        or "\\" in relative_url
+        or any(
+            ord(character) < 32 or ord(character) == 127 for character in relative_url
+        )
+    ):
+        return None, f"link has an unsafe or empty site path: {url!r}"
+    relative = Path(relative_url)
+    if relative.is_absolute() or ".." in relative.parts:
+        return None, f"link has an unsafe or empty site path: {url!r}"
+
+    if relative_url.endswith("/"):
+        target = rendered_root / relative / "index.html"
+    elif relative.suffix == ".html":
+        target = rendered_root / relative
+    else:
+        return None, f"link must target a rendered page route: {url!r}"
+
+    try:
+        target.resolve().relative_to(rendered_root.resolve())
+    except ValueError:
+        return None, f"link resolves outside the rendered site: {url!r}"
+    return target, None
+
+
+def validate(rendered_root: Path) -> list[str]:
+    failures: list[str] = []
+    llms_path = rendered_root / LLMS_FILENAME
+    try:
+        metadata = llms_path.lstat()
+    except FileNotFoundError:
+        return [f"missing {display_path(llms_path)}"]
+    except OSError as exc:
+        return [f"cannot inspect {display_path(llms_path)}: {exc}"]
+
+    if not stat.S_ISREG(metadata.st_mode):
+        return [
+            f"{display_path(llms_path)} must be a regular file, not a symlink or device"
+        ]
+    if metadata.st_size > MAX_OUTPUT_BYTES:
+        return [
+            f"{display_path(llms_path)} exceeds the {MAX_OUTPUT_BYTES}-byte safety limit"
+        ]
+
+    try:
+        raw = llms_path.read_bytes()
+    except OSError as exc:
+        return [f"cannot read {display_path(llms_path)}: {exc}"]
+    if len(raw) > MAX_OUTPUT_BYTES:
+        failures.append(
+            f"{display_path(llms_path)} exceeds the {MAX_OUTPUT_BYTES}-byte safety limit"
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return [f"{display_path(llms_path)} is not UTF-8: {exc}"]
+
+    if not text.endswith("\n"):
+        failures.append(f"{display_path(llms_path)} must end with a newline")
+    if "\r" in text:
+        failures.append(f"{display_path(llms_path)} must use LF line endings")
+    if any(ord(character) < 32 and character != "\n" for character in text):
+        failures.append(f"{display_path(llms_path)} contains control characters")
+
+    for marker in FORBIDDEN_MARKERS:
+        if marker.lower() in text.lower():
+            failures.append(
+                f"{display_path(llms_path)} contains forbidden marker {marker!r}"
+            )
+
+    lines = text.splitlines()
+    if not lines or lines[0] != EXPECTED_TITLE:
+        failures.append(f"first line must be exactly {EXPECTED_TITLE!r}")
+    first_nonempty_after_title = next((line for line in lines[1:] if line.strip()), "")
+    if not first_nonempty_after_title.startswith("> "):
+        failures.append(
+            "the first non-empty line after the title must be a blockquote summary"
+        )
+
+    current_section: str | None = None
+    section_order: list[str] = []
+    section_counts = {section: 0 for section in EXPECTED_SECTIONS}
+    seen_urls: set[str] = set()
+
+    for line_number, line in enumerate(lines, start=1):
+        if line.startswith("## "):
+            current_section = line[3:]
+            section_order.append(current_section)
+            if current_section not in section_counts:
+                failures.append(
+                    f"line {line_number}: unexpected section {current_section!r}"
+                )
+            continue
+        if not line.startswith("- "):
+            if current_section is not None and line.strip():
+                failures.append(
+                    f"line {line_number}: unexpected content inside "
+                    f"section {current_section!r}"
+                )
+            continue
+        if current_section not in section_counts:
+            failures.append(
+                f"line {line_number}: link entry appears outside an expected section"
+            )
+            continue
+
+        match = LINK_RE.fullmatch(line)
+        if not match:
+            failures.append(f"line {line_number}: malformed link entry")
+            continue
+        title, url, _description = match.groups()
+        if not title.strip():
+            failures.append(f"line {line_number}: link title is empty")
+        if url in seen_urls:
+            failures.append(f"line {line_number}: duplicate URL {url!r}")
+        else:
+            seen_urls.add(url)
+
+        target, error = rendered_target(rendered_root, url)
+        if error:
+            failures.append(f"line {line_number}: {error}")
+        elif target is not None and not target.is_file():
+            failures.append(
+                f"line {line_number}: link target is not rendered: {display_path(target)}"
+            )
+        section_counts[current_section] += 1
+
+    if section_order != list(EXPECTED_SECTIONS):
+        failures.append(
+            "sections must appear exactly once in this order: "
+            + ", ".join(EXPECTED_SECTIONS)
+        )
+    for section, count in section_counts.items():
+        if count == 0:
+            failures.append(f"section {section!r} must contain at least one link")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "rendered_root",
+        nargs="?",
+        default="site/public",
+        help="rendered Hugo output directory",
+    )
+    args = parser.parse_args()
+    rendered_root = (REPO_ROOT / args.rendered_root).resolve()
+    if not rendered_root.is_dir():
+        print(
+            f"llms.txt validation failed: missing rendered site {rendered_root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures = validate(rendered_root)
+    if failures:
+        for failure in failures:
+            print(f"llms.txt validation failed: {failure}", file=sys.stderr)
+        return 1
+    print("validated generated llms.txt")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/static/repo/.github/workflows/hugo-site.yml
+++ b/site/static/repo/.github/workflows/hugo-site.yml
@@ -33,6 +33,11 @@ jobs:
           set -euo pipefail
           python3 site/scripts/validate_claims.py
 
+      - name: Test llms.txt validation contract
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s site/tests -p 'test_*.py' -v
+
       - name: Install Hugo
         run: |
           set -euo pipefail
@@ -52,6 +57,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 site/scripts/validate_rendered_docs_links.py site/public
+
+      - name: Verify generated llms.txt
+        run: |
+          set -euo pipefail
+          python3 site/scripts/validate_llms_output.py site/public
 
       - name: Verify rendered source provenance
         run: |

--- a/site/tests/test_validate_llms_output.py
+++ b/site/tests/test_validate_llms_output.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = REPO_ROOT / "site" / "scripts" / "validate_llms_output.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location(
+        "validate_llms_output", VALIDATOR_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_validator()
+
+
+class LlmsOutputValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.rendered_root = Path(self.temporary_directory.name)
+        for route in ("get-started", "source/readme", "work-in-progress"):
+            target = self.rendered_root / route / "index.html"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                "<!doctype html><title>fixture</title>\n", encoding="utf-8"
+            )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def valid_text(self) -> str:
+        return """# Ardur
+
+> Runtime governance and evidence for configured AI-agent tool paths.
+
+This file is generated from the public evidence site.
+
+## Curated Documentation
+
+- [Get Started](https://ardurai.github.io/ardur/get-started/): Run the current proof.
+
+## Source-Backed Repository Documentation
+
+- [Ardur](https://ardurai.github.io/ardur/source/readme/): Source-backed project overview.
+
+## Optional
+
+- [Work in Progress](https://ardurai.github.io/ardur/work-in-progress/): Active work and boundaries.
+"""
+
+    def write_output(self, text: str | None = None) -> None:
+        (self.rendered_root / "llms.txt").write_text(
+            self.valid_text() if text is None else text,
+            encoding="utf-8",
+        )
+
+    def test_accepts_canonical_generated_index(self) -> None:
+        self.write_output()
+        self.assertEqual(validator.validate(self.rendered_root), [])
+
+    def test_rejects_missing_output(self) -> None:
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("missing" in failure for failure in failures), failures)
+
+    def test_rejects_wrong_section_order(self) -> None:
+        text = self.valid_text().replace(
+            "## Curated Documentation", "## Unexpected Documentation", 1
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("unexpected section" in failure for failure in failures), failures
+        )
+        self.assertTrue(
+            any("sections must appear" in failure for failure in failures), failures
+        )
+
+    def test_rejects_duplicate_urls_across_sections(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/work-in-progress/",
+            "https://ardurai.github.io/ardur/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("duplicate URL" in failure for failure in failures), failures
+        )
+
+    def test_rejects_noncanonical_origin(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://example.invalid/ardur/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("canonical" in failure for failure in failures), failures)
+
+    def test_rejects_invalid_port_without_crashing(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://ardurai.github.io:notaport/ardur/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("valid URL" in failure for failure in failures), failures)
+
+    def test_rejects_explicit_zero_port(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://ardurai.github.io:0/ardur/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("port" in failure for failure in failures), failures)
+
+    def test_rejects_empty_userinfo(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://@ardurai.github.io/ardur/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("credentials" in failure for failure in failures), failures)
+
+    def test_rejects_encoded_path_traversal(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://ardurai.github.io/ardur/%2e%2e/get-started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("unsafe" in failure for failure in failures), failures)
+
+    def test_rejects_encoded_control_character_in_path(self) -> None:
+        text = self.valid_text().replace(
+            "https://ardurai.github.io/ardur/get-started/",
+            "https://ardurai.github.io/ardur/get%00started/",
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("unsafe" in failure for failure in failures), failures)
+
+    def test_rejects_unrendered_target(self) -> None:
+        text = self.valid_text().replace("/get-started/", "/missing-page/", 1)
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("not rendered" in failure for failure in failures), failures
+        )
+
+    def test_rejects_llms_symlink(self) -> None:
+        outside_directory = TemporaryDirectory()
+        self.addCleanup(outside_directory.cleanup)
+        outside = Path(outside_directory.name) / "outside.txt"
+        outside.write_text(self.valid_text(), encoding="utf-8")
+        (self.rendered_root / "llms.txt").symlink_to(outside)
+
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("regular file" in failure for failure in failures), failures
+        )
+
+    def test_rejects_oversized_output_before_reading_it(self) -> None:
+        with (self.rendered_root / "llms.txt").open("wb") as output:
+            output.truncate(validator.MAX_OUTPUT_BYTES + 1)
+
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("safety limit" in failure for failure in failures), failures
+        )
+
+    def test_rejects_rendered_target_symlink_escape(self) -> None:
+        outside_directory = TemporaryDirectory()
+        self.addCleanup(outside_directory.cleanup)
+        outside = Path(outside_directory.name) / "outside.html"
+        outside.write_text("outside\n", encoding="utf-8")
+        target = self.rendered_root / "get-started" / "index.html"
+        target.unlink()
+        target.symlink_to(outside)
+        self.write_output()
+
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(any("outside" in failure for failure in failures), failures)
+
+    def test_rejects_provenance_placeholder(self) -> None:
+        text = self.valid_text().replace(
+            "Run the current proof.", "__ARDUR_SOURCE_REF__"
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("forbidden marker" in failure for failure in failures), failures
+        )
+
+    def test_rejects_multiline_link_injection(self) -> None:
+        text = self.valid_text().replace("[Get Started]", "[Get\n- [Injected]", 1)
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("malformed link entry" in failure for failure in failures), failures
+        )
+
+    def test_rejects_unstructured_section_content(self) -> None:
+        text = self.valid_text().replace(
+            "## Optional\n\n", "## Optional\n\nunexpected injected text\n", 1
+        )
+        self.write_output(text)
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("unexpected content" in failure for failure in failures), failures
+        )
+
+    def test_rejects_tab_control_characters(self) -> None:
+        self.write_output(self.valid_text().replace("current proof", "current\tproof"))
+        failures = validator.validate(self.rendered_root)
+        self.assertTrue(
+            any("control characters" in failure for failure in failures), failures
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a home-only Hugo `text/plain` output that generates `llms.txt` from the rendered regular-page collection
- partition deterministic links into curated public documentation, source-backed repository documentation, and the standard `Optional` section while excluding drafts explicitly
- add a fail-closed validator, 18 stdlib regression tests, the Hugo CI gates, public operator documentation, and synchronized source mirrors

## Publication boundary

The artifact is generated at build time rather than checked in, so Hugo remains the single content source of truth. The current build emits 153 unique rendered-page links (24 curated, 114 source-backed, 15 optional) in a 28,675-byte UTF-8 file. `dev` pushes validate the output; the existing workflow continues to upload and deploy Pages artifacts from `main` only.

## Security and reliability

The validator requires the expected llms.txt structure and canonical HTTPS project routes, rejects duplicate or missing targets, queries/fragments, credentials/ports, decoded traversal/control characters, provenance placeholders, symlinks/devices, output-root escapes, and artifacts over 5 MiB. The Hugo template normalizes one-line titles/descriptions and excludes drafts even when a preview includes draft content.

The independent frozen-diff security review reported zero unresolved findings. Pinned gitleaks 8.18.0, forbidden-term/model-identifier scans, local-agent-path checks, Ruff, and diff hygiene are green. No dependency, permission, secret, runtime, network, or cloud-cost surface is added.

## Validation

- 18/18 focused tests on Python 3.13 and Python 3.14
- 120 source-backed Hugo pages and 126 mirrored documentation artifacts synchronized
- 10 public claim records validated
- Hugo 0.161.1 built 292 pages twice from signed commit `1f69d6d5df6b6911747ef8709edac42768293133`
- both `llms.txt` builds matched SHA-256 `84ed3c33fe2f5fbd7989f3da58d3701c99c98a7f89d17e8db451d24077685a18`
- rendered documentation links, generated `llms.txt`, exact source provenance, and publication markers validated
- signed DCO/GSTACK checkpoint: `architect/sessions/issue-330-llms-output/2026-07-17-journal.md`

## Design sources

- Hugo output formats: https://gohugo.io/configuration/output-formats/
- Hugo media types: https://gohugo.io/configuration/media-types/
- llms.txt proposal: https://llmstxt.org/

## Repository checks

- [x] targets `dev` only
- [x] root README reviewed; site-specific behavior documented in the already-linked `site/README.md`
- [x] generated source and workflow mirrors refreshed with the repository generator
- [x] signed commit and DCO trailer verified
- [x] no changes to protected release, Dependabot, Biscuit, spend-gate, #313, or PR #329 lanes

Closes #330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a generated `llms.txt` documentation index with curated, source-backed, and optional content sections.
  * Included titles, descriptions, and links to eligible documentation pages.

* **Bug Fixes**
  * Added comprehensive validation to detect malformed, unsafe, duplicate, or broken documentation links.

* **Documentation**
  * Expanded site validation instructions and documented `llms.txt` generation and requirements.

* **Tests**
  * Added automated coverage for valid output, malformed content, security issues, and invalid links.
  * Integrated these checks into the site build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->