### PR TITLE
test(fixtures): isolate missing-dependency runner root

### DIFF
--- a/python/tests/test_provider_adapter_fixtures.py
+++ b/python/tests/test_provider_adapter_fixtures.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -25,6 +26,15 @@ EXPECTED_STATUSES = {
 
 def _runner(adapter: str) -> Path:
     return REPO_ROOT / "examples" / adapter / "run.sh"
+
+
+def _runner_without_repo_venv(tmp_path: Path, adapter: str) -> Path:
+    """Copy a runner into an ephemeral repo root with no local virtualenv."""
+
+    runner = tmp_path / "isolated-repo" / "examples" / adapter / "run.sh"
+    runner.parent.mkdir(parents=True)
+    shutil.copy(_runner(adapter), runner)
+    return runner
 
 
 def _json_report(stdout: str) -> dict[str, Any]:
@@ -206,10 +216,13 @@ def test_no_key_provider_adapter_runner_reports_missing_default_dependencies(tmp
 
     out_dir = tmp_path / f"{adapter}-missing-dependencies"
     env = _env_with_path_missing_dependency_python(tmp_path)
+    runner = _runner_without_repo_venv(tmp_path, adapter)
+    isolated_repo_root = runner.parents[2]
     assert "PYTHON" not in env
+    assert not (isolated_repo_root / "python" / ".venv").exists()
     completed = subprocess.run(
-        [str(_runner(adapter)), "--out-dir", str(out_dir), "--mission", str(MISSION)],
-        cwd=REPO_ROOT,
+        [str(runner), "--out-dir", str(out_dir), "--mission", str(MISSION)],
+        cwd=isolated_repo_root,
         env=env,
         text=True,
         capture_output=True,


### PR DESCRIPTION
## Summary

- copy each trusted provider runner into a per-test synthetic repository root
- preserve executable mode while ensuring that synthetic root has no `python/.venv`
- exercise the real supported-PATH fallback without mutating a developer environment or changing production interpreter precedence

Closes #347

## Root cause

The missing-default-dependency fixture invokes the public runner from the real checkout. After `scripts/setup-dev.sh`, that runner correctly prefers `python/.venv/bin/python`, so the test's PATH shim is never selected and both parameterized cases incorrectly complete successfully.

Setting `PYTHON` would test the explicit override path instead of the default-selection contract. Hiding or renaming the repository venv would mutate developer state. The test therefore runs the unchanged public shell script from an ephemeral same-shape repository root that structurally lacks a local venv.

## Validation

- red reproduction with documented repository venv present: 2 failed, 13 deselected
- corrected provider fixture module: 15 passed
- full Python suite with the real repository venv continuously present: 1,967 passed, 35 skipped
- path-with-spaces adversarial pytest base: both missing-dependency cases passed
- Ruff check: passed
- repository quick checks: passed
- diff hygiene: passed
- checksum-verified gitleaks 8.18.0: 597 commits and changed file, no leaks
- independent security diff review: zero findings

## Boundaries

- no production runner, setup, adapter, or exit behavior changes
- no provider calls or credentials
- public precedence remains explicit `PYTHON`, repository venv, then supported PATH interpreter
- README/docs unchanged because the user-facing contract is unchanged
- no runtime, infrastructure, or cloud-cost impact

## Primary references

- Python `shutil.copy` copies file data and permission mode: https://docs.python.org/3/library/shutil.html#shutil.copy
- pytest `tmp_path` provides a unique temporary directory per test invocation: https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmp-path-fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for adapter runner behavior when no repository virtual environment is available.
  * Added validation that an isolated run does not create a local virtual environment or generate an unexpected report.
  * Preserved checks for failure status and clear missing-dependency error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->