### PR TITLE
fix(security): patch CVE-2026-53615 (util-linux) in the proxy image

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-ARG PYTHON_IMAGE=python:3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
+ARG PYTHON_IMAGE=python:3.13.14-slim-trixie@sha256:9662417aace5ae7b8e2609cce472b72a8958e134ba372808abe9cc1a0c0125e6
 
 FROM ${PYTHON_IMAGE} AS wheel-builder
 
@@ -17,6 +17,9 @@ FROM ${PYTHON_IMAGE}
 ARG OCI_VERSION=dev
 ARG OCI_REVISION=unknown
 ARG OCI_SOURCE=https://github.com/ArdurAI/ardur
+ARG UTIL_LINUX_VERSION=2.41.5-0+deb13u1
+ARG BSDUTILS_VERSION=1:2.41.5-0+deb13u1
+ARG LOGIN_VERSION=1:4.16.0-2+really2.41.5-0+deb13u1
 
 LABEL org.opencontainers.image.title="Ardur Governance Proxy" \
       org.opencontainers.image.description="Runtime governance and signed evidence for AI agent tool calls" \
@@ -32,6 +35,20 @@ ENV HOME=/home/ardur \
     PIP_ROOT_USER_ACTION=ignore \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
+
+# Remove this targeted upgrade once the base includes the CVE-2026-53615 fix.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --only-upgrade \
+      bsdutils=${BSDUTILS_VERSION} \
+      libblkid1=${UTIL_LINUX_VERSION} \
+      liblastlog2-2=${UTIL_LINUX_VERSION} \
+      libmount1=${UTIL_LINUX_VERSION} \
+      libsmartcols1=${UTIL_LINUX_VERSION} \
+      libuuid1=${UTIL_LINUX_VERSION} \
+      login=${LOGIN_VERSION} \
+      mount=${UTIL_LINUX_VERSION} \
+      util-linux=${UTIL_LINUX_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 65532 --system ardur && \
     useradd --key UID_MAX=65532 --gid ardur --home-dir /home/ardur --no-create-home \

--- a/examples/autogen-quickstart/Dockerfile
+++ b/examples/autogen-quickstart/Dockerfile
@@ -21,10 +21,26 @@
 FROM ghcr.io/spiffe/spire-agent:1.15.2@sha256:1d042e4040466686e0ee46f74981ff2167c86adfadca19b3835946f4d6047536 AS spire
 
 # biscuit-python 0.4.0 embeds PyO3 0.24.1, whose supported ceiling is 3.13.
-FROM python:3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
+FROM python:3.13.14-slim-trixie@sha256:9662417aace5ae7b8e2609cce472b72a8958e134ba372808abe9cc1a0c0125e6
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
+ARG UTIL_LINUX_VERSION=2.41.5-0+deb13u1
+ARG BSDUTILS_VERSION=1:2.41.5-0+deb13u1
+ARG LOGIN_VERSION=1:4.16.0-2+really2.41.5-0+deb13u1
+
+# Remove this targeted upgrade once the base includes the CVE-2026-53615 fix.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --only-upgrade \
+        bsdutils=${BSDUTILS_VERSION} \
+        libblkid1=${UTIL_LINUX_VERSION} \
+        liblastlog2-2=${UTIL_LINUX_VERSION} \
+        libmount1=${UTIL_LINUX_VERSION} \
+        libsmartcols1=${UTIL_LINUX_VERSION} \
+        libuuid1=${UTIL_LINUX_VERSION} \
+        login=${LOGIN_VERSION} \
+        mount=${UTIL_LINUX_VERSION} \
+        util-linux=${UTIL_LINUX_VERSION} \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1000 ardur \

--- a/examples/langchain-quickstart/Dockerfile
+++ b/examples/langchain-quickstart/Dockerfile
@@ -18,11 +18,27 @@
 # Keep the tag for readable dependency updates while the immutable multi-arch
 # index digest prevents a registry tag re-push from changing published builds.
 # biscuit-python 0.4.0 embeds PyO3 0.24.1, whose supported ceiling is 3.13.
-FROM python:3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
+FROM python:3.13.14-slim-trixie@sha256:9662417aace5ae7b8e2609cce472b72a8958e134ba372808abe9cc1a0c0125e6
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
+ARG UTIL_LINUX_VERSION=2.41.5-0+deb13u1
+ARG BSDUTILS_VERSION=1:2.41.5-0+deb13u1
+ARG LOGIN_VERSION=1:4.16.0-2+really2.41.5-0+deb13u1
+
+# Remove this targeted upgrade once the base includes the CVE-2026-53615 fix.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --only-upgrade \
+        bsdutils=${BSDUTILS_VERSION} \
+        libblkid1=${UTIL_LINUX_VERSION} \
+        liblastlog2-2=${UTIL_LINUX_VERSION} \
+        libmount1=${UTIL_LINUX_VERSION} \
+        libsmartcols1=${UTIL_LINUX_VERSION} \
+        libuuid1=${UTIL_LINUX_VERSION} \
+        login=${LOGIN_VERSION} \
+        mount=${UTIL_LINUX_VERSION} \
+        util-linux=${UTIL_LINUX_VERSION} \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # uid 1000 matches the SPIRE workload registration shipped in


### PR DESCRIPTION
## Summary

- re-pin the shared Python 3.13.14 slim-trixie base from `sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280` to the registry-verified current index `sha256:9662417aace5ae7b8e2609cce472b72a8958e134ba372808abe9cc1a0c0125e6`
- patch CVE-2026-53615 by exact-version upgrading all nine installed binary packages from the util-linux source package to Debian's fixed `2.41.5-0+deb13u1` family
- apply the same base and package remediation to the two published demo images that shared the vulnerable digest
- keep the existing Trivy severity, fixability, secret-scanning, and exit-code gate unchanged

The current upstream Python base still contains util-linux `2.41-5`, so the Dockerfiles include a narrowly scoped, removable upgrade layer. Exact package versions make repository drift fail the build instead of silently changing the output.

## Local verification

- `python/.venv/bin/python -m pytest python/tests/test_demo_image_security.py python/tests/test_python_package_release.py python/tests/test_oci_release.py -q` — 24 passed
- `python3 scripts/validate-oci-release.py` — passed
- built the proxy, AutoGen demo, and LangChain demo for both `linux/amd64` and `linux/arm64`
- verified all nine affected packages in every built image with `dpkg-query`
- scanned both proxy architectures with workflow-pinned Trivy 0.72.0 using `vuln,secret`, `HIGH,CRITICAL`, `--ignore-unfixed`, and exit code 1 — zero findings, exit 0
- scanned the OS packages in both demo images on both architectures — zero CVE-2026-53615 findings
- verified the old digest has zero tracked references and `.github/workflows/oci-proxy.yml` is unchanged

The optional full Python suite was started locally and reached 71% without a failure before being stopped for the task runtime budget; it is not claimed as complete.

## CI confirmation

CI must still confirm the full repository test matrix and the GitHub-hosted `oci-proxy` build, authenticated smoke lifecycle, SBOM generation, and fresh-database Trivy gate.

Disclosure: implemented with AI assistance; a human reviewed the diff and accountability sits with the PR author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated container base images and system packages to address CVE-2026-53615.
  * Pinned package versions for more consistent and secure image builds.

* **Maintenance**
  * Applied the security updates across proxy and quickstart container images.
  * Cleaned package metadata after installation to reduce image size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->