### PR TITLE
fix(security): preserve MIC claims across delegation

### DIFF
--- a/docs/specs/ardur-drp-mapping-v0.1.json
+++ b/docs/specs/ardur-drp-mapping-v0.1.json
@@ -25,7 +25,7 @@
     },
     "legacy_python_passport": {
       "contract": "python/vibap/passport.py",
-      "scope": "JWT mission-passport claims emitted by issue_passport plus derive_child_passport lineage extensions, including explicit inventory of runtime-only claims that the current DRP profile must reject."
+      "scope": "JWT mission-passport claims emitted by issue_passport plus derive_child_passport lineage and MIC conformance extensions, including explicit inventory of runtime-only claims that the current DRP profile must reject."
     },
     "execution_receipt_v0.2": {
       "contract": "docs/specs/execution-receipt-v0.2.schema.json",
@@ -97,6 +97,7 @@
     "widening_rejected": "Tools, resources, argument constraints, budgets, time, and delegation depth MUST never widen.",
     "unknown_critical_extension_rejected": "A verifier that does not understand every path listed in metadata.x-ardur.critical MUST DENY and MUST NOT downgrade to base DRP authorization.",
     "unprojected_risk_budget_rejected": "A source credential carrying risk_budget MUST NOT be emitted or verified by this profile because typed contract and multi-scope ledger semantics are not implemented; dropping the claim is forbidden.",
+    "unprojected_mic_policy_bundle_rejected": "A source credential carrying conformance_profile or receipt_policy MUST NOT be emitted by this profile; the entire MIC bundle MUST be rejected and tool_manifest_digest MUST NOT be partially projected.",
     "tri_state_extension": "Ardur insufficient_evidence MUST project to DRP DENY while remaining distinguishable in the signed extension.",
     "no_redelegation": "redelegation.mode=none MUST prohibit creation of any sub-receipt.",
     "bounded_redelegation": "redelegation.mode=bounded MUST require depth below maxDepth and child maxDepth no greater than the parent.",
@@ -556,6 +557,27 @@
       "classification": "extension",
       "drp_path": "metadata.x-ardur.budget.reservedShare",
       "rationale": "Signed child budget reservation."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "conformance_profile",
+      "classification": "out_of_scope",
+      "drp_path": null,
+      "rationale": "The current DRP profile cannot preserve the MIC enforcement and evidence tier. Any source carrying this policy claim must fail closed; the MIC bundle must never be partially projected."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "receipt_policy",
+      "classification": "out_of_scope",
+      "drp_path": null,
+      "rationale": "The current DRP profile cannot preserve the MIC receipt-evidence requirement. Any source carrying this policy claim must fail closed; the MIC bundle must never be partially projected."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "tool_manifest_digest",
+      "classification": "extension",
+      "drp_path": "metadata.x-ardur.capabilityTokenRef.toolManifestDigest",
+      "rationale": "Normalize the legacy sha-256:<64-lowercase-hex> tag to the DRP extension's sha256:<64-lowercase-hex> tag while preserving the exact trusted tool-manifest digest."
     },
     {
       "source_surface": "execution_receipt_v0.2",

--- a/docs/specs/ardur-drp-mapping-v0.1.md
+++ b/docs/specs/ardur-drp-mapping-v0.1.md
@@ -29,8 +29,9 @@ members:
    `authorization_details`, argument-constraint members, `mission_ref`,
    `reserved_budget_share`, and `lineage_budget_share`;
 2. the JWT mission passport emitted by `python/vibap/passport.py`, including
-   child-lineage claims added by `derive_child_passport` and the optional
-   runtime-only `risk_budget` extension; and
+   child-lineage and inherited MIC conformance claims added by
+   `derive_child_passport`, plus the optional runtime-only `risk_budget`
+   extension; and
 3. every top-level property in
    `docs/specs/execution-receipt-v0.2.schema.json`.
 
@@ -78,6 +79,7 @@ transformations are:
 | depth and delegation policy | `metadata.x-ardur.redelegation` | DRP describes depth behavior but has no Authorization Object fields for mode, depth, or maximum depth. |
 | budgets and policy references | `metadata.x-ardur.budget`, `metadata.x-ardur.policy` | Security-critical extensions that participate in attenuation checks. |
 | Python `risk_budget` | No projection in the current profile | The current emitter/verifier does not implement typed fact contracts or atomic session/agent/lineage risk accounting. An emitter presented with this claim MUST deny/fail closed instead of dropping it. A future profile may define a critical `metadata.x-ardur.riskBudget` extension. |
+| Python MIC `conformance_profile`, `receipt_policy`, `tool_manifest_digest` | No projection for the policy claims; `metadata.x-ardur.capabilityTokenRef.toolManifestDigest` for a standalone digest | The current DRP profile cannot preserve the MIC enforcement/evidence tier. If either policy claim is present, reject the entire source object and never export only the digest. A standalone digest changes its tag from `sha-256:` to `sha256:` without changing the 64 lowercase hexadecimal digest. |
 | `mission_ref` | `metadata.x-ardur.missionRef` | DRP instruction commitment does not replace the governing Mission Declaration reference. |
 
 ### 3.1. Critical Extension Rule
@@ -114,6 +116,24 @@ prohibitions into stable `deny:<operation>:<resource>` strings. When the source
 has no explicit prohibition, it MUST include
 `x-ardur:deny-unlisted-actions`, which records the profile's closed-world
 default without inventing a permission.
+
+### 3.3. MIC Bundle Fail-Closed Rule
+
+The legacy Python passport may carry `conformance_profile`, `receipt_policy`,
+and `tool_manifest_digest` as one signed MIC conformance bundle. The current
+DRP profile can preserve the manifest digest but cannot preserve or enforce the
+MIC profile and receipt-evidence tier. Therefore, if either
+`conformance_profile` or `receipt_policy` is present, the emitter MUST reject
+the entire source object. It MUST NOT project `tool_manifest_digest` while
+silently dropping either policy claim, and a partial or malformed MIC bundle
+MUST NOT be treated as a standalone digest.
+
+When `tool_manifest_digest` is genuinely standalone and neither MIC policy
+claim is present, the emitter MAY retain it at
+`metadata.x-ardur.capabilityTokenRef.toolManifestDigest`. The conversion
+changes only the algorithm tag from the legacy `sha-256:` spelling to the DRP
+profile's `sha256:` spelling; the 64 lowercase hexadecimal digest bytes remain
+identical.
 
 ## 4. Target Authorization Object
 

--- a/python/tests/test_delegation.py
+++ b/python/tests/test_delegation.py
@@ -11,11 +11,47 @@ import pytest
 
 from vibap.passport import (
     MissionPassport,
+    _inherited_mic_conformance_claims,
     derive_child_passport,
     generate_keypair,
     issue_passport,
     verify_passport,
 )
+
+
+MIC_MANIFEST_DIGEST = "sha-256:" + ("a" * 64)
+MIC_CLAIMS = frozenset(
+    {"conformance_profile", "receipt_policy", "tool_manifest_digest"}
+)
+
+
+def _issue_delegating_parent(private_key, *, extra_claims=None):
+    return issue_passport(
+        MissionPassport(
+            agent_id="mic-parent",
+            mission="delegate governed work",
+            allowed_tools=["read"],
+            max_tool_calls=5,
+            max_duration_s=120,
+            delegation_allowed=True,
+            max_delegation_depth=1,
+        ),
+        private_key,
+        ttl_s=120,
+        extra_claims=extra_claims,
+    )
+
+
+def _derive_child(parent_token, private_key, public_key):
+    return derive_child_passport(
+        parent_token=parent_token,
+        public_key=public_key,
+        private_key=private_key,
+        child_agent_id="mic-child",
+        child_allowed_tools=["read"],
+        child_mission="perform governed work",
+        child_ttl_s=60,
+    )
 
 
 @pytest.fixture
@@ -67,6 +103,193 @@ class TestScopeNarrowing:
                 child_mission="evil",
                 child_ttl_s=60,
             )
+
+
+class TestMICConformanceInheritance:
+    def test_inherited_receipt_policy_is_deep_copied(self):
+        parent_claims = {
+            "conformance_profile": "MIC-Evidence",
+            "receipt_policy": {"level": "counter_signed"},
+            "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+        }
+
+        inherited = _inherited_mic_conformance_claims(parent_claims)
+        inherited["receipt_policy"]["level"] = "transparency_logged"
+
+        assert parent_claims["receipt_policy"] == {"level": "counter_signed"}
+
+    @pytest.mark.parametrize(
+        ("profile", "receipt_level"),
+        [
+            ("Delegation-Core", "minimal"),
+            ("MIC-State", "minimal"),
+            ("MIC-Evidence", "counter_signed"),
+        ],
+    )
+    def test_child_inherits_only_complete_mic_bundle(
+        self,
+        private_key,
+        public_key,
+        profile,
+        receipt_level,
+    ):
+        expected = {
+            "conformance_profile": profile,
+            "receipt_policy": {"level": receipt_level},
+            "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+        }
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims={
+                **expected,
+                "issuer_private_marker": {"must": "not propagate"},
+            },
+        )
+
+        child = _derive_child(parent, private_key, public_key)
+        claims = verify_passport(child, public_key, parent_token=parent)
+
+        assert {claim: claims[claim] for claim in MIC_CLAIMS} == expected
+        assert "issuer_private_marker" not in claims
+
+    @pytest.mark.parametrize(
+        "legacy_extras",
+        [
+            None,
+            {"receipt_policy": {"level": "minimal"}},
+            {"tool_manifest_digest": MIC_MANIFEST_DIGEST},
+            {
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+        ],
+    )
+    def test_legacy_parent_without_profile_remains_legacy(
+        self,
+        private_key,
+        public_key,
+        legacy_extras,
+    ):
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims=legacy_extras,
+        )
+
+        child = _derive_child(parent, private_key, public_key)
+        claims = verify_passport(child, public_key, parent_token=parent)
+
+        assert MIC_CLAIMS.isdisjoint(claims)
+
+    @pytest.mark.parametrize(
+        "extra_claims",
+        [
+            {"conformance_profile": "MIC-State"},
+            {
+                "conformance_profile": "MIC-Unknown",
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+            {
+                "conformance_profile": "MIC-State",
+                "receipt_policy": {"level": "unknown"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+            {
+                "conformance_profile": "MIC-State",
+                "receipt_policy": {"level": "minimal", "extra": True},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+            {
+                "conformance_profile": "MIC-State",
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": "sha-256:not-a-digest",
+            },
+            {
+                "conformance_profile": "MIC-Evidence",
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+        ],
+    )
+    def test_partial_or_malformed_mic_bundle_fails_closed(
+        self,
+        private_key,
+        public_key,
+        extra_claims,
+    ):
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims=extra_claims,
+        )
+
+        with pytest.raises(PermissionError, match="MIC conformance claim bundle"):
+            _derive_child(parent, private_key, public_key)
+
+    def test_parent_extras_cannot_overwrite_child_lineage_claims(
+        self, private_key, public_key
+    ):
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims={
+                "conformance_profile": "MIC-State",
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+                "parent_token_hash": "attacker-controlled",
+                "reserved_budget_share": 999,
+            },
+        )
+
+        child = _derive_child(parent, private_key, public_key)
+        claims = verify_passport(child, public_key, parent_token=parent)
+
+        expected_parent_hash = hashlib.sha256(parent.encode("utf-8")).hexdigest()
+        assert claims["parent_token_hash"] == expected_parent_hash
+        assert claims["reserved_budget_share"] == claims["max_tool_calls"]
+
+    def test_parent_aware_verification_rejects_pre_fix_child_without_bundle(
+        self, private_key, public_key
+    ):
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims={
+                "conformance_profile": "MIC-Evidence",
+                "receipt_policy": {"level": "counter_signed"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+        )
+        child = _derive_child(parent, private_key, public_key)
+        child_claims = verify_passport(child, public_key, parent_token=parent)
+        for claim in MIC_CLAIMS:
+            child_claims.pop(claim)
+        pre_fix_child = jwt.encode(child_claims, private_key, algorithm="ES256")
+
+        with pytest.raises(
+            PermissionError,
+            match="child MIC conformance claim bundle does not match parent",
+        ):
+            verify_passport(pre_fix_child, public_key, parent_token=parent)
+
+    def test_parent_aware_verification_rejects_weaker_child_profile(
+        self, private_key, public_key
+    ):
+        parent = _issue_delegating_parent(
+            private_key,
+            extra_claims={
+                "conformance_profile": "MIC-Evidence",
+                "receipt_policy": {"level": "counter_signed"},
+                "tool_manifest_digest": MIC_MANIFEST_DIGEST,
+            },
+        )
+        child = _derive_child(parent, private_key, public_key)
+        child_claims = verify_passport(child, public_key, parent_token=parent)
+        child_claims["conformance_profile"] = "MIC-State"
+        weakened_child = jwt.encode(child_claims, private_key, algorithm="ES256")
+
+        with pytest.raises(
+            PermissionError,
+            match="child MIC conformance claim bundle does not match parent",
+        ):
+            verify_passport(weakened_child, public_key, parent_token=parent)
 
 
 class TestMultiLevel:

--- a/python/tests/test_drp_mapping_contract.py
+++ b/python/tests/test_drp_mapping_contract.py
@@ -4,6 +4,8 @@ import ast
 import json
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PASSPORT_SOURCE = REPO_ROOT / "python" / "vibap" / "passport.py"
@@ -35,20 +37,133 @@ def _module_string_constants(tree: ast.Module) -> dict[str, str]:
     return constants
 
 
+def _module_string_sequence_constant(tree: ast.Module, name: str) -> set[str]:
+    """Resolve one required module-level literal sequence into unique keys."""
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name) or target.id != name:
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            raise AssertionError(f"{name} must be a literal string sequence")
+        values: list[str] = []
+        for element in node.value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(
+                element.value, str
+            ):
+                raise AssertionError(f"{name} must be a literal string sequence")
+            values.append(element.value)
+        if not values:
+            raise AssertionError(f"{name} must not be empty")
+        if len(values) != len(set(values)):
+            raise AssertionError(f"{name} must not contain duplicate entries")
+        return set(values)
+    raise AssertionError(f"missing module constant {name}")
+
+
 def _string_dict_keys(node: ast.Dict, constants: dict[str, str]) -> set[str]:
+    """Resolve static string keys while rejecting duplicate wire names."""
+
     keys: set[str] = set()
     for key in node.keys:
         if isinstance(key, ast.Constant) and isinstance(key.value, str):
-            keys.add(key.value)
-            continue
-        if isinstance(key, ast.Name) and key.id in constants:
-            keys.add(constants[key.id])
-            continue
+            resolved_key = key.value
+        elif isinstance(key, ast.Name) and key.id in constants:
+            resolved_key = constants[key.id]
         else:
             raise AssertionError(
                 "passport wire dictionaries must use literal string keys"
             )
+        if resolved_key in keys:
+            raise AssertionError(
+                "passport wire dictionaries must not contain duplicate resolved keys"
+            )
+        keys.add(resolved_key)
     return keys
+
+
+def _inherited_mic_claim_keys(tree: ast.Module) -> set[str]:
+    """Recover the closed MIC inventory from its approved helper shape."""
+
+    function = _function(tree, "_inherited_mic_conformance_claims")
+    approved_claims = _module_string_sequence_constant(tree, "_DELEGATED_MIC_CLAIMS")
+    nonempty_returns = 0
+
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Return):
+            continue
+        value = node.value
+        if isinstance(value, ast.Dict) and not value.keys and not value.values:
+            continue
+        if not isinstance(value, ast.DictComp) or len(value.generators) != 1:
+            raise AssertionError(
+                "_inherited_mic_conformance_claims may only return an empty "
+                "dictionary or the approved claim-key comprehension"
+            )
+        generator = value.generators[0]
+        if (
+            generator.is_async
+            or generator.ifs
+            or not isinstance(generator.target, ast.Name)
+            or not isinstance(generator.iter, ast.Name)
+            or generator.iter.id != "_DELEGATED_MIC_CLAIMS"
+            or not isinstance(value.key, ast.Name)
+            or value.key.id != generator.target.id
+        ):
+            raise AssertionError(
+                "_inherited_mic_conformance_claims non-empty return must be "
+                "keyed solely from _DELEGATED_MIC_CLAIMS"
+            )
+        nonempty_returns += 1
+
+    if nonempty_returns != 1:
+        raise AssertionError(
+            "_inherited_mic_conformance_claims must have exactly one approved "
+            "non-empty return"
+        )
+    return approved_claims
+
+
+def _derived_literal_dict_keys(
+    tree: ast.Module,
+    node: ast.Dict,
+    constants: dict[str, str],
+) -> set[str]:
+    """Recover derived claims from the single approved literal dictionary."""
+
+    unpack_indexes = [index for index, key in enumerate(node.keys) if key is None]
+    if unpack_indexes != [0]:
+        raise AssertionError(
+            "derive_child_passport extra_claims must start with exactly one "
+            "approved MIC inheritance unpack"
+        )
+    inherited = node.values[0]
+    if (
+        not isinstance(inherited, ast.Call)
+        or not isinstance(inherited.func, ast.Name)
+        or inherited.func.id != "_inherited_mic_conformance_claims"
+        or len(inherited.args) != 1
+        or not isinstance(inherited.args[0], ast.Name)
+        or inherited.args[0].id != "parent"
+        or inherited.keywords
+    ):
+        raise AssertionError(
+            "derive_child_passport approved MIC inheritance unpack must be "
+            "_inherited_mic_conformance_claims(parent)"
+        )
+
+    literal_claims = ast.Dict(keys=node.keys[1:], values=node.values[1:])
+    claims = _string_dict_keys(literal_claims, constants)
+    inherited_claims = _inherited_mic_claim_keys(tree)
+    collisions = claims & inherited_claims
+    if collisions:
+        raise AssertionError(
+            "derive_child_passport literal claims must not overwrite inherited "
+            f"MIC claims: {sorted(collisions)}"
+        )
+    return claims | inherited_claims
 
 
 def _issued_passport_claims(tree: ast.Module) -> set[str]:
@@ -77,21 +192,38 @@ def _issued_passport_claims(tree: ast.Module) -> set[str]:
 
 
 def _derived_passport_claims(tree: ast.Module) -> set[str]:
+    """Recover claims signed by the sole supported child-emission path."""
+
     function = _function(tree, "derive_child_passport")
     constants = _module_string_constants(tree)
+    issue_passport_calls: list[ast.Call] = []
     for node in ast.walk(function):
         if not isinstance(node, ast.Call):
             continue
         if not isinstance(node.func, ast.Name) or node.func.id != "issue_passport":
             continue
-        for keyword in node.keywords:
-            if keyword.arg == "extra_claims":
-                if not isinstance(keyword.value, ast.Dict):
-                    raise AssertionError(
-                        "derive_child_passport extra_claims must be literal"
-                    )
-                return _string_dict_keys(keyword.value, constants)
-    raise AssertionError("missing derive_child_passport extra_claims")
+        issue_passport_calls.append(node)
+
+    if len(issue_passport_calls) != 1:
+        raise AssertionError(
+            "derive_child_passport must have exactly one direct issue_passport call"
+        )
+    extra_claim_keywords = [
+        keyword
+        for keyword in issue_passport_calls[0].keywords
+        if keyword.arg == "extra_claims"
+    ]
+    if len(extra_claim_keywords) != 1:
+        raise AssertionError(
+            "derive_child_passport issue_passport call must carry exactly one "
+            "extra_claims keyword"
+        )
+    keyword = extra_claim_keywords[0]
+    if not isinstance(keyword.value, ast.Dict):
+        raise AssertionError(
+            "derive_child_passport extra_claims must be a literal dictionary"
+        )
+    return _derived_literal_dict_keys(tree, keyword.value, constants)
 
 
 def test_drp_mapping_covers_legacy_python_passport_claims() -> None:
@@ -126,3 +258,154 @@ def test_drp_mapping_required_extension_fields_match_profile_schema() -> None:
     assert set(mapping["profile_shape"]["ardur_required_fields"]) == set(
         schema["$defs"]["xArdur"]["required"]
     )
+
+
+def test_drp_mapping_pins_mic_bundle_fail_closed_decisions() -> None:
+    mapping = json.loads(MAPPING_PATH.read_text(encoding="utf-8"))
+    mic_paths = {
+        "conformance_profile",
+        "receipt_policy",
+        "tool_manifest_digest",
+    }
+    decisions = {
+        entry["source_path"]: (entry["classification"], entry["drp_path"])
+        for entry in mapping["entries"]
+        if entry["source_surface"] == "legacy_python_passport"
+        and entry["source_path"] in mic_paths
+    }
+
+    assert decisions == {
+        "conformance_profile": ("out_of_scope", None),
+        "receipt_policy": ("out_of_scope", None),
+        "tool_manifest_digest": (
+            "extension",
+            "metadata.x-ardur.capabilityTokenRef.toolManifestDigest",
+        ),
+    }
+    assert mapping["security_requirements"][
+        "unprojected_mic_policy_bundle_rejected"
+    ] == (
+        "A source credential carrying conformance_profile or receipt_policy MUST NOT "
+        "be emitted by this profile; the entire MIC bundle MUST be rejected and "
+        "tool_manifest_digest MUST NOT be partially projected."
+    )
+
+
+@pytest.mark.parametrize(
+    "extra_claims",
+    [
+        "{**unapproved_claims(parent), 'parent_token_hash': 'hash'}",
+        (
+            "{**_inherited_mic_conformance_claims(parent), "
+            "**_inherited_mic_conformance_claims(parent), "
+            "'parent_token_hash': 'hash'}"
+        ),
+    ],
+)
+def test_derived_claim_inventory_rejects_unknown_or_multiple_unpacks(
+    extra_claims: str,
+) -> None:
+    tree = ast.parse(
+        f"""
+def derive_child_passport():
+    return issue_passport(extra_claims={extra_claims})
+"""
+    )
+
+    with pytest.raises(AssertionError, match="approved MIC inheritance unpack"):
+        _derived_passport_claims(tree)
+
+
+def test_derived_claim_inventory_rejects_multiple_issue_calls() -> None:
+    tree = ast.parse(
+        """
+def derive_child_passport():
+    if legacy:
+        return issue_passport(extra_claims={"parent_token_hash": "hash"})
+    return issue_passport()
+"""
+    )
+
+    with pytest.raises(AssertionError, match="exactly one direct issue_passport call"):
+        _derived_passport_claims(tree)
+
+
+def test_derived_claim_inventory_rejects_unapproved_helper_keys() -> None:
+    tree = ast.parse(
+        """
+_DELEGATED_MIC_CLAIMS = ("conformance_profile",)
+
+def _inherited_mic_conformance_claims(parent_claims):
+    if "conformance_profile" not in parent_claims:
+        return {}
+    return {"unregistered_claim": parent_claims["unregistered_claim"]}
+
+def derive_child_passport():
+    return issue_passport(
+        extra_claims={
+            **_inherited_mic_conformance_claims(parent),
+            "parent_token_hash": "hash",
+        }
+    )
+"""
+    )
+
+    with pytest.raises(AssertionError, match="approved claim-key comprehension"):
+        _derived_passport_claims(tree)
+
+
+def test_derived_claim_inventory_rejects_mic_claim_overwrite() -> None:
+    tree = ast.parse(
+        """
+_DELEGATED_MIC_CLAIMS = ("conformance_profile",)
+
+def _inherited_mic_conformance_claims(parent_claims):
+    if "conformance_profile" not in parent_claims:
+        return {}
+    return {
+        claim: parent_claims[claim] for claim in _DELEGATED_MIC_CLAIMS
+    }
+
+def derive_child_passport():
+    return issue_passport(
+        extra_claims={
+            **_inherited_mic_conformance_claims(parent),
+            "conformance_profile": "Delegation-Core",
+        }
+    )
+"""
+    )
+
+    with pytest.raises(AssertionError, match="must not overwrite inherited MIC"):
+        _derived_passport_claims(tree)
+
+
+def test_derived_claim_inventory_rejects_duplicate_resolved_literal_keys() -> None:
+    tree = ast.parse(
+        """
+DELEGATION_CHAIN_CLAIM = "delegation_chain"
+
+def derive_child_passport():
+    return issue_passport(
+        extra_claims={
+            **_inherited_mic_conformance_claims(parent),
+            DELEGATION_CHAIN_CLAIM: child_chain,
+            "delegation_chain": attacker_chain,
+        }
+    )
+"""
+    )
+
+    with pytest.raises(AssertionError, match="duplicate resolved keys"):
+        _derived_passport_claims(tree)
+
+
+def test_derived_claim_inventory_rejects_duplicate_sequence_entries() -> None:
+    tree = ast.parse(
+        """
+_DELEGATED_MIC_CLAIMS = ("conformance_profile", "conformance_profile")
+"""
+    )
+
+    with pytest.raises(AssertionError, match="must not contain duplicate entries"):
+        _module_string_sequence_constant(tree, "_DELEGATED_MIC_CLAIMS")

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -28,7 +28,7 @@ import pytest
 # to stand up an HTTP server for testing. If serve_proxy gets refactored into
 # a factory, swap this for a direct call.
 import vibap.mission as mission_module
-from vibap.passport import ALGORITHM, MissionPassport, issue_passport
+from vibap.passport import ALGORITHM, MissionPassport, issue_passport, verify_passport
 from vibap.proxy import GovernanceProxy, serve_proxy
 from vibap.receipt import verify_chain
 from vibap.risk_budget import ToolRiskContract, ToolRiskRegistry
@@ -392,6 +392,213 @@ class TestHTTPDelegate:
         assert status == 200
         assert "child_token" in body
         assert body["child_claims"]["allowed_tools"] == ["read"]
+        assert "conformance_profile" not in body["child_claims"]
+        assert "receipt_policy" not in body["child_claims"]
+        assert "tool_manifest_digest" not in body["child_claims"]
+
+    def test_mic_evidence_delegation_preserves_bundle_and_enforcement(
+        self,
+        http_proxy,
+        private_key,
+        public_key,
+    ):
+        base, _ = http_proxy
+        mission_id = "urn:ardur:mission:http-mic-evidence"
+        manifest_digest = "sha-256:" + ("a" * 64)
+        parent_mission = MissionPassport(
+            agent_id="mic-parent",
+            mission_id=mission_id,
+            mission="delegate evidence-governed work",
+            allowed_tools=["read_file"],
+            resource_scope=["**"],
+            max_tool_calls=5,
+            delegation_allowed=True,
+            max_delegation_depth=1,
+            max_duration_s=120,
+        )
+        parent_extras = v01_required_md_extras(
+            mission_id=mission_id,
+            conformance_profile="MIC-Evidence",
+            receipt_level="counter_signed",
+        )
+        parent_extras["tool_manifest_digest"] = manifest_digest
+        parent_token = issue_passport(
+            parent_mission,
+            private_key,
+            ttl_s=120,
+            extra_claims=parent_extras,
+        )
+        start_status, _ = _post(base + "/session/start", {"token": parent_token})
+        assert start_status == 200
+
+        status, body = _post(
+            base + "/delegate",
+            {
+                "parent_token": parent_token,
+                "child_agent_id": "mic-child",
+                "child_mission": "perform evidence-governed work",
+                "child_allowed_tools": ["read_file"],
+                "child_ttl_s": 60,
+            },
+        )
+        assert status == 200
+
+        child_claims = verify_passport(
+            body["child_token"],
+            public_key,
+            parent_token=parent_token,
+        )
+        assert child_claims["conformance_profile"] == "MIC-Evidence"
+        assert child_claims["receipt_policy"] == {"level": "counter_signed"}
+        assert child_claims["tool_manifest_digest"] == manifest_digest
+        assert "revocation_ref" not in child_claims
+        assert "governed_memory_stores" not in child_claims
+        assert "probing_rate_limit" not in child_claims
+
+        child_start_status, child_start = _post(
+            base + "/session/start",
+            {"token": body["child_token"]},
+        )
+        assert child_start_status == 200
+        telemetry = {
+            "path": "/tmp/http-mic.txt",
+            "observed_manifest_digest": "sha-256:" + ("b" * 64),
+            "envelope_signature_valid": True,
+            "visibility": "full",
+        }
+        evaluation_status, evaluation = _post(
+            base + "/evaluate",
+            {
+                "session_id": child_start["session_id"],
+                "tool_name": "read_file",
+                "arguments": telemetry,
+            },
+        )
+        assert evaluation_status == 200
+        assert evaluation["decision"] == "VIOLATION"
+        assert evaluation["reason"].startswith("manifest_drift:")
+
+        telemetry["observed_manifest_digest"] = manifest_digest
+        telemetry["visibility"] = "partial"
+        _, evidence_evaluation = _post(
+            base + "/evaluate",
+            {
+                "session_id": child_start["session_id"],
+                "tool_name": "read_file",
+                "arguments": telemetry,
+            },
+        )
+        assert evidence_evaluation["decision"] == "INSUFFICIENT_EVIDENCE"
+        assert evidence_evaluation["reason"] == "visibility_insufficient:partial"
+
+    def test_profile_present_partial_bundle_rejected_without_child_reservation(
+        self,
+        http_proxy,
+        private_key,
+    ):
+        base, proxy = http_proxy
+        parent_mission = MissionPassport(
+            agent_id="partial-mic-parent",
+            mission="must not mint a downgraded child",
+            allowed_tools=["read"],
+            max_tool_calls=2,
+            delegation_allowed=True,
+            max_delegation_depth=1,
+            max_duration_s=120,
+        )
+        parent_token = issue_passport(
+            parent_mission,
+            private_key,
+            ttl_s=120,
+            extra_claims={"conformance_profile": "MIC-State"},
+        )
+        start_status, start = _post(
+            base + "/session/start",
+            {"token": parent_token},
+        )
+        assert start_status == 200
+
+        status, body = _post(
+            base + "/delegate",
+            {
+                "parent_token": parent_token,
+                "child_agent_id": "blocked-child",
+                "child_mission": "must not be minted",
+                "child_allowed_tools": ["read"],
+                "child_max_tool_calls": 1,
+                "delegation_request_id": "partial-mic-bundle",
+            },
+        )
+
+        assert status == 403
+        assert "MIC conformance claim bundle is incomplete" in body["error"]
+        assert "child_token" not in body
+        snapshot = proxy.lineage_budget_ledger.snapshot(start["session_id"])
+        assert snapshot["reserved_total"] == 0
+        assert snapshot["reservations"] == {}
+        parent_session = proxy.get_session(start["session_id"])
+        assert parent_session.delegated_children == []
+
+    def test_idempotent_replay_rejects_pre_fix_downgraded_mic_child(
+        self,
+        http_proxy,
+        private_key,
+        monkeypatch,
+    ):
+        base, proxy = http_proxy
+        parent_mission = MissionPassport(
+            agent_id="replay-mic-parent",
+            mission="reject downgraded replay",
+            allowed_tools=["read"],
+            max_tool_calls=2,
+            delegation_allowed=True,
+            max_delegation_depth=1,
+            max_duration_s=120,
+        )
+        parent_token = issue_passport(
+            parent_mission,
+            private_key,
+            ttl_s=120,
+            extra_claims={
+                "conformance_profile": "MIC-State",
+                "receipt_policy": {"level": "minimal"},
+                "tool_manifest_digest": "sha-256:" + ("a" * 64),
+            },
+        )
+        _, start = _post(base + "/session/start", {"token": parent_token})
+        request = {
+            "parent_token": parent_token,
+            "child_agent_id": "pre-fix-child",
+            "child_mission": "old downgraded child",
+            "child_allowed_tools": ["read"],
+            "child_max_tool_calls": 1,
+            "delegation_request_id": "mic-replay",
+        }
+
+        # Reproduce the old derivation/verification boundary once so the
+        # idempotency ledger contains a signed child with no MIC bundle.
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                "vibap.passport._inherited_mic_conformance_claims",
+                lambda *_args, **_kwargs: {},
+            )
+            first_status, first_body = _post(base + "/delegate", request)
+
+        assert first_status == 200
+        assert "conformance_profile" not in first_body["child_claims"]
+        before_replay = proxy.lineage_budget_ledger.snapshot(start["session_id"])
+        assert before_replay["reserved_total"] == 1
+
+        replay_status, replay_body = _post(base + "/delegate", request)
+
+        assert replay_status == 403
+        assert (
+            replay_body["error"]
+            == "child MIC conformance claim bundle does not match parent"
+        )
+        assert "child_token" not in replay_body
+        after_replay = proxy.lineage_budget_ledger.snapshot(start["session_id"])
+        assert after_replay == before_replay
 
     def test_delegation_escalation_returns_403(self, http_proxy, private_key):
         base, _ = http_proxy

--- a/python/tests/test_mic_conformance.py
+++ b/python/tests/test_mic_conformance.py
@@ -17,7 +17,12 @@ from pathlib import Path
 from typing import Any
 
 from vibap.denial import DenialReason
-from vibap.passport import MissionPassport, issue_passport
+from vibap.passport import (
+    MissionPassport,
+    derive_child_passport,
+    issue_passport,
+    verify_passport,
+)
 from vibap.proxy import Decision
 
 from tests.conftest import v01_required_md_extras
@@ -40,6 +45,9 @@ def _issue_passport(
     parent_jti: str | None = None,
     mission_id: str | None = None,
     allowed_tools: list[str] | None = None,
+    delegation_allowed: bool = False,
+    max_delegation_depth: int = 0,
+    receipt_level: str = "minimal",
     extra: dict[str, Any] | None = None,
 ) -> str:
     """Issue a passport. ``tool_manifest_digest=None`` means use the
@@ -54,10 +62,13 @@ def _issue_passport(
         resource_scope=["**"],
         max_tool_calls=10,
         max_duration_s=60,
+        delegation_allowed=delegation_allowed,
+        max_delegation_depth=max_delegation_depth,
     )
     extras = v01_required_md_extras(
         mission_id=mission_id or FAKE_MISSION_ID,
         conformance_profile=conformance_profile,
+        receipt_level=receipt_level,
     )
     if tool_manifest_digest is not None:
         if tool_manifest_digest:
@@ -397,6 +408,49 @@ class TestHiddenHopDetection:
         decision, reason = _call(proxy, session)
         assert decision == Decision.INSUFFICIENT_EVIDENCE
         assert "missing_parent_receipt" in reason
+
+    def test_signed_mic_evidence_child_requires_parent_receipt(
+        self,
+        proxy,
+        private_key,
+        public_key,
+    ):
+        parent_token = _issue_passport(
+            private_key,
+            conformance_profile="MIC-Evidence",
+            tool_manifest_digest=DIGEST,
+            allowed_tools=["read_file"],
+            delegation_allowed=True,
+            max_delegation_depth=1,
+            receipt_level="counter_signed",
+        )
+        parent_session = proxy.start_session(parent_token)
+        child_token = derive_child_passport(
+            parent_token=parent_token,
+            public_key=public_key,
+            private_key=private_key,
+            child_agent_id="mic-evidence-child",
+            child_allowed_tools=["read_file"],
+            child_mission="perform evidence-governed work",
+        )
+        child_claims = verify_passport(
+            child_token,
+            public_key,
+            parent_token=parent_token,
+        )
+        assert child_claims["conformance_profile"] == "MIC-Evidence"
+        assert child_claims["receipt_policy"] == {"level": "counter_signed"}
+        assert child_claims["tool_manifest_digest"] == DIGEST
+        child_session = proxy.start_session(child_token)
+
+        decision, reason = _call(proxy, child_session)
+        assert decision == Decision.INSUFFICIENT_EVIDENCE
+        assert reason == f"missing_parent_receipt:{parent_session.jti}"
+
+        parent_decision, _ = _call(proxy, parent_session)
+        assert parent_decision == Decision.PERMIT
+        child_decision, _ = _call(proxy, child_session)
+        assert child_decision == Decision.PERMIT
 
     def test_mic_state_skips_hidden_hop(self, proxy, private_key):
         token = _issue_passport(

--- a/python/vibap/passport.py
+++ b/python/vibap/passport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import hashlib
 import json
 import os
@@ -24,6 +25,17 @@ DEFAULT_AUDIENCE = "vibap-proxy"
 DELEGATION_CHAIN_CLAIM = "delegation_chain"
 MAX_DELEGATION_DEPTH = 16
 UNRESTRICTED_RESOURCE_SCOPE_PATTERN = "**"
+_DELEGATED_MIC_CLAIMS = (
+    "conformance_profile",
+    "receipt_policy",
+    "tool_manifest_digest",
+)
+_SUPPORTED_CONFORMANCE_PROFILES = frozenset(
+    {"Delegation-Core", "MIC-State", "MIC-Evidence"}
+)
+_SUPPORTED_RECEIPT_LEVELS = frozenset(
+    {"minimal", "counter_signed", "transparency_logged"}
+)
 
 
 def resource_scope_is_explicitly_unrestricted(scope: list[str]) -> bool:
@@ -909,6 +921,84 @@ def _token_sha256(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+def _inherited_mic_conformance_claims(
+    parent_claims: Mapping[str, Any],
+    *,
+    credential_label: str = "parent",
+) -> dict[str, Any]:
+    """Return the validated, closed MIC claim bundle for a child passport.
+
+    Conformance profiles and receipt levels are ordered, non-weakening policy
+    claims.  ``derive_child_passport`` has no child override surface, so exact
+    inheritance is the only safe behavior.  Copying a reviewed allowlist also
+    prevents issuer-controlled extras from colliding with child lineage or
+    budget claims.
+    """
+
+    # Older passports may carry receipt or digest metadata without declaring a
+    # conformance profile.  They remain legacy credentials: do not activate
+    # MIC validation or copy any part of a bundle until a profile is explicit.
+    if "conformance_profile" not in parent_claims:
+        return {}
+
+    present = {claim for claim in _DELEGATED_MIC_CLAIMS if claim in parent_claims}
+    expected = set(_DELEGATED_MIC_CLAIMS)
+    if present != expected:
+        missing = sorted(expected - present)
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle is incomplete; "
+            f"missing {missing}"
+        )
+
+    profile = parent_claims["conformance_profile"]
+    if not isinstance(profile, str) or profile not in _SUPPORTED_CONFORMANCE_PROFILES:
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle has an unsupported "
+            "conformance_profile"
+        )
+
+    receipt_policy = parent_claims["receipt_policy"]
+    if not isinstance(receipt_policy, dict) or set(receipt_policy) != {"level"}:
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle has a malformed "
+            "receipt_policy"
+        )
+    receipt_level = receipt_policy.get("level")
+    if (
+        not isinstance(receipt_level, str)
+        or receipt_level not in _SUPPORTED_RECEIPT_LEVELS
+    ):
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle has an unsupported "
+            "receipt level"
+        )
+    if profile == "MIC-Evidence" and receipt_level == "minimal":
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle weakens MIC-Evidence "
+            "with a minimal receipt level"
+        )
+
+    manifest_digest = parent_claims["tool_manifest_digest"]
+    digest_prefix = "sha-256:"
+    digest_hex = (
+        manifest_digest[len(digest_prefix) :]
+        if isinstance(manifest_digest, str)
+        and manifest_digest.startswith(digest_prefix)
+        else ""
+    )
+    if len(digest_hex) != 64 or any(
+        character not in "0123456789abcdef" for character in digest_hex
+    ):
+        raise PermissionError(
+            f"{credential_label} MIC conformance claim bundle has a malformed "
+            "tool_manifest_digest"
+        )
+
+    return {
+        claim: copy.deepcopy(parent_claims[claim]) for claim in _DELEGATED_MIC_CLAIMS
+    }
+
+
 def _require_nonempty_str(value: Any, *, field: str) -> str:
     if not isinstance(value, str) or not value:
         raise PermissionError(f"delegated passport has malformed {field}")
@@ -1057,6 +1147,9 @@ def verify_passport(
                     raise PermissionError(
                         "delegation chain ancestor parent hash is not trusted"
                     )
+            # The cold lineage indexes anchor hashes and parent edges, but do
+            # not persist ancestor policy claims.  MIC bundle equality can
+            # only be enforced below when the signed parent token is present.
             return claims
         parent_claims = _decode_passport(parent_token, public_key, audience=audience)
         if str(parent_claims["jti"]) != str(parent_jti):
@@ -1071,6 +1164,17 @@ def verify_passport(
             raise PermissionError(
                 "delegation chain does not match supplied parent lineage"
             )
+
+        parent_mic_claims = _inherited_mic_conformance_claims(parent_claims)
+        if parent_mic_claims:
+            child_mic_claims = _inherited_mic_conformance_claims(
+                claims,
+                credential_label="child",
+            )
+            if child_mic_claims != parent_mic_claims:
+                raise PermissionError(
+                    "child MIC conformance claim bundle does not match parent"
+                )
 
     return claims
 
@@ -1119,6 +1223,9 @@ def derive_child_passport(
              ``cwd escalation`` reason.
       - risk_budget: a governed parent policy is inherited or explicitly
                      attenuated; an ungoverned parent cannot introduce one.
+      - MIC conformance: an explicit, complete profile / receipt-policy /
+                         manifest-digest bundle is validated and inherited
+                         exactly; partial or malformed bundles fail closed.
     """
     # Signature-and-claims decode only. The full chain-anchor verification
     # (``verify_passport`` with ``parent_token=grandparent_token``) is the
@@ -1313,6 +1420,7 @@ def derive_child_passport(
         private_key,
         ttl_s=requested_ttl,
         extra_claims={
+            **_inherited_mic_conformance_claims(parent),
             "parent_token_hash": _token_sha256(parent_token),
             DELEGATION_CHAIN_CLAIM: child_chain,
             "reserved_budget_share": int(child_budget),

--- a/site/content/source/docs/specs/ardur-drp-mapping-v0.1.md
+++ b/site/content/source/docs/specs/ardur-drp-mapping-v0.1.md
@@ -2,7 +2,7 @@
 title: "Ardur DRP Mapping Profile v0.1"
 description: "This document maps the current Ardur delegation and action-receipt surfaces to"
 source_path: "docs/specs/ardur-drp-mapping-v0.1.md"
-source_sha256: "24cd46ccfe61242e2dc30a60502e4aca3fdde43a63734afb4342d8a8d6de65a8"
+source_sha256: "6b5151369a536c6c6dc382796fd7a2e7f5d78c3d51216f62cd893d589f4ea442"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["protocol-spec"]
@@ -46,8 +46,9 @@ members:
    `authorization_details`, argument-constraint members, `mission_ref`,
    `reserved_budget_share`, and `lineage_budget_share`;
 2. the JWT mission passport emitted by `python/vibap/passport.py`, including
-   child-lineage claims added by `derive_child_passport` and the optional
-   runtime-only `risk_budget` extension; and
+   child-lineage and inherited MIC conformance claims added by
+   `derive_child_passport`, plus the optional runtime-only `risk_budget`
+   extension; and
 3. every top-level property in
    `docs/specs/execution-receipt-v0.2.schema.json`.
 
@@ -95,6 +96,7 @@ transformations are:
 | depth and delegation policy | `metadata.x-ardur.redelegation` | DRP describes depth behavior but has no Authorization Object fields for mode, depth, or maximum depth. |
 | budgets and policy references | `metadata.x-ardur.budget`, `metadata.x-ardur.policy` | Security-critical extensions that participate in attenuation checks. |
 | Python `risk_budget` | No projection in the current profile | The current emitter/verifier does not implement typed fact contracts or atomic session/agent/lineage risk accounting. An emitter presented with this claim MUST deny/fail closed instead of dropping it. A future profile may define a critical `metadata.x-ardur.riskBudget` extension. |
+| Python MIC `conformance_profile`, `receipt_policy`, `tool_manifest_digest` | No projection for the policy claims; `metadata.x-ardur.capabilityTokenRef.toolManifestDigest` for a standalone digest | The current DRP profile cannot preserve the MIC enforcement/evidence tier. If either policy claim is present, reject the entire source object and never export only the digest. A standalone digest changes its tag from `sha-256:` to `sha256:` without changing the 64 lowercase hexadecimal digest. |
 | `mission_ref` | `metadata.x-ardur.missionRef` | DRP instruction commitment does not replace the governing Mission Declaration reference. |
 
 ### 3.1. Critical Extension Rule
@@ -131,6 +133,24 @@ prohibitions into stable `deny:<operation>:<resource>` strings. When the source
 has no explicit prohibition, it MUST include
 `x-ardur:deny-unlisted-actions`, which records the profile's closed-world
 default without inventing a permission.
+
+### 3.3. MIC Bundle Fail-Closed Rule
+
+The legacy Python passport may carry `conformance_profile`, `receipt_policy`,
+and `tool_manifest_digest` as one signed MIC conformance bundle. The current
+DRP profile can preserve the manifest digest but cannot preserve or enforce the
+MIC profile and receipt-evidence tier. Therefore, if either
+`conformance_profile` or `receipt_policy` is present, the emitter MUST reject
+the entire source object. It MUST NOT project `tool_manifest_digest` while
+silently dropping either policy claim, and a partial or malformed MIC bundle
+MUST NOT be treated as a standalone digest.
+
+When `tool_manifest_digest` is genuinely standalone and neither MIC policy
+claim is present, the emitter MAY retain it at
+`metadata.x-ardur.capabilityTokenRef.toolManifestDigest`. The conversion
+changes only the algorithm tag from the legacy `sha-256:` spelling to the DRP
+profile's `sha256:` spelling; the 64 lowercase hexadecimal digest bytes remain
+identical.
 
 ## 4. Target Authorization Object
 

--- a/site/static/repo/docs/specs/ardur-drp-mapping-v0.1.json
+++ b/site/static/repo/docs/specs/ardur-drp-mapping-v0.1.json
@@ -25,7 +25,7 @@
     },
     "legacy_python_passport": {
       "contract": "python/vibap/passport.py",
-      "scope": "JWT mission-passport claims emitted by issue_passport plus derive_child_passport lineage extensions, including explicit inventory of runtime-only claims that the current DRP profile must reject."
+      "scope": "JWT mission-passport claims emitted by issue_passport plus derive_child_passport lineage and MIC conformance extensions, including explicit inventory of runtime-only claims that the current DRP profile must reject."
     },
     "execution_receipt_v0.2": {
       "contract": "docs/specs/execution-receipt-v0.2.schema.json",
@@ -97,6 +97,7 @@
     "widening_rejected": "Tools, resources, argument constraints, budgets, time, and delegation depth MUST never widen.",
     "unknown_critical_extension_rejected": "A verifier that does not understand every path listed in metadata.x-ardur.critical MUST DENY and MUST NOT downgrade to base DRP authorization.",
     "unprojected_risk_budget_rejected": "A source credential carrying risk_budget MUST NOT be emitted or verified by this profile because typed contract and multi-scope ledger semantics are not implemented; dropping the claim is forbidden.",
+    "unprojected_mic_policy_bundle_rejected": "A source credential carrying conformance_profile or receipt_policy MUST NOT be emitted by this profile; the entire MIC bundle MUST be rejected and tool_manifest_digest MUST NOT be partially projected.",
     "tri_state_extension": "Ardur insufficient_evidence MUST project to DRP DENY while remaining distinguishable in the signed extension.",
     "no_redelegation": "redelegation.mode=none MUST prohibit creation of any sub-receipt.",
     "bounded_redelegation": "redelegation.mode=bounded MUST require depth below maxDepth and child maxDepth no greater than the parent.",
@@ -556,6 +557,27 @@
       "classification": "extension",
       "drp_path": "metadata.x-ardur.budget.reservedShare",
       "rationale": "Signed child budget reservation."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "conformance_profile",
+      "classification": "out_of_scope",
+      "drp_path": null,
+      "rationale": "The current DRP profile cannot preserve the MIC enforcement and evidence tier. Any source carrying this policy claim must fail closed; the MIC bundle must never be partially projected."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "receipt_policy",
+      "classification": "out_of_scope",
+      "drp_path": null,
+      "rationale": "The current DRP profile cannot preserve the MIC receipt-evidence requirement. Any source carrying this policy claim must fail closed; the MIC bundle must never be partially projected."
+    },
+    {
+      "source_surface": "legacy_python_passport",
+      "source_path": "tool_manifest_digest",
+      "classification": "extension",
+      "drp_path": "metadata.x-ardur.capabilityTokenRef.toolManifestDigest",
+      "rationale": "Normalize the legacy sha-256:<64-lowercase-hex> tag to the DRP extension's sha256:<64-lowercase-hex> tag while preserving the exact trusted tool-manifest digest."
     },
     {
       "source_surface": "execution_receipt_v0.2",


### PR DESCRIPTION
## Summary

- inherit the signed parent `conformance_profile`, `receipt_policy`, and `tool_manifest_digest` through the supported child-passport path
- validate the closed bundle and fail before mint or reservation on partial, malformed, unknown, or internally weakened MIC policy
- require exact signed parent/child MIC equality whenever the raw parent token is available, including idempotent delegation replay
- retain legacy behavior when the parent has no explicit conformance profile and never copy unrelated issuer extras
- keep the DRP mapping inventory synchronized with every newly signed delegated-passport claim

## Security and compatibility boundary

This closes the silent MIC-to-`Delegation-Core` downgrade for new derivations, live-parent verification, and stored `/delegate` replay. A parent without an explicit profile remains a legacy credential; receipt/digest-only legacy metadata does not activate MIC behavior.

Hash-only cold verification cannot compare parent policy because ADR-016 stores token hashes and parent edges, not claims. That upgrade/migration boundary is explicitly decomposed in #369; this PR does not trust persisted `passport_claims` or alter the lineage-index schema.

The DRP v0.1 mapping remains explicitly `mapping-only`. It rejects credentials carrying the unprojected MIC policy claims as a complete bundle and permits a genuinely standalone manifest digest only through the existing critical Ardur extension with the algorithm tag normalized from `sha-256:` to `sha256:`.

## Verification

- affected passport, delegation, MIC, proxy, HTTP, and DRP mapping suites: **217 passed**
- focused DRP mapping contract: **11 passed**, including fail-closed overwrite and duplicate-key regressions
- Ruff 0.13 check and format: clean on changed Python files
- `./scripts/check-local.sh --quick`: passed
- repository hooks: passed, including private-key detection and hardcoded-secret scanning
- source documentation sync: 124 pages and 133 mirrored artifacts verified
- Hugo build: 296 pages and 136 static files; rendered-link validation passed
- site claims: 10 validated; site unit tests: 18 passed
- independent final review: clear after exact MIC-overwrite and duplicate-lineage-key repros
- signed commit, author identity, exact DCO trailer, clean diff, and exact `dev` parent verified
- fresh GitHub CI and CodeRabbit review are required on exact head `aae73becbcb9dda875f533775baf9a85b0f82400`

README was reviewed; no update is required because commands, configuration, and the documented non-weakening contract do not change.

AI-assisted implementation and review were used. Human authorship, DCO sign-off, and review accountability remain with the PR author.

Closes #368
Unblocks #366
Follow-up: #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delegated passports can now inherit validated MIC conformance information from verified parents.
  - MIC evidence and receipt policy details are preserved across delegation chains when the MIC bundle is complete.

- **Bug Fixes**
  - Fail-closed enforcement rejects incomplete, malformed, weakened, or mismatched MIC bundles during verification and derivation.
  - Child passports no longer allow overwriting lineage-sensitive MIC fields via parent-provided extra claims.

- **Documentation**
  - Updated DRP mapping guidance to specify MIC bundle fail-closed behavior and tool-manifest digest normalization.

- **Tests**
  - Expanded MIC inheritance, delegation enforcement, and idempotent replay regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
