### PR TITLE
fix(anchor): refuse to commit a non-receipt to the self-hosted log

### DIFF
--- a/python/tests/test_transparency.py
+++ b/python/tests/test_transparency.py
@@ -5,6 +5,7 @@ import copy
 import json
 import os
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,7 +19,7 @@ from jsonschema import Draft202012Validator
 from vibap.canonical_json import canonical_json_bytes
 from vibap.cli import main as cli_main
 from vibap.proxy import Decision, PolicyEvent
-from vibap.receipt import build_receipt, sign_receipt
+from vibap.receipt import assert_receipt_shaped, build_receipt, sign_receipt
 from vibap.transparency import (
     BACKEND_LOCAL_SIGNED,
     BACKEND_REKOR_V1,
@@ -659,4 +660,103 @@ def test_published_golden_anchor_schema_tamper_and_freshness_contract() -> None:
             control_character,
             receipt_public_key=receipt_public_key,
             log_public_key=log_public_key,
+        )
+
+
+def test_local_backend_refuses_to_anchor_a_non_receipt() -> None:
+    """A Merkle leaf cannot be withdrawn, so a non-receipt must never reach one.
+
+    Before this gate the local backend committed any string in ``receipt_jwt``
+    to the tree and reported ``anchored``; the resulting bundle was then
+    rejected by ``verify_anchor_bundle`` -- dead on arrival, but only after
+    the irreversible write. The Rekor backend already refused this
+    (test_rekor_refuses_invalid_receipt_before_transport); the two backends
+    must not disagree about what is anchorable.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        backend = LocalSignedLogBackend(
+            Path(tmp) / "log.jsonl",
+            ed25519.Ed25519PrivateKey.generate(),
+            origin="fixture.local/log",
+        )
+        with pytest.raises(TransparencyError) as caught:
+            backend.submit(
+                pending_anchor_bundle("aaa.bbb.ccc", backend_kind=BACKEND_LOCAL_SIGNED)
+            )
+        assert "refusing to anchor an invalid receipt" in str(caught.value)
+        assert not (Path(tmp) / "log.jsonl").exists(), (
+            "nothing may be written to the log when submission is refused"
+        )
+
+
+def test_local_backend_still_anchors_a_genuine_receipt_without_any_key() -> None:
+    """The structural gate must not break the keyless local-anchoring path."""
+
+    token, _ = _signed_receipt()
+    with tempfile.TemporaryDirectory() as tmp:
+        backend = LocalSignedLogBackend(
+            Path(tmp) / "log.jsonl",
+            ed25519.Ed25519PrivateKey.generate(),
+            origin="fixture.local/log",
+        )
+        anchored = backend.submit(
+            pending_anchor_bundle(token, backend_kind=BACKEND_LOCAL_SIGNED)
+        )
+        assert anchored["status"] == "anchored"
+
+
+def test_local_backend_refuses_a_receipt_signed_by_another_key_when_given_one() -> None:
+    """With a receipt public key the gate upgrades from structural to genuine.
+
+    Without a key the backend can only tell that a receipt is well formed. An
+    operator who supplies one gets the same guarantee the Rekor path has: a
+    receipt from a different issuer is refused before the write.
+    """
+
+    token, _ = _signed_receipt()
+    stranger = ec.generate_private_key(ec.SECP256R1())
+    with tempfile.TemporaryDirectory() as tmp:
+        backend = LocalSignedLogBackend(
+            Path(tmp) / "log.jsonl",
+            ed25519.Ed25519PrivateKey.generate(),
+            origin="fixture.local/log",
+            receipt_public_key=stranger.public_key(),
+        )
+        with pytest.raises(TransparencyError) as caught:
+            backend.submit(
+                pending_anchor_bundle(token, backend_kind=BACKEND_LOCAL_SIGNED)
+            )
+        assert "InvalidSignature" in str(caught.value)
+
+
+def test_assert_receipt_shaped_does_not_claim_to_check_signatures() -> None:
+    """Pin the honest boundary of the structural gate.
+
+    ``assert_receipt_shaped`` accepts a well-formed receipt regardless of who
+    signed it. That is by design -- it exists for backends holding no key --
+    and the limit must stay visible, because treating it as verification
+    would be the overclaim it was written to avoid.
+    """
+
+    token, _ = _signed_receipt()
+    claims = assert_receipt_shaped(token)
+    assert claims["receipt_id"]
+
+    for junk in ("", "aaa.bbb.ccc", "not-a-jws"):
+        with pytest.raises(jwt.PyJWTError):
+            assert_receipt_shaped(junk)
+
+    # A corrupted signature is NOT caught here, on purpose: this gate runs
+    # where no key is available. Pin it so nobody later mistakes the gate for
+    # verification.
+    header, payload, signature = token.split(".")
+    flipped = ("A" if signature[0] != "A" else "B") + signature[1:]
+    assert assert_receipt_shaped(".".join((header, payload, flipped)))
+
+    # A corrupted payload IS caught, because the canonical-payload check
+    # recomputes the encoding rather than trusting it.
+    with pytest.raises(jwt.PyJWTError):
+        assert_receipt_shaped(
+            ".".join((header, payload[:-4] + "AAAA", signature))
         )

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -3273,10 +3273,20 @@ def cmd_anchor(args: argparse.Namespace) -> int:
                 raise TransparencyError(
                     "local anchoring requires --local-log, --log-private-key, and --origin"
                 )
+            # --keys-dir is optional here: local anchoring works with no
+            # receipt key at all. When the operator does supply one, use it,
+            # so a receipt signed by a different issuer is refused before the
+            # irreversible log write rather than at verification time.
+            local_receipt_public_key = (
+                load_existing_public_key(keys_dir=args.keys_dir)
+                if args.keys_dir is not None
+                else None
+            )
             backend = LocalSignedLogBackend(
                 args.local_log,
                 _load_local_log_private_key(args.log_private_key),
                 origin=args.origin,
+                receipt_public_key=local_receipt_public_key,
             )
         else:
             if args.keys_dir is None:

--- a/python/vibap/receipt.py
+++ b/python/vibap/receipt.py
@@ -851,6 +851,53 @@ def _validate_canonical_payload(jwt_str: str, claims: dict[str, Any]) -> None:
         _schema_violation("JWS payload is not RFC 8785 canonical JSON")
 
 
+def assert_receipt_shaped(jwt_str: str) -> dict[str, Any]:
+    """Structurally validate a receipt JWS without checking its signature.
+
+    This exists for one job: refusing to commit a non-receipt to an
+    append-only log. A transparency-log write is irreversible, so a backend
+    that cannot check a signature (it holds no key) still must not anchor an
+    arbitrary string.
+
+    What this checks, using the same helpers ``verify_receipt`` uses so the
+    two cannot drift: the token decodes as a JWS with the receipt ``typ``,
+    every required claim is present, the payload is canonical, and the claim
+    schema validates.
+
+    What this does NOT check, and callers must not pretend otherwise: the
+    signature, the issuer, expiry, or ``iat`` skew. A structurally valid
+    receipt signed by the wrong key passes here. ``verify_receipt`` remains
+    the only authority on whether a receipt is genuine; prefer it whenever a
+    public key is available.
+    """
+
+    try:
+        header = jwt.get_unverified_header(jwt_str)
+    except jwt.PyJWTError as exc:
+        raise jwt.InvalidTokenError(
+            f"receipt is not a decodable JWS: {type(exc).__name__}"
+        ) from exc
+    if header.get("typ") != RECEIPT_JWT_TYPE:
+        raise jwt.InvalidTokenError(f"receipt typ header must be {RECEIPT_JWT_TYPE!r}")
+    if header.get("alg") != ALGORITHM:
+        raise jwt.InvalidTokenError(f"receipt alg header must be {ALGORITHM!r}")
+    claims = jwt.decode(
+        jwt_str,
+        options={
+            "verify_signature": False,
+            "verify_aud": False,
+            "verify_exp": False,
+            "verify_iat": False,
+        },
+    )
+    missing = [claim for claim in _REQUIRED_CLAIMS if claim not in claims]
+    if missing:
+        raise jwt.MissingRequiredClaimError(missing[0])
+    _validate_canonical_payload(jwt_str, claims)
+    _validate_receipt_claim_schema(claims)
+    return claims
+
+
 def verify_receipt(
     jwt_str: str,
     public_key: ec.EllipticCurvePublicKey,

--- a/python/vibap/transparency.py
+++ b/python/vibap/transparency.py
@@ -30,7 +30,7 @@ from jsonschema import Draft202012Validator, ValidationError
 
 from ._specs import transparency_anchor_v01_schema
 from .canonical_json import canonical_json_bytes
-from .receipt import RECEIPT_JWT_TYPE, verify_receipt
+from .receipt import RECEIPT_JWT_TYPE, assert_receipt_shaped, verify_receipt
 
 try:
     import fcntl
@@ -541,11 +541,16 @@ class LocalSignedLogBackend:
         *,
         origin: str,
         clock: Callable[[], float] = time.time,
+        receipt_public_key: ec.EllipticCurvePublicKey | None = None,
     ) -> None:
         self.log_path = Path(log_path).expanduser()
         self.private_key = private_key
         self.origin = origin
         self.clock = clock
+        # Optional because this backend is usable with no receipt key at all.
+        # When supplied, submissions are checked against it, which is strictly
+        # stronger than the structural gate every submission gets.
+        self.receipt_public_key = receipt_public_key
 
     def _read_entries_locked(self) -> list[bytes]:
         if not self.log_path.exists():
@@ -579,6 +584,35 @@ class LocalSignedLogBackend:
                 entries.append(body)
         return entries
 
+    def _assert_submittable(self, receipt_jwt: str) -> None:
+        """Refuse to commit anything that is not a receipt.
+
+        A Merkle-tree leaf cannot be withdrawn, so submission is the last
+        point at which refusal is free. The Rekor backend already refuses an
+        unverifiable receipt before its transport call; the two backends must
+        not disagree about what is anchorable just because this one holds no
+        key by default.
+
+        Without a receipt public key this is a structural gate only: it stops
+        a non-receipt, not a receipt signed by the wrong key. Pass
+        ``receipt_public_key`` to get the full check.
+        """
+
+        try:
+            assert_receipt_shaped(receipt_jwt)
+            if self.receipt_public_key is not None:
+                verify_receipt(
+                    receipt_jwt,
+                    self.receipt_public_key,
+                    verify_expiry=False,
+                    iat_future_skew_s=None,  # type: ignore[arg-type]
+                    iat_past_skew_s=None,  # type: ignore[arg-type]
+                )
+        except jwt.PyJWTError as exc:
+            raise TransparencyError(
+                f"refusing to anchor an invalid receipt: {type(exc).__name__}"
+            ) from exc
+
     def submit(
         self,
         pending_bundle: Mapping[str, Any],
@@ -587,6 +621,7 @@ class LocalSignedLogBackend:
     ) -> dict[str, Any]:
         del receipt_private_key
         digest = _validate_pending_bundle(pending_bundle)
+        self._assert_submittable(str(pending_bundle.get("receipt_jwt", "")))
         if fcntl is None:
             raise TransparencyError(
                 "local signed log backend requires POSIX file locking"
@@ -692,9 +727,7 @@ def _classify_rekor_transport_error(
             )
         return TransparencyError("Rekor submission failed: network error")
     if isinstance(reason, str) and reason.strip():
-        return TransparencyError(
-            f"Rekor submission failed: {reason.strip()}"
-        )
+        return TransparencyError(f"Rekor submission failed: {reason.strip()}")
     return TransparencyError("Rekor submission failed: network error")
 
 


### PR DESCRIPTION
Closes #435.

## What

`LocalSignedLogBackend.submit` verified nothing about what it anchored. It committed any string in `receipt_jwt` to the Merkle tree and reported `anchored` — reproduced with the literal `"aaa.bbb.ccc"`, which is not a receipt, is not signed by anyone, and has no issuer.

The Rekor backend already refuses this before its transport call (`test_rekor_refuses_invalid_receipt_before_transport`). The two backends should not disagree about what is anchorable just because this one holds no key by default — and the asymmetry mattered, because a Merkle leaf cannot be withdrawn. `verify_anchor_bundle` would reject the resulting bundle later, so the artifact was dead on arrival rather than dangerous, but only *after* the irreversible write and after the CLI printed `anchored: 1`.

## How

- `assert_receipt_shaped` in `receipt.py`: a signature-independent structural check reusing `verify_receipt`'s own helpers — required claims, canonical payload, claim schema — so the two cannot drift. It checks the `typ` and `alg` headers and refuses anything that is not a decodable receipt-shaped JWS.
- Every local submission is gated on it, before the tree write.
- An optional `receipt_public_key` upgrades the check from structural to genuine. `ardur anchor` passes it whenever `--keys-dir` is supplied on the local path; that flag stays optional, so keyless local anchoring works exactly as before.

## The boundary, stated rather than glossed

Without a key this stops a non-receipt, **not** a receipt signed by the wrong key. A test pins that limit explicitly — a flipped signature byte is accepted, a corrupted payload is not — so nobody later mistakes the gate for verification. `verify_receipt` remains the only authority on genuineness.

## Verification

| Case | Before | After |
|---|---|---|
| `"aaa.bbb.ccc"` | `anchored` | refused, nothing written to the log |
| genuine receipt, no key | `anchored` | `anchored` (unchanged) |
| genuine receipt, wrong `receipt_public_key` | `anchored` | refused (`InvalidSignatureError`) |

147 tests pass across `test_transparency.py`, `test_offline_verification.py`, `test_anchor_paths.py`, and the receipt suites; `ruff check`/`format` clean on changed files.

## Proof-boundary impact

Strictly fail-closed: it narrows what can be written, adds no capability claim, and adds no network call. Related to #429 (the drain-path staleness gate), deliberately kept as a separate commit — mixing them makes the diff unreviewable.

Prepared with AI assistance; the human author reviewed the change and takes accountability for it.
