### PR TITLE
test: migrate showcase class fixtures for pytest 10

### DIFF
--- a/python/tests/test_e2e_showcase.py
+++ b/python/tests/test_e2e_showcase.py
@@ -448,7 +448,8 @@ class TestHTTPSecurityLayer:
     These tests use direct HTTP calls; no Ollama needed."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 1",
             "HTTP Security Layer",
@@ -611,7 +612,8 @@ class TestSessionAndPassportLayer:
     driven by real Ollama tool requests."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 2",
             "Session & Passport Layer",
@@ -915,7 +917,8 @@ class TestDelegationLayer:
     """Parent-child delegation with budget escrow and scope narrowing."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 3",
             "Delegation Layer",
@@ -1147,7 +1150,8 @@ class TestReceiptLayer:
     """Receipt generation, hash chaining, and trace_id continuity."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 4",
             "Receipt Layer",
@@ -1341,7 +1345,8 @@ class TestMICConformanceLayer:
     """MIC-State and MIC-Evidence conformance profile enforcement."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 5",
             "MIC Conformance Layer",
@@ -1580,7 +1585,8 @@ class TestPolicyBackendLayer:
     """Multi-backend policy composition with Deny-wins semantics."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 6",
             "Policy Backend Layer",
@@ -1700,7 +1706,8 @@ class TestAdvancedFeatures:
     """Declared telemetry, session attestation, and concurrent sessions."""
 
     @pytest.fixture(autouse=True, scope="class")
-    def _section_header(self):
+    @classmethod
+    def _section_header(cls):
         _show.section(
             "LAYER 7",
             "Advanced Features",


### PR DESCRIPTION
## Relevant issues

Closes #371

## Type

- [ ] `feat` — new capability or surface
- [ ] `fix` — bug fix
- [ ] `docs` — article, README, or doc change
- [ ] `refactor` — internal change, no behaviour change
- [x] `test` — test-only change
- [ ] `ci` — CI / workflow / tooling
- [ ] `chore` — housekeeping
- [ ] `dev → main graduation` — promoting reviewed work to release branch

## Changes

- Convert all seven class-scoped autouse showcase fixtures from deprecated instance methods to supported class methods.
- Preserve section-output behavior while removing a construct deprecated in pytest 9.1 and removed in pytest 10.
- Follow the official pytest migration form: https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method

Compatibility and proof boundary: this is test-only. It changes no runtime enforcement, network behavior, credentials, public claims, or production artifacts. The ten live-Ollama cases remain credential-gated and intentionally unverified by this local lane.

## Testing

- `PYTHONPATH=. uv run --project . pytest tests/test_e2e_showcase.py tests/test_e2e_showcase_transcript.py -q --tb=short -W error::pytest.PytestRemovedIn10Warning` — 29 passed, 10 skipped.
- `PYTHONPATH=. uv run --project . pytest tests/test_e2e_showcase.py -q --tb=short -W error::pytest.PytestRemovedIn10Warning` — 18 passed, 10 skipped.
- pytest collection — exactly 28 showcase cases.
- Ruff 0.13.0 check and format check — passed.
- `uvx --from pre-commit==4.3.0 pre-commit run --files python/tests/test_e2e_showcase.py` — all applicable hooks passed, including private-key and hardcoded-secret detection.
- `./scripts/check-local.sh --quick` — passed.
- `git diff --check` — passed.

README and documentation were reviewed; no update is warranted for this internal test compatibility migration.

AI-assisted implementation and review were used. The human author reviewed the final diff, owns the commit, and retains accountability.