### PR TITLE
fix(spiffe): accept Workload API JWT bundles without the optional use field

### DIFF
--- a/python/tests/test_spiffe_identity.py
+++ b/python/tests/test_spiffe_identity.py
@@ -37,7 +37,7 @@ _SPIFFE_ID = "spiffe://example.org/workload-test"
 
 
 class TestVerifyJwtSvidHappyPath:
-    def test_fresh_token_valid_audience_returns_claims(self):
+    def test_federation_bundle_with_labelled_keys_verifies(self):
         """Round-5 happy path: a freshly-minted SVID with valid audience
         flows through ``verify_jwt_svid`` cleanly. Without this test, a
         regression that breaks the entire verifier (e.g. accidentally
@@ -45,11 +45,36 @@ class TestVerifyJwtSvidHappyPath:
         now = int(time.time())
         bundle = make_mock_svid_bundle(_SPIFFE_ID, iat=now, exp=now + 600)
         trust = make_mock_trust_bundle(_SPIFFE_ID)
+        for key in trust.jwks["keys"]:
+            if key.get("use") != "jwt-svid":
+                key["use"] = "x509-svid"
+        assert {key["use"] for key in trust.jwks["keys"]} == {
+            "jwt-svid",
+            "x509-svid",
+        }
         claims = verify_jwt_svid(bundle.jwt_svid_token, trust, _AUDIENCE)
         assert isinstance(claims, SvidClaims)
         assert claims.spiffe_id == _SPIFFE_ID
         assert _AUDIENCE in claims.audience
         assert claims.iat == now
+
+    def test_workload_api_bundle_without_use_verifies(self):
+        now = int(time.time())
+        bundle = make_mock_svid_bundle(_SPIFFE_ID, iat=now, exp=now + 600)
+        trust = make_mock_trust_bundle(_SPIFFE_ID)
+        labelled_key = next(
+            key for key in trust.jwks["keys"] if key.get("use") == "jwt-svid"
+        )
+        workload_api_key = {
+            field: labelled_key[field] for field in ("kty", "kid", "crv", "x", "y")
+        }
+        assert "use" not in workload_api_key
+        trust.jwks = {"keys": [workload_api_key]}
+        assert bundle.jwt_svid_token is not None
+
+        claims = verify_jwt_svid(bundle.jwt_svid_token, trust, _AUDIENCE)
+
+        assert claims.spiffe_id == _SPIFFE_ID
 
 
 class TestVerifyJwtSvidIatGate:
@@ -115,12 +140,55 @@ class TestVerifyJwtSvidInputValidation:
         with pytest.raises(ValueError):
             verify_jwt_svid(bundle.jwt_svid_token, trust, "wrong-audience")
 
+    def test_tampered_signature_rejected(self):
+        now = int(time.time())
+        bundle = make_mock_svid_bundle(_SPIFFE_ID, iat=now, exp=now + 600)
+        trust = make_mock_trust_bundle(_SPIFFE_ID)
+        assert bundle.jwt_svid_token is not None
+        header, payload, signature = bundle.jwt_svid_token.split(".")
+        replacement = "A" if signature[0] != "A" else "B"
+        tampered_token = f"{header}.{payload}.{replacement}{signature[1:]}"
+
+        with pytest.raises(ValueError, match="JWT-SVID validation failed"):
+            verify_jwt_svid(tampered_token, trust, _AUDIENCE)
+
+    def test_unknown_trust_domain_rejected(self):
+        unknown_spiffe_id = "spiffe://unknown.example/workload-test"
+        now = int(time.time())
+        bundle = make_mock_svid_bundle(
+            unknown_spiffe_id,
+            iat=now,
+            exp=now + 600,
+        )
+        trust = make_mock_trust_bundle(_SPIFFE_ID)
+        assert bundle.jwt_svid_token is not None
+
+        with pytest.raises(
+            ValueError,
+            match="No trust bundle available for trust domain 'unknown.example'",
+        ):
+            verify_jwt_svid(bundle.jwt_svid_token, trust, _AUDIENCE)
+
     def test_non_jwt_svid_bundle_keys_are_rejected(self):
         now = int(time.time())
         bundle = make_mock_svid_bundle(_SPIFFE_ID, iat=now, exp=now + 600)
         trust = make_mock_trust_bundle(_SPIFFE_ID)
         for key in trust.jwks["keys"]:
             key["use"] = "sig"
+
+        with pytest.raises(ValueError, match="does not contain JWT-SVID"):
+            verify_jwt_svid(bundle.jwt_svid_token, trust, _AUDIENCE)
+
+    def test_x509_svid_only_bundle_keys_are_rejected(self):
+        now = int(time.time())
+        bundle = make_mock_svid_bundle(_SPIFFE_ID, iat=now, exp=now + 600)
+        trust = make_mock_trust_bundle(_SPIFFE_ID)
+        jwt_key = next(
+            dict(key) for key in trust.jwks["keys"] if key.get("use") == "jwt-svid"
+        )
+        jwt_key["use"] = "x509-svid"
+        trust.jwks = {"keys": [jwt_key]}
+        assert bundle.jwt_svid_token is not None
 
         with pytest.raises(ValueError, match="does not contain JWT-SVID"):
             verify_jwt_svid(bundle.jwt_svid_token, trust, _AUDIENCE)

--- a/python/vibap/spiffe_identity.py
+++ b/python/vibap/spiffe_identity.py
@@ -317,7 +317,7 @@ def _jwt_svid_jwks(jwks: dict) -> dict:
     jwt_svid_keys = [
         dict(key)
         for key in keys
-        if isinstance(key, dict) and key.get("use") == "jwt-svid"
+        if isinstance(key, dict) and ("use" not in key or key["use"] == "jwt-svid")
     ]
     if not jwt_svid_keys:
         raise ValueError("Trust bundle JWKS does not contain JWT-SVID signing keys")


### PR DESCRIPTION
## Summary

- Accept JWT-SVID signing keys whose optional RFC 7517 `use` member is absent, matching real SPIFFE Workload API JWT bundles.
- Preserve exact filtering for federation bundles: `use: jwt-svid` is accepted while `use: x509-svid` and other explicit values remain excluded.
- Add regression coverage for both real bundle shapes and fail-closed controls for x509-only bundles, wrong audience, signature tampering, and unknown trust domains.

## Why

`_jwt_svid_jwks()` previously required `use == "jwt-svid"`. Real Workload API JWT bundles contain only JWT-SVID keys and omit the optional `use` member, so valid SPIRE-issued JWT-SVIDs failed before cryptographic verification. Federation bundle endpoints mix key types and label them, which is why that format already worked.

This change is limited to key selection. Signature verification, audience validation, expiry, bounded `iat`, and trust-domain matching are unchanged.

## Real SPIRE 1.14.4 verification

The existing real SPIRE stack was running as `ardur-spire-server-1` and `ardur-spire-agent-1`. I fetched a fresh JWT-SVID and Workload API bundle in one response with:

```bash
docker exec -u 0 ardur-spire-agent-1 /opt/spire/bin/spire-agent \
  api fetch jwt -audience ardur-proxy -output json \
  -socketPath /run/spire/sockets/agent.sock
```

I fetched the federation/bundle-endpoint shape from the same server with:

```bash
docker exec ardur-spire-server-1 /opt/spire/bin/spire-server \
  bundle show -format spiffe \
  -socketPath /run/spire/sockets/server.sock
```

I then ran an ignored, in-memory verification harness (no token, key, or bundle was written into the checkout):

```bash
cd python
.venv/bin/python ../.context/verify-real-spire.py
```

Output:

```text
SPIRE runtime: server=1.14.4 agent=1.14.4
Fresh JWT-SVID: subject=spiffe://ardur.dev/agent/test-runner age_s=189 lifetime_s=900
Workload API shape: keys=1 uses=['<absent>']
Federation shape: keys=2 uses=['x509-svid', 'jwt-svid']
Workload API bundle: VERIFIED -> spiffe://ardur.dev/agent/test-runner
Federation bundle: VERIFIED -> spiffe://ardur.dev/agent/test-runner
Wrong audience: REJECTED (ValueError)
Tampered signature: REJECTED (ValueError)
X.509-only bundle: REJECTED (no JWT-SVID signing keys)
```

## Tests

- `cd python && .venv/bin/python -m pytest tests/test_spiffe_identity.py tests/test_biscuit_spiffe_binding.py -q` — 18 passed.
- `python/.venv/bin/ruff check python/vibap/spiffe_identity.py python/tests/test_spiffe_identity.py` — passed with repo-pinned ruff 0.13.0.
- `cd python && .venv/bin/python -m pytest tests/ -q --deselect=tests/test_conductor_bootstrap_contract.py::test_no_generator_bootstrap_only_advertises_existing_artifacts` — timeboxed after 15 minutes at 77% with no failures observed; the task-documented hanging bootstrap test was deselected.
- `PATH="$PWD/python/.venv/bin:$PATH" make lint-python` — reports one unrelated pre-existing F401 in `python/tests/test_port_in_use_traceback.py:177`; reproduced against `origin/dev`. The changed files lint clean.
- Independent security review: GLM PASS; Kimi PASS; no blocking findings.

Fixes #403

Disclosure: implemented with AI assistance; a human reviewed the diff and accountability sits with the PR author.
