### PR TITLE
security(keys): stop read-only report paths from minting signing keys

### DIFF
--- a/python/tests/test_report_paths_never_mint_keys.py
+++ b/python/tests/test_report_paths_never_mint_keys.py
@@ -1,0 +1,118 @@
+"""Read-only report paths must never create key material.
+
+`load_public_key` auto-creates: it returns `generate_keypair(...)[1]` when
+`passport_public.pem` is missing. Three report builders called it, so a
+command whose entire job is verifying existing evidence would mint a
+*signing* keypair -- private key included -- and then verify against the key
+it had just invented. That makes "nothing verified" indistinguishable from
+"verified against a key I made up", and it writes a new root of trust into
+whatever directory the run happened to resolve.
+
+The fix is deliberately narrower than "always require a key". A fresh install
+with no receipts must still get its onboarding report, so the key is required
+only when there is evidence to verify. These tests pin all three edges: no
+minting ever, onboarding preserved, and fail-closed once evidence exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibap.claude_code_report import build_claude_code_report
+from vibap.codex_app_server_fixture import (
+    build_shareable_report as build_codex_report,
+)
+from vibap.gemini_cli_hook import build_shareable_report as build_gemini_report
+
+
+def _keys_dir(tmp_path: Path) -> Path:
+    keys = tmp_path / "keys"
+    keys.mkdir()
+    return keys
+
+
+def _key_files(keys: Path) -> list[str]:
+    return sorted(p.name for p in keys.iterdir())
+
+
+def test_claude_code_report_on_a_fresh_install_mints_no_keys(tmp_path: Path) -> None:
+    keys = _keys_dir(tmp_path)
+
+    report = build_claude_code_report(
+        home=tmp_path,
+        chain_dir=tmp_path / "missing-chain",
+        keys_dir=keys,
+        verify_expiry=False,
+    )
+
+    assert report["receipt_count"] == 0
+    assert report["next_steps"], "onboarding guidance must survive"
+    assert _key_files(keys) == [], "a report path must not create key material"
+
+
+def test_claude_code_report_fails_closed_when_receipts_exist_without_a_key(
+    tmp_path: Path,
+) -> None:
+    """Evidence with no key is unverifiable, so it must not report success."""
+
+    keys = _keys_dir(tmp_path)
+    chain = tmp_path / "claude-code-hook" / "project"
+    chain.mkdir(parents=True)
+    (chain / "receipts.jsonl").write_text(
+        "eyJhbGciOiJFUzI1NiJ9.e30.sig\n", encoding="utf-8"
+    )
+
+    with pytest.raises(FileNotFoundError):
+        build_claude_code_report(
+            home=tmp_path,
+            chain_dir=tmp_path / "claude-code-hook",
+            keys_dir=keys,
+            verify_expiry=False,
+        )
+    assert _key_files(keys) == [], "failing closed must not leave key material behind"
+
+
+@pytest.mark.parametrize(
+    ("builder", "chain_name"),
+    [(build_gemini_report, "gemini-chain"), (build_codex_report, "codex-chain")],
+)
+def test_adapter_reports_on_a_fresh_install_mint_no_keys(
+    tmp_path: Path, builder, chain_name: str
+) -> None:
+    keys = _keys_dir(tmp_path)
+
+    report = builder(
+        home=tmp_path,
+        chain_dir=tmp_path / chain_name,
+        keys_dir=keys,
+        verify_expiry=False,
+    )
+
+    assert report["receipt_count"] == 0
+    assert _key_files(keys) == []
+
+
+@pytest.mark.parametrize(
+    ("builder", "chain_name"),
+    [(build_gemini_report, "gemini-chain"), (build_codex_report, "codex-chain")],
+)
+def test_adapter_reports_fail_closed_when_chains_exist_without_a_key(
+    tmp_path: Path, builder, chain_name: str
+) -> None:
+    keys = _keys_dir(tmp_path)
+    chains = tmp_path / chain_name
+    chains.mkdir()
+    (chains / "receipts.jsonl").write_text(
+        "eyJhbGciOiJFUzI1NiJ9.e30.sig\n", encoding="utf-8"
+    )
+
+    with pytest.raises(FileNotFoundError):
+        builder(
+            home=tmp_path,
+            chain_dir=chains,
+            keys_dir=keys,
+            verify_expiry=False,
+        )
+    assert _key_files(keys) == []

--- a/python/vibap/claude_code_report.py
+++ b/python/vibap/claude_code_report.py
@@ -8,7 +8,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping
 
-from .passport import DEFAULT_HOME, load_public_key
+from .passport import DEFAULT_HOME, load_report_public_key
 from .receipt import verify_chain
 from .shareable_redaction import path_aliases, redact_local_paths
 
@@ -394,7 +394,9 @@ def build_claude_code_report(
     )
     resolved_keys_dir = (keys_dir or (resolved_home / "keys")).expanduser().resolve()
     receipt_files = sorted(resolved_chain_dir.rglob("receipts.jsonl"))
-    public_key = load_public_key(resolved_keys_dir)
+    public_key = load_report_public_key(
+        resolved_keys_dir, evidence_present=bool(receipt_files)
+    )
 
     chains: list[dict[str, Any]] = []
     all_claims: list[dict[str, Any]] = []

--- a/python/vibap/cli.py
+++ b/python/vibap/cli.py
@@ -3536,6 +3536,14 @@ def cmd_claude_code_report(args: argparse.Namespace) -> int:
     except KeyDirectoryError as exc:
         _print_json(_keys_dir_failure_response(exc))
         return 1
+    except FileNotFoundError:
+        # Reporting is read-only: a missing key means "nothing verifiable
+        # here", never "mint a key and verify against it".
+        _print_json(_verify_public_key_missing_response())
+        return 1
+    except ValueError:
+        _print_json(_verify_public_key_invalid_response())
+        return 1
     if (
         getattr(args, "redact_paths", False)
         and not getattr(args, "json", False)
@@ -4178,6 +4186,14 @@ def cmd_gemini_cli_report(args: argparse.Namespace) -> int:
     except KeyDirectoryError as exc:
         _print_json(_keys_dir_failure_response(exc))
         return 1
+    except FileNotFoundError:
+        # Reporting is read-only: a missing key means "nothing verifiable
+        # here", never "mint a key and verify against it".
+        _print_json(_verify_public_key_missing_response())
+        return 1
+    except ValueError:
+        _print_json(_verify_public_key_invalid_response())
+        return 1
     if (
         getattr(args, "redact_paths", False)
         and not getattr(args, "json", False)
@@ -4371,6 +4387,14 @@ def cmd_codex_app_server_report(args: argparse.Namespace) -> int:
         )
     except KeyDirectoryError as exc:
         _print_json(_keys_dir_failure_response(exc))
+        return 1
+    except FileNotFoundError:
+        # Reporting is read-only: a missing key means "nothing verifiable
+        # here", never "mint a key and verify against it".
+        _print_json(_verify_public_key_missing_response())
+        return 1
+    except ValueError:
+        _print_json(_verify_public_key_invalid_response())
         return 1
     if (
         getattr(args, "redact_paths", False)

--- a/python/vibap/codex_app_server_fixture.py
+++ b/python/vibap/codex_app_server_fixture.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from .claude_code_hook import MissionLoadError, load_active_passport
 from .denial import DenialReason
-from .passport import DEFAULT_HOME, _ensure_default_home_dir, load_private_key, load_public_key, resolve_keys_dir
+from .passport import DEFAULT_HOME, _ensure_default_home_dir, load_report_public_key, load_private_key, resolve_keys_dir
 from .receipt import build_receipt, sign_receipt, verify_chain
 from .shareable_redaction import path_aliases, redact_local_paths
 
@@ -1272,7 +1272,6 @@ def build_shareable_report(
     ardur_home = Path(home or os.environ.get("VIBAP_HOME", str(DEFAULT_HOME))).expanduser().resolve(strict=False)
     chains = Path(chain_dir or os.environ.get(CHAIN_DIR_ENV_VAR, str(DEFAULT_CHAIN_DIR))).expanduser().resolve(strict=False)
     signing_keys = resolve_keys_dir(keys_dir)
-    public_key = load_public_key(signing_keys)
     roots: dict[str, str | Path | None] = {
         "CODEX_HOME": ardur_home,
         "ARDUR_CODEX_CHAIN": chains,
@@ -1282,6 +1281,9 @@ def build_shareable_report(
         roots.update(dict(redaction_roots))
 
     chain_files = _iter_chain_files(chains)
+    public_key = load_report_public_key(
+        signing_keys, evidence_present=bool(chain_files)
+    )
     receipt_claims: list[dict[str, Any]] = []
     verification: list[dict[str, Any]] = []
     invalid_chains: list[dict[str, Any]] = []

--- a/python/vibap/gemini_cli_hook.py
+++ b/python/vibap/gemini_cli_hook.py
@@ -24,7 +24,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from .claude_code_hook import HOOK_INPUT_MAX_CHARS, MissionLoadError, load_active_passport
 from .denial import DenialReason
-from .passport import DEFAULT_HOME, _ensure_default_home_dir, load_private_key, load_public_key, resolve_keys_dir
+from .passport import DEFAULT_HOME, _ensure_default_home_dir, load_report_public_key, load_private_key, resolve_keys_dir
 from .receipt import build_receipt, sign_receipt, verify_chain
 from .shareable_redaction import path_aliases, redact_local_paths
 
@@ -1079,7 +1079,6 @@ def build_shareable_report(
     ardur_home = Path(home or os.environ.get("VIBAP_HOME", str(DEFAULT_HOME))).expanduser().resolve(strict=False)
     chains = Path(chain_dir or os.environ.get(CHAIN_DIR_ENV_VAR, str(DEFAULT_CHAIN_DIR))).expanduser().resolve(strict=False)
     signing_keys = resolve_keys_dir(keys_dir)
-    public_key = load_public_key(signing_keys)
     roots: dict[str, str | Path | None] = {
         "GEMINI_HOME": ardur_home,
         "ARDUR_GEMINI_CHAIN": chains,
@@ -1089,6 +1088,9 @@ def build_shareable_report(
         roots.update(dict(redaction_roots))
 
     chain_files = _iter_chain_files(chains)
+    public_key = load_report_public_key(
+        signing_keys, evidence_present=bool(chain_files)
+    )
     receipt_claims: list[dict[str, Any]] = []
     verification: list[dict[str, Any]] = []
     invalid_chains: list[dict[str, Any]] = []

--- a/python/vibap/passport.py
+++ b/python/vibap/passport.py
@@ -603,6 +603,33 @@ def load_public_key(keys_dir: str | Path | None = None) -> ec.EllipticCurvePubli
     return serialization.load_pem_public_key(pub_path.read_bytes())
 
 
+def load_report_public_key(
+    keys_dir: str | Path | None = None,
+    *,
+    evidence_present: bool,
+) -> ec.EllipticCurvePublicKey | None:
+    """Load the verification key for a read-only report path.
+
+    Reporting must never mint key material: a command whose job is to verify
+    existing evidence cannot be allowed to invent the key it verifies against.
+    But a fresh install with no receipts still needs its onboarding report, so
+    a missing ``passport_public.pem`` is only an error when there is something
+    to verify.
+
+    The key directory itself is validated either way, so a malformed
+    ``--keys-dir`` keeps failing closed whether or not evidence exists.
+
+    Returns ``None`` only when no evidence is present and no key exists.
+    """
+
+    if evidence_present:
+        return load_existing_public_key(keys_dir)
+    try:
+        return load_existing_public_key(keys_dir)
+    except FileNotFoundError:
+        return None
+
+
 def load_existing_public_key(
     keys_dir: str | Path | None = None,
 ) -> ec.EllipticCurvePublicKey:


### PR DESCRIPTION
Closes #434 (the "Now" item in its recommended sequencing). The `$CWD/.vibap` default (#433) is deliberately **not** touched here — it is a separate change and needs a maintainer call.

## What

`load_public_key` auto-creates: it returns `generate_keypair(...)[1]` when `passport_public.pem` is missing (`passport.py:598-602`). Three report builders called it, so a command whose entire job is verifying existing evidence would mint a keypair — **private key included** — and then verify against the key it had just invented.

Demonstrated on `dev`:

```
$ ardur claude-code-report --home $T --keys-dir $T/keys --json
exit 0, ok: true
$ ls $T/keys
passport_private.pem  passport_public.pem
```

That makes "nothing verified" indistinguishable from "verified against a key I made up", and it writes a new root of trust into whatever directory the run resolved — which, given the CWD-keyed home default (#433), need not be the one holding the real key.

The repo already states the norm this violated: *"Verification is read-only and will not create signing keys"* (`cli.py:2196`). Seven `ardur verify` surfaces already use the strict loader. These three were on the wrong side of a line the codebase had already drawn.

## Deliberately narrower than "always require a key"

A blanket strictification would break the documented fresh-user flow, which is exactly what #434 warns against. `load_report_public_key` requires the key **only when there is evidence to verify**, validates the key directory either way so a malformed `--keys-dir` keeps failing closed, and never creates anything. The CLI turns a missing key into the existing structured `passport_public_key_missing` response rather than a traceback.

| Scenario | Result |
|---|---|
| fresh install, no receipts, no key | onboarding report, exit 0, **0 keys created** |
| receipts present, no key | `passport_public_key_missing`, exit 1, **0 keys created** |
| `--keys-dir` pointing at a file | `keys_dir_not_directory`, exit 1 |

## Verification

Six regression tests covering all three adapters, each confirmed to **fail on `dev`** and pass here — they catch the defect rather than describing the fix. 752 tests pass in the affected selection (`claude_code`/`gemini`/`codex`/`report`/`passport`/`keys`); `ruff check` clean.

`gemini_cli_hook.py` and `codex_app_server_fixture.py` have pre-existing `ruff format` drift on `dev`; I left it alone rather than reformatting two large files inside an unrelated change.

## Out of scope

`ardur attest` (`cli.py:3466`) and the mid-session actor-key load (`proxy.py:3062`) — both flagged in #434 as inferred rather than demonstrated. They want their own change with their own evidence.

Prepared with AI assistance; the human author reviewed the change and takes accountability for it.
