### PR TITLE
test: preserve multi-tool assistant turns

### DIFF
--- a/python/tests/test_e2e_showcase.py
+++ b/python/tests/test_e2e_showcase.py
@@ -376,11 +376,8 @@ def _chat_with_retry(client, messages, tools, max_retries=3):
 
 
 def _ollama_chat_single(client, messages, tools):
-    """Single chat call — may return text or tool_calls."""
-    try:
-        return client.chat(model=CLOUD_MODEL, messages=messages, tools=tools)
-    except Exception:
-        return None
+    """Make one model request and propagate provider or transcript errors."""
+    return client.chat(model=CLOUD_MODEL, messages=messages, tools=tools)
 
 
 # ---------------------------------------------------------------------------
@@ -811,7 +808,7 @@ class TestSessionAndPassportLayer:
         )
 
     def test_multi_turn_conversation(self, ollama_client, session):
-        base, sid, _token, proxy = session
+        base, sid, _token, _proxy = session
         tools = [
             {
                 "type": "function",
@@ -868,6 +865,7 @@ class TestSessionAndPassportLayer:
                     {"role": "assistant", "content": resp.message.content or ""}
                 )
                 break
+            messages.append(resp.message)
             for tc in tcs:
                 args = _parse_tool_args(tc.function.arguments)
                 status, decision, _ = _post(
@@ -881,12 +879,9 @@ class TestSessionAndPassportLayer:
                 if status == 200:
                     evaluations += 1
                 messages.append(
-                    {"role": "assistant", "content": None, "tool_calls": [tc]}
-                )
-                messages.append(
                     {
                         "role": "tool",
-                        "name": tc.function.name,
+                        "tool_name": tc.function.name,
                         "content": json.dumps({"status": "ok", "result": "processed"}),
                     }
                 )

--- a/python/tests/test_e2e_showcase.py
+++ b/python/tests/test_e2e_showcase.py
@@ -380,6 +380,16 @@ def _ollama_chat_single(client, messages, tools):
     return client.chat(model=CLOUD_MODEL, messages=messages, tools=tools)
 
 
+def _tool_result_for_evaluation(status, decision):
+    """Return a fail-closed simulated result for one governance evaluation."""
+    decision_value = decision.get("decision") if isinstance(decision, dict) else None
+    if status == 200 and decision_value == "PERMIT":
+        return {"status": "ok", "result": "processed"}
+    if status == 200 and decision_value == "DENY":
+        return {"status": "denied", "result": "not processed"}
+    return {"status": "unknown", "result": "not processed"}
+
+
 # ---------------------------------------------------------------------------
 # fixtures
 # ---------------------------------------------------------------------------
@@ -878,11 +888,12 @@ class TestSessionAndPassportLayer:
                 )
                 if status == 200:
                     evaluations += 1
+                tool_result = _tool_result_for_evaluation(status, decision)
                 messages.append(
                     {
                         "role": "tool",
                         "tool_name": tc.function.name,
-                        "content": json.dumps({"status": "ok", "result": "processed"}),
+                        "content": json.dumps(tool_result),
                     }
                 )
 

--- a/python/tests/test_e2e_showcase_transcript.py
+++ b/python/tests/test_e2e_showcase_transcript.py
@@ -24,9 +24,33 @@ from tests import test_e2e_showcase as showcase
     ],
     ids=["single-call", "multi-call"],
 )
+@pytest.mark.parametrize(
+    ("decision_body", "expected_tool_result"),
+    [
+        (
+            {"decision": "PERMIT"},
+            {"status": "ok", "result": "processed"},
+        ),
+        (
+            {"decision": "DENY"},
+            {"status": "denied", "result": "not processed"},
+        ),
+        (
+            {"decision": "VIOLATION"},
+            {"status": "unknown", "result": "not processed"},
+        ),
+        (
+            None,
+            {"status": "unknown", "result": "not processed"},
+        ),
+    ],
+    ids=["permit", "deny", "other-decision", "missing-decision"],
+)
 def test_tool_turn_preserves_original_assistant_message_and_order(
     monkeypatch,
     call_specs,
+    decision_body,
+    expected_tool_result,
 ):
     """Single and parallel tool turns reach the next request without reshaping."""
     tool_calls = [
@@ -58,7 +82,7 @@ def test_tool_turn_preserves_original_assistant_message_and_order(
 
     def fake_post(url, payload, token=None):
         evaluations.append((url, payload, token))
-        return 200, {"decision": "PERMIT"}, {}
+        return 200, decision_body, {}
 
     showcase_results = []
     monkeypatch.setattr(showcase, "_post", fake_post)
@@ -81,7 +105,7 @@ def test_tool_turn_preserves_original_assistant_message_and_order(
         {
             "role": "tool",
             "tool_name": name,
-            "content": json.dumps({"status": "ok", "result": "processed"}),
+            "content": json.dumps(expected_tool_result),
         }
         for name, _arguments in call_specs
     ]
@@ -109,6 +133,27 @@ def test_tool_turn_preserves_original_assistant_message_and_order(
             f"LLM made {len(call_specs)} tool call(s) through proxy across multiple turns",
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("status", "decision", "expected"),
+    [
+        (
+            503,
+            {"decision": "PERMIT"},
+            {"status": "unknown", "result": "not processed"},
+        ),
+        (
+            200,
+            "not-a-decision-object",
+            {"status": "unknown", "result": "not processed"},
+        ),
+    ],
+    ids=["non-200", "unusable-decision"],
+)
+def test_tool_result_without_valid_evidence_is_unknown(status, decision, expected):
+    """Missing or unusable evaluation evidence never becomes success."""
+    assert showcase._tool_result_for_evaluation(status, decision) == expected
 
 
 def test_follow_up_model_error_fails_multi_turn_showcase(monkeypatch):

--- a/python/tests/test_e2e_showcase_transcript.py
+++ b/python/tests/test_e2e_showcase_transcript.py
@@ -1,0 +1,160 @@
+"""Credential-free transcript regressions for the live E2E showcase."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tests import test_e2e_showcase as showcase
+
+
+@pytest.mark.parametrize(
+    "call_specs",
+    [
+        [("read_file", '{"path": "/tmp/input.txt"}')],
+        [
+            ("read_file", '{"path": "/tmp/input.txt"}'),
+            (
+                "write_file",
+                {"path": "/tmp/output.txt", "content": "summary"},
+            ),
+        ],
+    ],
+    ids=["single-call", "multi-call"],
+)
+def test_tool_turn_preserves_original_assistant_message_and_order(
+    monkeypatch,
+    call_specs,
+):
+    """Single and parallel tool turns reach the next request without reshaping."""
+    tool_calls = [
+        SimpleNamespace(function=SimpleNamespace(name=name, arguments=arguments))
+        for name, arguments in call_specs
+    ]
+    assistant_message = SimpleNamespace(
+        role="assistant",
+        content="I will read the input and write the summary.",
+        tool_calls=tool_calls,
+    )
+    final_message = SimpleNamespace(
+        role="assistant",
+        content="Done.",
+        tool_calls=[],
+    )
+    responses = [
+        SimpleNamespace(message=assistant_message),
+        SimpleNamespace(message=final_message),
+    ]
+    model_requests = []
+
+    class FakeClient:
+        def chat(self, *, model, messages, tools):
+            model_requests.append(list(messages))
+            return responses.pop(0)
+
+    evaluations = []
+
+    def fake_post(url, payload, token=None):
+        evaluations.append((url, payload, token))
+        return 200, {"decision": "PERMIT"}, {}
+
+    showcase_results = []
+    monkeypatch.setattr(showcase, "_post", fake_post)
+    monkeypatch.setattr(
+        showcase,
+        "_show",
+        SimpleNamespace(
+            test=lambda name, detail: showcase_results.append((name, detail)) or True
+        ),
+    )
+
+    showcase.TestSessionAndPassportLayer.test_multi_turn_conversation(
+        object(),
+        FakeClient(),
+        ("http://proxy.test", "session-123", "token", object()),
+    )
+
+    assert len(model_requests) == 2
+    expected_tool_messages = [
+        {
+            "role": "tool",
+            "tool_name": name,
+            "content": json.dumps({"status": "ok", "result": "processed"}),
+        }
+        for name, _arguments in call_specs
+    ]
+    assert model_requests[1] == [
+        *model_requests[0],
+        assistant_message,
+        *expected_tool_messages,
+    ]
+    assert model_requests[1][len(model_requests[0])] is assistant_message
+    assert evaluations == [
+        (
+            "http://proxy.test/evaluate",
+            {
+                "session_id": "session-123",
+                "tool_name": name,
+                "arguments": showcase._parse_tool_args(arguments),
+            },
+            None,
+        )
+        for name, arguments in call_specs
+    ]
+    assert showcase_results == [
+        (
+            "Multi-Turn Conversation",
+            f"LLM made {len(call_specs)} tool call(s) through proxy across multiple turns",
+        )
+    ]
+
+
+def test_follow_up_model_error_fails_multi_turn_showcase(monkeypatch):
+    """A provider rejection after a governed call cannot become a showcase pass."""
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(
+            name="read_file",
+            arguments={"path": "/tmp/input.txt"},
+        )
+    )
+    first_response = SimpleNamespace(
+        message=SimpleNamespace(
+            role="assistant",
+            content="I will read the input.",
+            tool_calls=[tool_call],
+        )
+    )
+
+    class RejectingClient:
+        def __init__(self):
+            self.calls = 0
+
+        def chat(self, *, model, messages, tools):
+            self.calls += 1
+            if self.calls == 1:
+                return first_response
+            raise RuntimeError("server rejected follow-up transcript")
+
+    showcase_results = []
+    monkeypatch.setattr(
+        showcase,
+        "_post",
+        lambda *_args, **_kwargs: (200, {"decision": "PERMIT"}, {}),
+    )
+    monkeypatch.setattr(
+        showcase,
+        "_show",
+        SimpleNamespace(
+            test=lambda name, detail: showcase_results.append((name, detail)) or True
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="server rejected follow-up transcript"):
+        showcase.TestSessionAndPassportLayer.test_multi_turn_conversation(
+            object(),
+            RejectingClient(),
+            ("http://proxy.test", "session-123", "token", object()),
+        )
+    assert showcase_results == []


### PR DESCRIPTION
## Summary

- preserve the original assistant response once when a turn contains one or more tool calls
- append one ordered tool-result message per call using Ollama's current `tool_name` field
- keep one `/evaluate` request per call with its own parsed arguments and preserve the exact displayed evaluation count
- propagate rejected follow-up model requests instead of allowing the showcase to report a false success
- report simulated execution success only for explicit `PERMIT`; report explicit `DENY` as denied and missing or unusable evidence as unknown
- add credential-free single-call, two-call, decision-outcome, and rejected-follow-up regressions outside the 28-capability showcase accounting

## Contract evidence

Ollama's official tool-calling documentation appends `response.message` once, processes its ordered `tool_calls`, then appends one `role: tool` message with `tool_name` per result:

https://docs.ollama.com/capabilities/tool-calling

## Validation

- red proof on exact base `3a5015b00a78604f8db4fc8f65433e0e883668a2`: the two-call regression failed because the old loop produced two synthetic assistant turns and legacy `name` fields
- `PYTHONPATH=. uv run --project . pytest tests/test_e2e_showcase.py tests/test_e2e_showcase_transcript.py -q --tb=short`: **29 passed, 10 skipped**, with five pre-existing pytest warnings tracked by #371
- Ruff 0.13 check: passed
- Ruff 0.13 format check: passed
- repository pre-commit hooks: passed, including private-key and gitleaks checks
- `./scripts/check-local.sh --quick`: passed
- `git diff --check`: passed
- independent review: clear before the CodeRabbit follow-up
- hosted CodeRabbit found one valid fail-closed result issue; signed/DCO commit `18954b63db3b239552cccbf7fa0b33766c218fcc` addresses it and re-review is pending

The ten skips are the unchanged credential-disabled cloud showcase cases. No external model, Docker, or cluster access was required for this deterministic transcript fix.

README was reviewed; no update is needed because public behavior and the 28-capability inventory are unchanged.

## Scope

Adjacent legacy transcript builders and the optional workflow dependency gap are intentionally excluded from this focused issue and tracked by #374 and #375.

## AI assistance disclosure

This change was implemented with Codex assistance. The author reviewed the diff, contract source, tests, and validation evidence.

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-turn conversation handling for tool-call transcripts, including correct ordering and preservation of full assistant messages.
  * Tool-call evaluation payloads are now constructed consistently, and missing/invalid evaluation evidence yields an unknown outcome instead of a misleading result.
  * Errors from follow-up model requests now surface correctly instead of being silently ignored.

* **Tests**
  * Added end-to-end regression tests covering multi-tool and tool-call transcript behavior, including evaluation calls and failure propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->