### PR TITLE
fix(biscuit): scope authority baseline explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Scope Biscuit authority-baseline queries explicitly to the issuer-signed
+  authority block and reject duplicate required or optional scalar facts
+  instead of selecting a row by dependency-defined ordering
 - Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
   side-effect, budget, time, delegation, lineage-parent, or working-directory
   authority while preserving valid transitive attenuation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to Ardur will be documented in this file.
 ### Security
 - Scope Biscuit authority-baseline queries explicitly to the issuer-signed
   authority block and reject duplicate required or optional scalar facts
-  instead of selecting a row by dependency-defined ordering
+  instead of selecting a row by dependency-defined ordering; verified by
+  `test_verify_preserves_special_authority_values_with_explicit_scope` and
+  `test_verify_rejects_duplicate_authority_scalar`
 - Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
   side-effect, budget, time, delegation, lineage-parent, or working-directory
   authority while preserving valid transitive attenuation

--- a/python/tests/test_biscuit_passport.py
+++ b/python/tests/test_biscuit_passport.py
@@ -6,6 +6,7 @@ from dataclasses import fields
 import pytest
 from biscuit_auth import (
     Biscuit,
+    BiscuitBuilder,
     BiscuitValidationError,
     BlockBuilder,
     Fact,
@@ -213,6 +214,65 @@ def test_verify_accepts_valid_biscuit() -> None:
     assert context.agent_id == "agent-001"
     assert context.spiffe_id == "spiffe://example.org/agent/root"
     assert context.issuer_spiffe_id == "spiffe://example.org/issuer/root"
+
+
+def test_verify_preserves_special_authority_values_with_explicit_scope() -> None:
+    keypair = _keypair()
+    mission = 'line 1\nline 2; a "quoted" value'
+    token = issue_biscuit_passport(
+        _mission(mission=mission),
+        keypair.private_key,
+        "spiffe://example.org/issuer/root",
+        now=100,
+    )
+
+    context = verify_biscuit_passport(token, keypair.public_key, now=101)
+
+    assert context.mission == mission
+
+
+@pytest.mark.parametrize(
+    ("duplicate_sources", "error"),
+    [
+        (
+            ("max_tool_calls(1)", "max_tool_calls(999)"),
+            "malformed:max_tool_calls",
+        ),
+        (
+            (
+                "max_tool_calls(1)",
+                'mission_id("mission:first")',
+                'mission_id("mission:second")',
+            ),
+            "malformed:mission_id",
+        ),
+    ],
+)
+def test_verify_rejects_duplicate_authority_scalar(
+    duplicate_sources: tuple[str, ...],
+    error: str,
+) -> None:
+    keypair = _keypair()
+    builder = BiscuitBuilder()
+    authority_sources = (
+        'agent_id("agent-001")',
+        'spiffe_id("spiffe://example.org/agent/root")',
+        'issuer_spiffe_id("spiffe://example.org/issuer/root")',
+        'mission("duplicate scalar regression")',
+        'jti("root-jti")',
+        "iat(100)",
+        "exp(700)",
+        "max_duration_s(300)",
+        "delegation_allowed(false)",
+        "max_delegation_depth(0)",
+        "resource_scope_empty(true)",
+    )
+    for source in (*authority_sources, *duplicate_sources):
+        builder.add_fact(Fact(source))
+    token = bytes(builder.build(keypair.private_key).to_bytes())
+
+    with pytest.raises(BiscuitVerifyError, match=error):
+        verify_biscuit_passport(token, keypair.public_key, now=101)
 
 
 def test_verify_rejects_wrong_root_public_key() -> None:

--- a/python/vibap/biscuit_passport.py
+++ b/python/vibap/biscuit_passport.py
@@ -255,13 +255,9 @@ def verify_biscuit_passport(
     # facts (jti / mission / etc.) — the iat-bound failure is the
     # primary security signal for the audit's threat model.
     # FIX-R6-8 (round-6, 2026-04-29): walk EVERY iat fact row in EVERY
-    # block, not just iat_facts[0]. Round-5 audit (LOW-1) noted that
-    # ``_extract_authority_block_facts`` queries the authorizer which
-    # may return iat rows from any block that asserted ``iat(...)``;
-    # if a future biscuit-auth library version reverses the iteration
-    # order, an attacker's far-future authority iat could hide behind
-    # a benign present-time iat at index 0. Iterating every row makes
-    # the bound robust to row-ordering changes upstream.
+    # block, not just iat_facts[0]. Iterating every row keeps the bound robust
+    # if a malformed block contains duplicate iat facts or query row ordering
+    # changes upstream.
     for block_index, block in enumerate(block_facts):
         iat_facts = block.get("iat", [])
         if not iat_facts:
@@ -830,6 +826,16 @@ def _parse_block_source(source: str) -> dict[str, Any]:
 
 
 def _extract_authority_block_facts(authorizer: Any, source: str) -> dict[str, Any]:
+    """Return structured facts that explicitly trust only the authority block.
+
+    ``Biscuit.block_source()`` is a display API, not a lossless serialization:
+    biscuit-python 0.4.0 can print embedded quotes and newlines without escapes,
+    so reparsing block 0 would reject valid credentials. Structured queries keep
+    the original values intact. Every rule carries Biscuit's explicit
+    ``trusting authority`` scope so appended holder blocks cannot contribute
+    facts even if a future binding changes the query method's default scope.
+    """
+
     facts: dict[str, Any] = {"__source__": source}
     for name in (
         "agent_id",
@@ -846,7 +852,7 @@ def _extract_authority_block_facts(authorizer: Any, source: str) -> dict[str, An
         "resource_scope_empty",
         "allowed_side_effect_class",
     ):
-        rows = _query_fact_terms(authorizer, name, 1)
+        rows = _query_authority_fact_terms(authorizer, name, 1)
         if rows:
             facts[name] = rows
 
@@ -857,24 +863,33 @@ def _extract_authority_block_facts(authorizer: Any, source: str) -> dict[str, An
         "max_duration_s",
         "max_delegation_depth",
     ):
-        rows = _query_fact_terms(authorizer, name, 1)
+        rows = _query_authority_fact_terms(authorizer, name, 1)
         if rows:
             facts[name] = rows
 
-    delegation_rows = _query_fact_terms(authorizer, "delegation_allowed", 1)
+    delegation_rows = _query_authority_fact_terms(authorizer, "delegation_allowed", 1)
     if delegation_rows:
         facts["delegation_allowed"] = delegation_rows
 
-    budget_rows = _query_fact_terms(authorizer, "max_tool_calls_per_class", 2)
+    budget_rows = _query_authority_fact_terms(
+        authorizer, "max_tool_calls_per_class", 2
+    )
     if budget_rows:
         facts["max_tool_calls_per_class"] = budget_rows
 
     return facts
 
 
-def _query_fact_terms(authorizer: Any, predicate: str, arity: int) -> list[list[Any]]:
+def _query_authority_fact_terms(
+    authorizer: Any,
+    predicate: str,
+    arity: int,
+) -> list[list[Any]]:
     variables = ", ".join(f"$v{index}" for index in range(arity))
-    rows = authorizer.query(Rule(f"data({variables}) <- {predicate}({variables})"))
+    rule = Rule(
+        f"data({variables}) <- {predicate}({variables}) trusting authority"
+    )
+    rows = authorizer.query(rule)
     return [list(row.terms) for row in rows]
 
 
@@ -925,9 +940,11 @@ def _required_single(block: dict[str, Any], name: str, expected_type: type[Any])
     values = block.get(name)
     if not values:
         raise ValueError(f"missing:{name}")
-    value = values[-1][0] if len(values[-1]) == 1 else None
+    if len(values) != 1:
+        raise ValueError(f"malformed:{name}")
+    value = values[0][0] if len(values[0]) == 1 else None
     if (
-        len(values[-1]) != 1
+        len(values[0]) != 1
         or not isinstance(value, expected_type)
         or (expected_type is int and isinstance(value, bool))
     ):
@@ -941,9 +958,13 @@ def _optional_single(
     values = block.get(name)
     if not values:
         return None
-    if len(values[-1]) != 1 or not isinstance(values[-1][0], expected_type):
+    if (
+        len(values) != 1
+        or len(values[0]) != 1
+        or not isinstance(values[0][0], expected_type)
+    ):
         raise ValueError(f"malformed:{name}")
-    return values[-1][0]
+    return values[0][0]
 
 
 def _fact_values(

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "4ed143c3bc5e2c15aa0975af19b5818108f0873137883db6437bc94bb8ce5b41"
+source_sha256: "57f57467042aba072cef2a05218f66abf446555017f112930b105eca32962ae6"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -22,6 +22,9 @@ All notable changes to Ardur will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- Scope Biscuit authority-baseline queries explicitly to the issuer-signed
+  authority block and reject duplicate required or optional scalar facts
+  instead of selecting a row by dependency-defined ordering
 - Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
   side-effect, budget, time, delegation, lineage-parent, or working-directory
   authority while preserving valid transitive attenuation

--- a/site/content/source/CHANGELOG.md
+++ b/site/content/source/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to Ardur will be documented in this file."
 source_path: "CHANGELOG.md"
-source_sha256: "57f57467042aba072cef2a05218f66abf446555017f112930b105eca32962ae6"
+source_sha256: "096ad506c8fa785042bc35dc5243238148df09149794671d8d3e0ce33d264ba5"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -24,7 +24,9 @@ All notable changes to Ardur will be documented in this file.
 ### Security
 - Scope Biscuit authority-baseline queries explicitly to the issuer-signed
   authority block and reject duplicate required or optional scalar facts
-  instead of selecting a row by dependency-defined ordering
+  instead of selecting a row by dependency-defined ordering; verified by
+  `test_verify_preserves_special_authority_values_with_explicit_scope` and
+  `test_verify_rejects_duplicate_authority_scalar`
 - Reject holder-authored Biscuit blocks that widen tool, deny-list, resource,
   side-effect, budget, time, delegation, lineage-parent, or working-directory
   authority while preserving valid transitive attenuation


### PR DESCRIPTION
## Summary

- add explicit `trusting authority` scope to every structured Biscuit authority-baseline query
- reject duplicate required and optional scalar facts instead of selecting a dependency-ordered row
- preserve valid multiline, semicolon, and quoted authority values without reparsing `block_source()` display output
- document the hardening in the changelog and regenerate the Hugo mirror

## Security rationale

This is defense-in-depth, not a confirmed live vulnerability with `biscuit-python==0.4.0`. Current default queries are authority-scoped. The explicit scope makes that trust decision part of every rule, while strict scalar cardinality removes the independent last-wins or first-wins ambiguity.

The issue proposed reparsing `parsed.block_source(0)`. A regression run showed that `block_source()` is not a lossless serialization for valid parameter-bound strings containing newlines and quotes. Keeping structured query results avoids building a security parser over display text.

Primary sources:

- https://doc.biscuitsec.org/getting-started/authorization-policies
- https://doc.biscuitsec.org/reference/datalog.html
- https://doc.biscuitsec.org/reference/specifications
- https://github.com/eclipse-biscuit/biscuit-python/blob/0.4.0/src/lib.rs

## Validation

- focused Biscuit suite: 61 passed
- full Python suite: 2,058 passed, 35 skipped, 6 warnings
- all Go tests and `go vet ./...`: passed
- repository quick and full gates: passed
- Ruff 0.13.0 lint: passed
- source mirror verification: 120 pages, 132 artifacts
- gitleaks: zero findings
- pip-audit: zero known vulnerabilities

The repeatedly timing-out Codex Security app setup was skipped under the user-authorized exception; this PR does not claim that app ledger complete.

Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Biscuit passport verification against malformed or duplicate authority facts.
  * Ensured authority values (including quoted text and newlines) are preserved correctly when an explicit authority scope is provided.
  * Restricted authority verification to issuer-signed authority data so appended blocks can’t affect results.
  * Improved validation for required/optional scalar authority facts with clearer “malformed” error reporting.
* **Tests**
  * Added regression tests covering special authority value preservation and rejection of duplicate scalar sources.
* **Documentation**
  * Updated the unreleased security changelog to reflect the improved verification safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->