### PR TITLE
fix(deps): bump Go toolchain to 1.26.6 (GO-2026-6218)

### DIFF
--- a/.github/workflows/agent-recognition-benchmark.yml
+++ b/.github/workflows/agent-recognition-benchmark.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/kernel-enforce.yml
+++ b/.github/workflows/kernel-enforce.yml
@@ -135,8 +135,8 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: "1.26.5"
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -326,7 +326,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: '1.26.5'
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -160,9 +160,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -208,8 +208,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: '1.26.5'
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ The full, current list lives in
 
 | Toolchain | Version | Source of truth |
 | --- | --- | --- |
-| Go | `1.26.5` | `go/go.mod` (`go` directive) |
+| Go | `1.26.6` | `go/go.mod` (`go` directive) |
 | Python | `>=3.10` | `python/pyproject.toml` |
 | ruff | `v0.13.0` | `.pre-commit-config.yaml` |
 

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -37,7 +37,7 @@ rather than trivially agreeing.
 
 ## Reproducing the results
 
-**Prerequisites**: Go ≥ 1.26.5, `make`.
+**Prerequisites**: Go ≥ 1.26.6, `make`.
 
 ```sh
 # 1. Clone (or pull) the repository

--- a/docs/articles/06-public-import-discipline.md
+++ b/docs/articles/06-public-import-discipline.md
@@ -142,7 +142,7 @@ The graduation gates we run before promoting a `dev` commit to
    (the runtime's embedded copy). A CI gate fails the build on
    drift between them.
 4. **Tests.** Python on 3.10 and 3.13; Go at the version pinned
-   in `go.mod` (currently 1.26.5).
+   in `go.mod` (currently 1.26.6).
 5. **CodeQL** for both Python and Go.
 6. **A 24-hour cool-off re-read** of the diff by the maintainer
    before the merge. The graduation gate isn't just CI — it's

--- a/docs/demo/enforce-e2e/Dockerfile
+++ b/docs/demo/enforce-e2e/Dockerfile
@@ -13,7 +13,7 @@
 # needed at build time. Stage 2 installs the Python `ardur` CLI. Run the
 # image privileged with --pid=host — see docs/demo/enforce-e2e.md.
 
-FROM golang:1.26.5-bookworm AS build
+FROM golang:1.26.6-bookworm AS build
 WORKDIR /src
 COPY go/go.mod go/go.sum ./go/
 RUN cd go && go mod download

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArdurAI/ardur/go
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0

--- a/scripts/gen-agent-docs.py
+++ b/scripts/gen-agent-docs.py
@@ -48,7 +48,7 @@ def _fail(message: str) -> None:
 
 
 def read_go_version() -> str:
-    """Return the `go` directive from go/go.mod (e.g. "1.26.5")."""
+    """Return the `go` directive from go/go.mod (e.g. "1.26.6")."""
     text = (REPO_ROOT / "go" / "go.mod").read_text(encoding="utf-8")
     match = re.search(r"^go\s+(\S+)\s*$", text, re.MULTILINE)
     if not match:

--- a/site/content/source/AGENTS.md
+++ b/site/content/source/AGENTS.md
@@ -2,7 +2,7 @@
 title: "Ardur Agent Instructions"
 description: "The canonical entry point for coding agents working in this repository. These"
 source_path: "AGENTS.md"
-source_sha256: "58dc104d3f677c47289b5c24c73811902b8e5ac5ecc01ef3ccbac208074d0e29"
+source_sha256: "0d86b0b1882a5b96b867f787f0e3cad0cad3d59beda0a061010dc5bf2ae2ef07"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -119,7 +119,7 @@ The full, current list lives in
 
 | Toolchain | Version | Source of truth |
 | --- | --- | --- |
-| Go | `1.26.5` | `go/go.mod` (`go` directive) |
+| Go | `1.26.6` | `go/go.mod` (`go` directive) |
 | Python | `>=3.10` | `python/pyproject.toml` |
 | ruff | `v0.13.0` | `.pre-commit-config.yaml` |
 

--- a/site/content/source/REPRODUCE.md
+++ b/site/content/source/REPRODUCE.md
@@ -2,7 +2,7 @@
 title: "Reproducing AuditBench Harness Fixtures"
 description: "This document describes how to reproduce the deterministic AuditBench harness"
 source_path: "REPRODUCE.md"
-source_sha256: "dc0e4bbc322e20664bc83fa6d6460719d81ee9bc6f5c9d729f73802d22e4e3dc"
+source_sha256: "98a233cc33bdb726e6cebf7088d4bae6294830ef36afab6b865ca56c1eb2cd34"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["documentation"]
@@ -54,7 +54,7 @@ rather than trivially agreeing.
 
 ## Reproducing the results
 
-**Prerequisites**: Go ≥ 1.26.5, `make`.
+**Prerequisites**: Go ≥ 1.26.6, `make`.
 
 ```sh
 # 1. Clone (or pull) the repository

--- a/site/content/source/docs/articles/06-public-import-discipline.md
+++ b/site/content/source/docs/articles/06-public-import-discipline.md
@@ -2,7 +2,7 @@
 title: "Public Import Discipline"
 description: "We had a private research repo with three years of history, a paper,"
 source_path: "docs/articles/06-public-import-discipline.md"
-source_sha256: "7086b650d92cb623df02117f0ec1762db8e13f275ec6f9c1a11c63a5d41871c8"
+source_sha256: "43020b1889fc49cc13c68d2ca3346061e1ef4d836b09864aa96c6b38f885ab1a"
 weight: 100
 maturity: ["public-now"]
 claim_types: ["article"]
@@ -159,7 +159,7 @@ The graduation gates we run before promoting a `dev` commit to
    (the runtime's embedded copy). A CI gate fails the build on
    drift between them.
 4. **Tests.** Python on 3.10 and 3.13; Go at the version pinned
-   in `go.mod` (currently 1.26.5).
+   in `go.mod` (currently 1.26.6).
 5. **CodeQL** for both Python and Go.
 6. **A 24-hour cool-off re-read** of the diff by the maintainer
    before the merge. The graduation gate isn't just CI — it's

--- a/site/static/repo/.github/workflows/agent-recognition-benchmark.yml
+++ b/site/static/repo/.github/workflows/agent-recognition-benchmark.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/site/static/repo/.github/workflows/kernel-enforce.yml
+++ b/site/static/repo/.github/workflows/kernel-enforce.yml
@@ -135,8 +135,8 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: "1.26.5"
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -326,7 +326,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/site/static/repo/.github/workflows/tests.yml
+++ b/site/static/repo/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: '1.26.5'
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -160,9 +160,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
           # If you bump go.mod, bump this string in the same PR.
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -208,8 +208,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          # Must match the `go` directive in go/go.mod (currently 1.26.5).
-          go-version: '1.26.5'
+          # Must match the `go` directive in go/go.mod (currently 1.26.6).
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go/go.sum
 


### PR DESCRIPTION
## Summary

- bump the module Go directive and all seven CI setup pins from 1.26.5 to 1.26.6
- update current toolchain references in the enforcement demo image, reproduction guide, and public-import article
- regenerate the AGENTS command block and all affected Hugo/source mirrors

## Why

GO-2026-6218 reports quadratic complexity in `net/url.resolvePath`. The repository was using the affected `net/url@go1.26.5`; the issue is fixed in `net/url@go1.26.6`.

The call is reachable through:

`pkg/credential/status.go:143` → `StatusClient.fetchStatusList` → `http.Client.Get` → `url.URL.Parse`

The repository-wide Go CVE job therefore needed the patched toolchain rather than an application-level workaround.

## Verification

- `go env GOTOOLCHAIN` → `auto` (no setting changed)
- `go env GOVERSION` from `go/` → `go1.26.6` (the host Go 1.25.4 installation downloaded the required toolchain automatically)
- `cd go && go build ./...` → pass
- `cd go && go test -count=1 -timeout 120s ./...` → pass across 27 packages
- `cd go && go vet ./...` → pass
- workflow-pinned `govulncheck@v1.1.4 ./...` → no called vulnerabilities; code affected by 0 vulnerabilities (three required-module findings are unreachable)
- `python3 scripts/gen-agent-docs.py --check` → pass
- `python3 site/scripts/sync_source_docs.py --check` → pass (125 source-backed pages, 133 mirrored artifacts)
- `docker manifest inspect golang:1.26.6-bookworm` → pass
- no `1.26.5` matches remain in `go/go.mod` or `.github/workflows/`
- post-commit generator rerun is idempotent and leaves the worktree clean

Historical agent-recognition benchmark reports and dated synthetic fixture data continue to record the toolchain that actually produced those artifacts; they were intentionally not rewritten.

Linux-only privileged BPF-LSM and seccomp smoke jobs were not run on this macOS host; CI remains authoritative for those paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain requirement from 1.26.5 to 1.26.6.
  * Updated automated builds, benchmarks, tests, and container builds to use Go 1.26.6.

* **Documentation**
  * Updated setup, reproduction, and development guidance to reflect Go 1.26.6.
  * Refreshed generated documentation and associated source checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Disclosure: this change was implemented with AI assistance (an agent harness drafted the change and ran the local verification); a human reviewed the full diff, and accountability sits with the PR author.