### PR TITLE
fix(benchmark): expose bounded schema diagnostics

### DIFF
--- a/docs/benchmarks/linux-governance-overhead.md
+++ b/docs/benchmarks/linux-governance-overhead.md
@@ -48,6 +48,9 @@ If a generated report violates the schema, the command keeps the stable
 paths with their failed schema keywords, followed by `+N more` when needed.
 Diagnostics are capped and do not include rejected values or unknown property
 names, so a useful CI failure does not disclose host metadata or operator input.
+The Python heap peak is a nonnegative byte count with its own wide integer
+bound rather than the one-million operation-count ceiling; temporary traced
+allocations can legitimately exceed one million bytes.
 
 ## Stress mode
 

--- a/docs/benchmarks/linux-governance-overhead.md
+++ b/docs/benchmarks/linux-governance-overhead.md
@@ -43,6 +43,12 @@ The command writes owner-only JSON and Markdown reports. On non-Linux hosts,
 development-only shape checks require `--allow-non-linux`; those reports carry
 `claim_eligible: false` and `claim_status: non_linux_smoke_only`.
 
+If a generated report violates the schema, the command keeps the stable
+`report_schema_invalid` error code and prints up to five deterministic JSON
+paths with their failed schema keywords, followed by `+N more` when needed.
+Diagnostics are capped and do not include rejected values or unknown property
+names, so a useful CI failure does not disclose host metadata or operator input.
+
 ## Stress mode
 
 Stress mode requires Linux and at least 100 latency samples. Run it on a quiet,

--- a/docs/specs/linux-governance-benchmark-report-v0.1.schema.json
+++ b/docs/specs/linux-governance-benchmark-report-v0.1.schema.json
@@ -143,6 +143,11 @@
       "minimum": 0,
       "maximum": 1000000
     },
+    "byteCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000000000000
+    },
     "finiteNonnegative": {
       "type": "number",
       "minimum": 0,
@@ -419,7 +424,7 @@
           "$ref": "#/$defs/finiteNonnegative"
         },
         "python_heap_peak_bytes": {
-          "$ref": "#/$defs/count"
+          "$ref": "#/$defs/byteCount"
         },
         "linux_rss_start_kib": {
           "oneOf": [

--- a/python/tests/test_linux_benchmark.py
+++ b/python/tests/test_linux_benchmark.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 
 import vibap.linux_benchmark as benchmark
 from vibap._specs import linux_governance_benchmark_report_v01_schema
@@ -114,6 +115,21 @@ def test_distribution_schema_separates_latency_and_percent_domains() -> None:
     )
 
 
+def test_report_schema_gives_heap_bytes_a_dedicated_integer_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(benchmark, "validate_report", lambda _report: None)
+    report = benchmark.run_benchmark(_tiny_config(), allow_non_linux=True)
+    report["sustained_governance"]["python_heap_peak_bytes"] = 1_955_064
+    validator = Draft202012Validator(linux_governance_benchmark_report_v01_schema())
+
+    assert list(validator.iter_errors(report)) == []
+
+    report["sustained_governance"]["python_heap_peak_bytes"] = True
+    errors = list(validator.iter_errors(report))
+    assert [error.validator for error in errors] == ["type"]
+
+
 def test_report_schema_rejects_cross_field_claim_mismatches() -> None:
     report = benchmark.run_benchmark(_tiny_config(), allow_non_linux=True)
     validator = Draft202012Validator(linux_governance_benchmark_report_v01_schema())
@@ -198,6 +214,57 @@ def test_report_schema_failure_details_are_deterministic_and_bounded() -> None:
         * 2
     )
     assert len(details[0]) < 512
+
+
+def test_schema_failure_detail_counts_only_omitted_unique_diagnostics() -> None:
+    duplicate = ValidationError("private value", validator="type", path=("alpha",))
+    other = ValidationError("other private value", validator="minimum", path=("beta",))
+
+    detail = benchmark._schema_failure_detail([duplicate, duplicate, other])
+
+    assert detail == (
+        "generated report violated its JSON Schema: $.alpha [type]; $.beta [minimum]"
+    )
+
+
+def test_schema_failure_detail_enforces_total_text_cap() -> None:
+    errors = [
+        ValidationError(
+            "private value",
+            validator="type",
+            path=(
+                f"section_{index}_" + "a" * 64,
+                "nested_" + "b" * 64,
+                "leaf_" + "c" * 64,
+            ),
+        )
+        for index in range(3)
+    ]
+
+    details = [benchmark._schema_failure_detail(errors) for _ in range(2)]
+
+    assert details[0] == details[1]
+    assert len(details[0]) == benchmark.MAX_SCHEMA_ERROR_TEXT_CHARS
+    assert details[0].endswith("...")
+    assert "private value" not in details[0]
+
+    omitted_errors = [
+        ValidationError(
+            "other private value",
+            validator="type",
+            path=(
+                f"omitted_section_{index}_" + "d" * 64,
+                "nested_" + "e" * 64,
+                "leaf_" + "f" * 64,
+            ),
+        )
+        for index in range(6)
+    ]
+    omitted_detail = benchmark._schema_failure_detail(omitted_errors)
+
+    assert len(omitted_detail) == benchmark.MAX_SCHEMA_ERROR_TEXT_CHARS
+    assert omitted_detail.endswith("...; +1 more")
+    assert "other private value" not in omitted_detail
 
 
 def test_write_outputs_are_owner_only_and_stdout_is_path_free(

--- a/python/tests/test_linux_benchmark.py
+++ b/python/tests/test_linux_benchmark.py
@@ -125,6 +125,13 @@ def test_report_schema_gives_heap_bytes_a_dedicated_integer_bound(
 
     assert list(validator.iter_errors(report)) == []
 
+    report["sustained_governance"]["python_heap_peak_bytes"] = 1_000_000_000_000_000
+    assert list(validator.iter_errors(report)) == []
+
+    report["sustained_governance"]["python_heap_peak_bytes"] = 1_000_000_000_000_001
+    errors = list(validator.iter_errors(report))
+    assert [error.validator for error in errors] == ["maximum"]
+
     report["sustained_governance"]["python_heap_peak_bytes"] = True
     errors = list(validator.iter_errors(report))
     assert [error.validator for error in errors] == ["type"]

--- a/python/tests/test_linux_benchmark.py
+++ b/python/tests/test_linux_benchmark.py
@@ -151,6 +151,55 @@ def test_tiny_report_is_schema_valid_and_does_not_leak_private_paths(
     )
 
 
+def test_report_schema_failure_names_path_and_rule_without_echoing_value(
+    tmp_path: Path,
+) -> None:
+    report = benchmark.run_benchmark(_tiny_config(), allow_non_linux=True)
+    private_marker = str(tmp_path / "private-report-value")
+    report["environment"]["cpu_count"] = private_marker
+    report[private_marker] = "unknown private field"
+
+    with pytest.raises(benchmark.BenchmarkError) as error:
+        benchmark.validate_report(report)
+
+    assert error.value.code == "report_schema_invalid"
+    assert "$ [additionalProperties]" in error.value.detail
+    assert "$.environment.cpu_count [type]" in error.value.detail
+    assert private_marker not in error.value.detail
+    assert "unknown private field" not in error.value.detail
+    assert "\n" not in error.value.detail
+
+
+def test_report_schema_failure_details_are_deterministic_and_bounded() -> None:
+    report = benchmark.run_benchmark(_tiny_config(), allow_non_linux=True)
+    report["config"]["evidence_event_count"] = 0
+    report["config"]["sample_count"] = 0
+    report["environment"]["architecture"] = ""
+    report["environment"]["cpu_count"] = 0
+    report["environment"]["kernel_release"] = ""
+    report["mode"] = "invalid"
+
+    details = []
+    for _ in range(2):
+        with pytest.raises(benchmark.BenchmarkError) as error:
+            benchmark.validate_report(report)
+        details.append(error.value.detail)
+
+    assert (
+        details
+        == [
+            "generated report violated its JSON Schema: "
+            "$.config.evidence_event_count [minimum]; "
+            "$.config.sample_count [minimum]; "
+            "$.environment.architecture [minLength]; "
+            "$.environment.cpu_count [minimum]; "
+            "$.environment.kernel_release [minLength]; +1 more"
+        ]
+        * 2
+    )
+    assert len(details[0]) < 512
+
+
 def test_write_outputs_are_owner_only_and_stdout_is_path_free(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/python/vibap/_specs/linux_governance_benchmark_report_v01.schema.json
+++ b/python/vibap/_specs/linux_governance_benchmark_report_v01.schema.json
@@ -143,6 +143,11 @@
       "minimum": 0,
       "maximum": 1000000
     },
+    "byteCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000000000000
+    },
     "finiteNonnegative": {
       "type": "number",
       "minimum": 0,
@@ -419,7 +424,7 @@
           "$ref": "#/$defs/finiteNonnegative"
         },
         "python_heap_peak_bytes": {
-          "$ref": "#/$defs/count"
+          "$ref": "#/$defs/byteCount"
         },
         "linux_rss_start_kib": {
           "oneOf": [

--- a/python/vibap/linux_benchmark.py
+++ b/python/vibap/linux_benchmark.py
@@ -982,22 +982,26 @@ def _schema_error_sort_key(error: ValidationError) -> tuple[str, str, tuple[str,
 
 
 def _schema_failure_detail(errors: Sequence[ValidationError]) -> str:
+    seen_details: set[str] = set()
     details: list[str] = []
     for error in errors:
         rule = _schema_error_token(error.validator, fallback="unknown")
         detail = f"{_schema_error_path(error)} [{rule}]"
-        if detail not in details:
+        if detail in seen_details:
+            continue
+        seen_details.add(detail)
+        if len(details) < MAX_SCHEMA_ERROR_DETAILS:
             details.append(detail)
-        if len(details) == MAX_SCHEMA_ERROR_DETAILS:
-            break
 
-    omitted = len(errors) - len(details)
+    omitted = len(seen_details) - len(details)
     summary = "generated report violated its JSON Schema: " + "; ".join(details)
+    suffix = ""
     if omitted > 0:
-        summary += f"; +{omitted} more"
-    if len(summary) > MAX_SCHEMA_ERROR_TEXT_CHARS:
-        summary = summary[: MAX_SCHEMA_ERROR_TEXT_CHARS - 3] + "..."
-    return summary
+        suffix = f"; +{omitted} more"
+    if len(summary) + len(suffix) <= MAX_SCHEMA_ERROR_TEXT_CHARS:
+        return summary + suffix
+    body_limit = MAX_SCHEMA_ERROR_TEXT_CHARS - len(suffix)
+    return summary[: body_limit - 3] + "..." + suffix
 
 
 def validate_report(report: Mapping[str, Any]) -> None:

--- a/python/vibap/linux_benchmark.py
+++ b/python/vibap/linux_benchmark.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError
 
 from ._specs import linux_governance_benchmark_report_v01_schema
 from .backends.native import NativeBackend
@@ -47,6 +48,9 @@ MAX_SENSOR_CONFIG_BYTES = 64 * 1024
 MAX_ARGV_ITEMS = 64
 MAX_ARG_BYTES = 4096
 MAX_ARGV_BYTES = 32 * 1024
+MAX_SCHEMA_ERROR_DETAILS = 5
+MAX_SCHEMA_ERROR_PATH_CHARS = 192
+MAX_SCHEMA_ERROR_TEXT_CHARS = 512
 
 LIMITATIONS = (
     "Smoke mode verifies report shape and execution only; it is not performance evidence.",
@@ -940,18 +944,70 @@ def _validate_source_ref(source_ref: str) -> str:
     )
 
 
+def _schema_error_token(value: object, *, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    token = "".join(
+        character
+        if character.isascii() and (character.isalnum() or character in "_-")
+        else "?"
+        for character in value[:64]
+    )
+    return token or fallback
+
+
+def _schema_error_path(error: ValidationError) -> str:
+    parts = ["$"]
+    for component in error.absolute_path:
+        if isinstance(component, bool):
+            parts.append("[?]")
+        elif isinstance(component, int):
+            parts.append(f"[{component}]")
+        elif isinstance(component, str):
+            parts.append(f".{_schema_error_token(component, fallback='?')}")
+        else:
+            parts.append(".?")
+    path = "".join(parts)
+    if len(path) > MAX_SCHEMA_ERROR_PATH_CHARS:
+        return path[: MAX_SCHEMA_ERROR_PATH_CHARS - 3] + "..."
+    return path
+
+
+def _schema_error_sort_key(error: ValidationError) -> tuple[str, str, tuple[str, ...]]:
+    return (
+        _schema_error_path(error),
+        _schema_error_token(error.validator, fallback="unknown"),
+        tuple(str(component) for component in error.absolute_schema_path),
+    )
+
+
+def _schema_failure_detail(errors: Sequence[ValidationError]) -> str:
+    details: list[str] = []
+    for error in errors:
+        rule = _schema_error_token(error.validator, fallback="unknown")
+        detail = f"{_schema_error_path(error)} [{rule}]"
+        if detail not in details:
+            details.append(detail)
+        if len(details) == MAX_SCHEMA_ERROR_DETAILS:
+            break
+
+    omitted = len(errors) - len(details)
+    summary = "generated report violated its JSON Schema: " + "; ".join(details)
+    if omitted > 0:
+        summary += f"; +{omitted} more"
+    if len(summary) > MAX_SCHEMA_ERROR_TEXT_CHARS:
+        summary = summary[: MAX_SCHEMA_ERROR_TEXT_CHARS - 3] + "..."
+    return summary
+
+
 def validate_report(report: Mapping[str, Any]) -> None:
     validator = Draft202012Validator(
         linux_governance_benchmark_report_v01_schema(),
         format_checker=FormatChecker(),
     )
-    errors = sorted(
-        validator.iter_errors(report), key=lambda item: list(item.absolute_path)
-    )
+    errors = sorted(validator.iter_errors(report), key=_schema_error_sort_key)
     if errors:
-        raise BenchmarkError(
-            "report_schema_invalid", "generated report violated its JSON Schema"
-        )
+        raise BenchmarkError("report_schema_invalid", _schema_failure_detail(errors))
 
 
 def run_benchmark(

--- a/site/content/source/docs/benchmarks/linux-governance-overhead.md
+++ b/site/content/source/docs/benchmarks/linux-governance-overhead.md
@@ -2,7 +2,7 @@
 title: "Linux Governance Overhead Harness"
 description: "Ardur ships a repeatable local harness for measuring governance work without"
 source_path: "docs/benchmarks/linux-governance-overhead.md"
-source_sha256: "95180aeac84f17850f25d3f26b56a532d343128ca2b76e14e72d6d22b5b3eb0c"
+source_sha256: "784475204d5b7ac2c7324fbedbef547e04b84f1292b520920101ea7bf194e077"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -59,6 +59,12 @@ python scripts/run-linux-governance-benchmark.py \
 The command writes owner-only JSON and Markdown reports. On non-Linux hosts,
 development-only shape checks require `--allow-non-linux`; those reports carry
 `claim_eligible: false` and `claim_status: non_linux_smoke_only`.
+
+If a generated report violates the schema, the command keeps the stable
+`report_schema_invalid` error code and prints up to five deterministic JSON
+paths with their failed schema keywords, followed by `+N more` when needed.
+Diagnostics are capped and do not include rejected values or unknown property
+names, so a useful CI failure does not disclose host metadata or operator input.
 
 ## Stress mode
 

--- a/site/content/source/docs/benchmarks/linux-governance-overhead.md
+++ b/site/content/source/docs/benchmarks/linux-governance-overhead.md
@@ -2,7 +2,7 @@
 title: "Linux Governance Overhead Harness"
 description: "Ardur ships a repeatable local harness for measuring governance work without"
 source_path: "docs/benchmarks/linux-governance-overhead.md"
-source_sha256: "784475204d5b7ac2c7324fbedbef547e04b84f1292b520920101ea7bf194e077"
+source_sha256: "20b9c1c1afd64b292ae2eed1a213b80617301d60c7f2890d92e60c9cd9244eda"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -65,6 +65,9 @@ If a generated report violates the schema, the command keeps the stable
 paths with their failed schema keywords, followed by `+N more` when needed.
 Diagnostics are capped and do not include rejected values or unknown property
 names, so a useful CI failure does not disclose host metadata or operator input.
+The Python heap peak is a nonnegative byte count with its own wide integer
+bound rather than the one-million operation-count ceiling; temporary traced
+allocations can legitimately exceed one million bytes.
 
 ## Stress mode
 

--- a/site/static/repo/docs/specs/linux-governance-benchmark-report-v0.1.schema.json
+++ b/site/static/repo/docs/specs/linux-governance-benchmark-report-v0.1.schema.json
@@ -143,6 +143,11 @@
       "minimum": 0,
       "maximum": 1000000
     },
+    "byteCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000000000000
+    },
     "finiteNonnegative": {
       "type": "number",
       "minimum": 0,
@@ -419,7 +424,7 @@
           "$ref": "#/$defs/finiteNonnegative"
         },
         "python_heap_peak_bytes": {
-          "$ref": "#/$defs/count"
+          "$ref": "#/$defs/byteCount"
         },
         "linux_rss_start_kib": {
           "oneOf": [

--- a/site/static/repo/python/vibap/_specs/linux_governance_benchmark_report_v01.schema.json
+++ b/site/static/repo/python/vibap/_specs/linux_governance_benchmark_report_v01.schema.json
@@ -143,6 +143,11 @@
       "minimum": 0,
       "maximum": 1000000
     },
+    "byteCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000000000000
+    },
     "finiteNonnegative": {
       "type": "number",
       "minimum": 0,
@@ -419,7 +424,7 @@
           "$ref": "#/$defs/finiteNonnegative"
         },
         "python_heap_peak_bytes": {
-          "$ref": "#/$defs/count"
+          "$ref": "#/$defs/byteCount"
         },
         "linux_rss_start_kib": {
           "oneOf": [


### PR DESCRIPTION
## Summary

- preserve the stable report_schema_invalid code while reporting deterministic sanitized JSON paths and failed schema keywords
- cap diagnostics at five unique entries and 512 characters, preserve the complete +N more suffix, and never echo rejected values or unknown property names
- correct the over-constrained heap-byte schema field with a dedicated bounded integer domain while leaving operation/sample and RSS bounds unchanged
- document the operator-facing contract and add confidentiality, ordering, deduplication, truncation, and byte-bound regressions

## Root-cause boundary

The exact invalid field from the historical b920309 hosted run cannot be proven retroactively because the old diagnostic discarded it. Nine subsequent exact-dev runs were green. The new diagnostics did, however, make the same failure class reproducible locally: a valid report measured 1,955,064 Python heap bytes and the schema rejected it against a generic 1,000,000 count maximum.

That is a concrete schema defect consistent with the historical allocation-sensitive pattern. The generic bound was designed for operation/sample counts but was reused for a byte measurement. Python documents that get_traced_memory reports the peak of traced allocations and demonstrates legitimate temporary multi-megabyte peaks: https://docs.python.org/3.13/library/tracemalloc.html#record-the-current-and-peak-size-of-all-traced-memory-blocks

This PR gives heap bytes a dedicated nonnegative integer bound through 10^15. It does not change benchmark measurement, eligibility, workload, or claim semantics. Consumers caching the older v0.1 schema must adopt the corrected schema before accepting reports above the former one-million-byte ceiling.

The diagnostic formatter uses absolute_path and validator metadata documented by the official jsonschema error API: https://python-jsonschema.readthedocs.io/en/stable/errors/

## Security

Diagnostics use sanitized schema paths and validator keywords only. Raw error messages, instances, rejected values, validator values, and unknown property names are excluded. Two independent security-diff passes closed with zero unresolved findings after addressing unique omitted counts and suffix-preserving truncation. Adversarial value, key, newline, insertion-order, 200-error, six-long-error, and boundary probes passed.

The widened byte range is validation-only and does not allocate memory from the reported value. Only python_heap_peak_bytes uses it; operation/sample counts and RSS-in-KiB ceilings remain unchanged.

## Validation

- 28 focused benchmark tests passed; five consecutive focused runs produced 140 passes
- full Python suite: 1,967 passed, 35 expected skips
- Ruff 0.13.0 check and format passed
- repository quick checks passed
- canonical, embedded, and two generated schema mirrors are byte-identical
- Hugo source sync: 120 pages and 126 mirrored artifacts; 10 public claims validated
- 18 llms-output contract tests, Hugo 292-page build, rendered links, llms output, provenance, forbidden-content, local-path, and model-output checks passed
- checksum-verified gitleaks 8.18.0 found no secrets across 596 commits or the working tree
- exact-final-revision hosted matrix passed, including Linux smoke, first-attempt latency, Python 3.10/3.13, Go, CodeQL, packages, OCI scan, Hugo, formats, links, and secret scans

The unrelated local test-environment parity defect discovered during full-suite validation remains tracked separately in #347.

Closes #327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark report schema-validation errors with a stable `report_schema_invalid` code, deterministic JSON paths/validation rules, deduplicated and size-capped diagnostics, and “+N more” when limits are exceeded—without echoing rejected values or unknown properties.
  * Updated `python_heap_peak_bytes` validation to a non-negative byte count with a larger numeric bound.
* **Documentation**
  * Updated linux-governance-overhead smoke-mode docs to reflect the new schema-failure reporting and heap peak validation behavior.
* **Tests**
  * Added regression coverage for deterministic, bounded schema-error details and the dedicated integer constraint for heap-peak bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
