### PR TITLE
docs(research): replace bot-blocked policy citations

### DIFF
--- a/docs/research/epic-b-policy-selection.md
+++ b/docs/research/epic-b-policy-selection.md
@@ -637,9 +637,9 @@ Web (accessed 2026-07-03):
 - Santa MONITOR/LOCKDOWN semantics: <https://santa.dev/concepts/mode.html>,
   <https://github.com/northpolesec/santa>
 - SELinux targeted/unconfined; AppArmor complain mode + `aa-logprof`:
-  <https://documentation.suse.com/sles/12-SP5/html/SLES-all/cha-apparmor-concept.html>,
-  <https://wiki.archlinux.org/title/AppArmor>,
-  <https://tuxcare.com/blog/selinux-vs-apparmor/>
+  <https://fedoraproject.org/wiki/SELinux/Policies>,
+  <https://documentation.ubuntu.com/server/how-to/security/apparmor/>,
+  <https://apparmor.net/man/4.0/aa-logprof/>
 - NAC/802.1X quarantine & guest VLAN, posture assessment:
   <https://www.forescout.com/glossary/802-1x-network-access-control/>,
   <https://infohub.delltechnologies.com/static/media/60658f87-85c9-4493-a78a-7871a3e7acbb.pdf>

--- a/site/content/source/docs/research/epic-b-policy-selection.md
+++ b/site/content/source/docs/research/epic-b-policy-selection.md
@@ -2,7 +2,7 @@
 title: "Epic B — Policy Selection for Un-Wrapped Agents: Default Missions, Binding Rules, and the Governance Posture Ladder"
 description: "Status: **research/design document** (2026-07-03). No code changed. This is the"
 source_path: "docs/research/epic-b-policy-selection.md"
-source_sha256: "e28081a82b0980c4b2df977fbd92c40b662273fbc1d30aa2c3046362d6e284f7"
+source_sha256: "62c51124d24600fb3d247f9c2197719bafbfc3e264a8e60381682e0a72e87d6d"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -654,9 +654,9 @@ Web (accessed 2026-07-03):
 - Santa MONITOR/LOCKDOWN semantics: <https://santa.dev/concepts/mode.html>,
   <https://github.com/northpolesec/santa>
 - SELinux targeted/unconfined; AppArmor complain mode + `aa-logprof`:
-  <https://documentation.suse.com/sles/12-SP5/html/SLES-all/cha-apparmor-concept.html>,
-  <https://wiki.archlinux.org/title/AppArmor>,
-  <https://tuxcare.com/blog/selinux-vs-apparmor/>
+  <https://fedoraproject.org/wiki/SELinux/Policies>,
+  <https://documentation.ubuntu.com/server/how-to/security/apparmor/>,
+  <https://apparmor.net/man/4.0/aa-logprof/>
 - NAC/802.1X quarantine & guest VLAN, posture assessment:
   <https://www.forescout.com/glossary/802-1x-network-access-control/>,
   <https://infohub.delltechnologies.com/static/media/60658f87-85c9-4493-a78a-7871a3e7acbb.pdf>


### PR DESCRIPTION
## Summary

- replace the inaccessible SELinux/AppArmor comparison citation with direct Fedora, Ubuntu, and upstream AppArmor documentation
- refresh the generated source-backed Hugo mirror and digest
- preserve the research statement without adding a link-check exclusion or timeout exception

Closes #351.
Unblocks required link validation for #350.

## Validation

- exact Lychee v0.24.2 workflow arguments: 585 total, 327 unique, 578 successful, 7 intentionally excluded, zero errors
- `./scripts/check-local.sh --quick`
- `python3 site/scripts/sync_source_docs.py --check`
- `python3 site/scripts/validate_claims.py` — 10 claims
- `python3 -m unittest discover -s site/tests -p test_*.py -v` — 18 passed
- `hugo --source site --destination /tmp/ardur-issue-351-hugo --gc --minify` — 292 pages
- generated mirror source SHA-256 matches the source document

## Security and operations

- final security diff reviewed 14/14 changed rows with zero findings and zero deferred items
- all added references use HTTPS without URL userinfo, embedded credentials, unsafe schemes, or local paths
- no runtime, authorization, dependency, workflow, exclusion, timeout, permission, secret, or cloud-cost change
- README reviewed; no update is required for this citation-only repair

## Commit integrity

- signed head: `3e7c270ad0090233071fec8a9ba4135bb5f53300`
- sealed diff SHA-256: `ad1bdaa44fba405cd06bcac282f76a91176990a55521bcc9cfa0e33e3ad588f7`
- DCO and GSTACK checkpoint trailers present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SELinux and AppArmor reference links with current Fedora, Ubuntu, and AppArmor documentation sources.
  * Refreshed the generated documentation metadata to reflect the latest source content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->