### PR TITLE
fix(security): reissue credentials with empty subjects

### DIFF
--- a/go/cmd/operator/reconciler.go
+++ b/go/cmd/operator/reconciler.go
@@ -449,8 +449,12 @@ func needsUnverifiedIdentityMigration(ap *vibapv1alpha1.AgentPassport) bool {
 	// Status is controller-owned. Decode classifies the artifact conservatively;
 	// it is not treated as independent proof of signature authenticity.
 	decoded, err := credential.Decode(ap.Status.Credential)
-	if err != nil || decoded.Claims.Identity != nil ||
-		strings.Contains(strings.ToLower(decoded.Claims.Subject), "spiffe://") {
+	if err != nil {
+		return true
+	}
+	subject := strings.TrimSpace(decoded.Claims.Subject)
+	if subject == "" || decoded.Claims.Identity != nil ||
+		strings.Contains(strings.ToLower(subject), "spiffe://") {
 		return true
 	}
 	for _, condition := range ap.Status.Conditions {

--- a/go/cmd/operator/reconciler_test.go
+++ b/go/cmd/operator/reconciler_test.go
@@ -411,6 +411,51 @@ func TestReconcile_ExistingMissingSPIFFEIDRemediatesLegacyCredential(t *testing.
 	t.Fatal("IdentityUnverified condition disappeared after migration completed")
 }
 
+func TestReconcile_ExistingMissingSPIFFEIDRemediatesEmptySubjectCredential(t *testing.T) {
+	ap := testPassport("empty-subject", "default")
+	ap.Finalizers = []string{vibapv1alpha1.FinalizerName}
+
+	invalidEncoded := spiffeSubjectOnlyEncodedCredential(t, "")
+	ap.Status.Credential = invalidEncoded
+	ap.Status.ObservedGeneration = ap.Generation
+	expiresAt := metav1.NewTime(time.Now().Add(2 * time.Hour))
+	ap.Status.ExpiresAt = &expiresAt
+	ap.Status.Conditions = []metav1.Condition{{
+		Type:               vibapv1alpha1.ConditionIdentityUnverified,
+		Status:             metav1.ConditionTrue,
+		Reason:             vibapv1alpha1.ReasonMissingSPIFFEID,
+		ObservedGeneration: ap.Generation,
+	}}
+
+	r, err := testReconciler(ap)
+	if err != nil {
+		t.Fatalf("creating reconciler: %v", err)
+	}
+	nn := types.NamespacedName{Name: ap.Name, Namespace: ap.Namespace}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn}); err != nil {
+		t.Fatalf("reconciling empty-subject credential: %v", err)
+	}
+
+	var updated vibapv1alpha1.AgentPassport
+	if err := r.Get(context.Background(), nn, &updated); err != nil {
+		t.Fatalf("getting reconciled resource: %v", err)
+	}
+	if updated.Status.Credential == invalidEncoded {
+		t.Fatal("reconcile retained an empty-subject credential that the verifier rejects")
+	}
+	decoded, err := credential.Decode(updated.Status.Credential)
+	if err != nil {
+		t.Fatalf("decoding replacement credential: %v", err)
+	}
+	const expectedSubject = "default/empty-subject"
+	if decoded.Claims.Subject != expectedSubject {
+		t.Fatalf("replacement subject = %q, want %q", decoded.Claims.Subject, expectedSubject)
+	}
+	if decoded.Claims.Identity != nil {
+		t.Fatalf("replacement credential must remain identity-less: %+v", decoded.Claims.Identity)
+	}
+}
+
 func TestNeedsUnverifiedIdentityMigration_InspectsCredentialDespiteCondition(t *testing.T) {
 	ap := testPassport("stale-condition", "default")
 	const legacySPIFFEID = "spiffe://ardur.dev/ns/default/agent/stale-condition"


### PR DESCRIPTION
## Summary

- fail closed when an identity-less status credential has an empty or whitespace-only subject before trusting the current `IdentityUnverified=True/MissingSPIFFEID` migration marker
- force a one-time reissue to the non-SPIFFE `namespace/name` subject while continuing to omit the optional identity layer
- add a reconcile regression that starts from a current-generation, non-expiring invalid credential with the current completion condition already present

## Why

This is a scoped follow-up to #407 and #400. `credential.Decode` parses status artifacts but does not validate their claims, while the verifier rejects `strings.TrimSpace(subject) == ""`. The migration classifier previously treated a decodable empty-subject credential as clean whenever the status condition looked current, so reconcile could retain a credential that relying-party verification rejects.

The change keeps artifact inspection authoritative over the condition marker and closes this remaining CWE-345 trust-inversion edge. The original AAT audience and proof-of-possession defaults addressing cross-audience replay and authorization-boundary risks (CWE-287/CWE-863) remain unchanged from #400.

Replacing `status.credential` does not revoke copies of an older credential that have already been presented elsewhere; those retain their original expiry/revocation behavior.

## Verification

- `cd go && go build ./... && go test -count=1 -timeout 120s ./...`
- `cd go && go vet ./cmd/operator ./pkg/credential ./pkg/issuer`
- focused RED/GREEN regression and full `./cmd/operator` package tests
- `cd python && .venv/bin/python -m pytest tests/ -q` with non-interactive fixture signing disabled: `3435 passed, 35 skipped`
- pinned `ruff 0.13.0` on the AAT adapter and its tests
- `gofmt -l` on the two touched Go files: no output
- `git diff --check`
- `python3 site/scripts/sync_source_docs.py --check`
- `make gen-agent-docs-check`
- `./scripts/check-local.sh --quick`

Privileged Linux seccomp, BPF-LSM, and end-to-end enforcement smoke tests were not run on this macOS host.